### PR TITLE
Fix memory leak in StPicoDstMaker reported in #21

### DIFF
--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -856,12 +856,6 @@ Int_t StPicoDstMaker::MakeWrite() {
 
   // Get Emc collection
   mEmcCollection = mMuDst->emcCollection();
-  StMuEmcUtil *emcUtil = new StMuEmcUtil();
-  if ( !mEmcCollection ) {
-    // Recover StEmcCollection in case of broken/deleted pointer
-    // This usually happens during daq->picoDst converstion
-    mEmcCollection = emcUtil->getEmc( mMuDst->muEmcCollection() );
-  }
 
   if (mEmcCollection) {
     // Build EmcIndex before ::fillTracks()

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -857,7 +857,9 @@ Int_t StPicoDstMaker::MakeWrite() {
 #if !defined (__TFG__VERSION__)
   // Get Emc collection
   mEmcCollection = mMuDst->emcCollection();
+  Bool_t isFromDaq = kFALSE;
   if ( !mEmcCollection ) {
+    isFromDaq = kTRUE;
     static StMuEmcUtil emcUtil;
     // Recover StEmcCollection in case of broken/deleted pointer
     // This usually happens during daq->picoDst converstion
@@ -898,6 +900,10 @@ Int_t StPicoDstMaker::MakeWrite() {
   if (Debug()) mPicoDst->printTracks();
 
   mTTree->Fill();
+  if ( isFromDaq ) {
+    delete mEmcCollection;
+    mEmcCollection = nullptr;
+  }
 
   mMuDst->setVertexIndex(originalVertexId);
 

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -858,10 +858,10 @@ Int_t StPicoDstMaker::MakeWrite() {
   // Get Emc collection
   mEmcCollection = mMuDst->emcCollection();
   if ( !mEmcCollection ) {
-    static StMuEmcUtil *emcUtil = new StMuEmcUtil();
+    static StMuEmcUtil emcUtil;
     // Recover StEmcCollection in case of broken/deleted pointer
     // This usually happens during daq->picoDst converstion
-    mEmcCollection = emcUtil->getEmc( mMuDst->muEmcCollection() );
+    mEmcCollection = emcUtil.getEmc( mMuDst->muEmcCollection() );
   }
 
   if (mEmcCollection) {

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -854,8 +854,15 @@ Int_t StPicoDstMaker::MakeWrite() {
 
   mBField = muEvent->magneticField();
 
+#if !defined (__TFG__VERSION__)
   // Get Emc collection
   mEmcCollection = mMuDst->emcCollection();
+  if ( !mEmcCollection ) {
+    static StMuEmcUtil *emcUtil = new StMuEmcUtil();
+    // Recover StEmcCollection in case of broken/deleted pointer
+    // This usually happens during daq->picoDst converstion
+    mEmcCollection = emcUtil->getEmc( mMuDst->muEmcCollection() );
+  }
 
   if (mEmcCollection) {
     // Build EmcIndex before ::fillTracks()
@@ -863,6 +870,7 @@ Int_t StPicoDstMaker::MakeWrite() {
     // Fill BTOW hits only if ::buildEmcIndex() has been called for this event
     fillBTowHits();
   }
+#endif /* !__TFG__VERSION__ */
   
 
   // Fill StPicoEvent members


### PR DESCRIPTION
The code to "recover" StEmcCollection was added in bb715e65f0da0ad6ec9bef78cb791546d0bcbe57

It seems to have introduced a memory leak which resulted in slower production jobs as reported in #21. While the investigation is still underway, there is a need to produce a new release with other changes included since SL21b.