### PR TITLE
Fixed a bug in StEvent version of tstart_NoVpd() in StBTofCalibMaker.cxx

### DIFF
--- a/StRoot/StBTofCalibMaker/StBTofCalibMaker.cxx
+++ b/StRoot/StBTofCalibMaker/StBTofCalibMaker.cxx
@@ -1958,6 +1958,10 @@ void StBTofCalibMaker::tstart_NoVpd(const StBTofCollection *btofColl, const StPr
         }
     }
 
+    mNTzeroCan = nCan;
+    mTCanFirst = tCanFirst;
+    mTCanLast  = tCanLast;
+
     if(nCan<=0) {
         *tstart = -9999.;
         return;


### PR DESCRIPTION
The variables mNTzeroCan, mTCanFirst, and mTCanLast were not being assigned values in the StEvent version of tstart_NoVpd() in StBTofCalibMaker.cxx.