### PR TITLE
Introduce run time switch for dN/dx calculation

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1795,6 +1795,7 @@ Bfc_st BFC[] = { // standard chains
 #endif
   {"dEdxY2"       ,"dEdxY2","","tpcDb,StEvent","StdEdxY2Maker","libMinuit,StdEdxY2Maker"
    ,                                                                 "Bichsel method used for dEdx",kFALSE},
+  {"CalcdNdx", "", "", "dEdxY2", "", "",              "Option for StdEdxY2Maker to calculate dN/dx",kFALSE},
 
   // Options in need to be done after the tracker
   // second wave of BTOF options needed after Sti

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -785,13 +785,12 @@ Int_t StBFChain::Instantiate()
       }
       mk->PrintAttr();
     }
-    if (maker == "StTpcHitMover" && GetOption("EbyET0")) {
-      mk->SetAttr("EbyET0", kTRUE);
+    if (maker == "StTpcHitMover") {
+      if (GetOption("EbyET0"))            mk->SetAttr("EbyET0", kTRUE);
+      if (GetOption("EmbeddingShortCut")) mk->SetAttr("EmbeddingShortCut", kTRUE);
     }
-    if ((maker == "StdEdxY2Maker"  || maker == "StTpcHitMover") &&
-	GetOption("EmbeddingShortCut"))  {
-      mk->SetAttr("EmbeddingShortCut", kTRUE);
-      mk->PrintAttr();
+    if (maker == "StdEdxY2Maker") {
+      if (GetOption("EmbeddingShortCut")) mk->SetAttr("EmbeddingShortCut", kTRUE);
     }
     if (maker == "StSvtDbMaker" || maker == "StSsdDbMaker"){
       mk->SetMode(0);

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -791,6 +791,7 @@ Int_t StBFChain::Instantiate()
     }
     if (maker == "StdEdxY2Maker") {
       if (GetOption("EmbeddingShortCut")) mk->SetAttr("EmbeddingShortCut", kTRUE);
+      if (GetOption("CalcdNdx"))          mk->SetAttr("CalcdNdx", kTRUE);
     }
     if (maker == "StSvtDbMaker" || maker == "StSsdDbMaker"){
       mk->SetMode(0);

--- a/StRoot/StdEdxY2Maker/StdEdxY2Maker.cxx
+++ b/StRoot/StdEdxY2Maker/StdEdxY2Maker.cxx
@@ -169,8 +169,8 @@ Int_t StdEdxY2Maker::InitRun(Int_t RunNumber){
 
   if (! DoOnce) {
     DoOnce = 1;
-    if ((GetDate() > 20171201 && m_TpcdEdxCorrection->IsFixedTarget()) ||
-	(GetDate() > 20181201)) fUsedNdx = kTRUE; // use dN/dx for fixed target for Run XVIII and year >= XIX
+    if (IAttr("CalcdNdx") && ((GetDate() > 20171201 && m_TpcdEdxCorrection->IsFixedTarget()) ||
+	(GetDate() > 20181201))) fUsedNdx = kTRUE; // use dN/dx for fixed target for Run XVIII and year >= XIX
     if (TESTBIT(m_Mode, kCalibration)) {// calibration mode
       if (Debug()) LOG_WARN << "StdEdxY2Maker::InitRun Calibration Mode is On (make calibration histograms)" << endm;
       TFile *f = GetTFile();


### PR DESCRIPTION
The functionality to calculate dN/dx is already in the code. In order to enable it one just need to define an environment variable `STAR_USE_DNDX` before starting processing jobs.