### PR TITLE
Enable MC branches if they are there

### DIFF
--- a/StRoot/macros/mudst/genDst.C
+++ b/StRoot/macros/mudst/genDst.C
@@ -227,6 +227,7 @@ void genDst(unsigned int First,
     muDstMaker.SetStatus("ETof*", 1);
     muDstMaker.SetStatus("Epd*", 1);
     muDstMaker.SetStatus("Fms*", 1);
+    muDstMaker.SetStatus("MCAll", 1);
 
     // EMCs
     StEEmcDbMaker* eemcDb = new StEEmcDbMaker;


### PR DESCRIPTION
MC branches need to be activated for embedding to leverage them. No impact seen when no MC branches present.