### PR TITLE
Propose fixes to StRoot/StSpinPool in order to include it in our builds

### DIFF
--- a/StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.cxx
+++ b/StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.cxx
@@ -48,6 +48,8 @@
 
 #include "RTS/include/rtsLog.h"
 
+#include "StRoot/RTS/src/TRG_FCS/fcs_trg_base.h"
+
 namespace {
   enum {kMaxNS=2, kMaxDet=3, kMaxDep=24, kMaxCh=32, kMaxEcalDep=24, kMaxHcalDep=8, kMaxPresDep=4, kMaxLink2=2};
   u_int   fcs_trg_sim_adc[kMaxNS][kMaxDet][kMaxDep][kMaxCh] ;
@@ -337,6 +339,10 @@ int StFcsTriggerSimMaker::Make(){
     LOG_INFO << Form("Output to DSM = 0x%03x  Filter=0x%03x\n",mTrg,mFlt)<<endm;
     return kStOK;
 }    
+
+void StFcsTriggerSimMaker::runStage2(link_t ecal[], link_t hcal[], link_t pres[], geom_t& geo, link_t output[]){
+  mTrgSim->stage_2(ecal,hcal,pres,geo,output);
+}
 
 void StFcsTriggerSimMaker::print4B4(){
     //printout ecal 4x4

--- a/StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.h
+++ b/StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.h
@@ -8,12 +8,13 @@
 #define STAR_StFcsTriggerSimMaker_HH
 
 #include "StMaker.h"
-#include "StRoot/RTS/src/DAQ_FCS/fcs_data_c.h"
-#include "StRoot/RTS/src/TRG_FCS/fcs_trg_base.h"
 
 class StFcsDb;
 class StFcsCollection;
 class TFile;
+class fcs_trg_base;
+class link_t;
+class geom_t;
 
 class StFcsTriggerSimMaker : public StMaker{
 public: 
@@ -33,9 +34,7 @@ public:
     void setTrgTimeBin(int v) {mTrgTimebin=v;} //8 timebin = v-3 to v+4. v=52 for 49~56
 
     fcs_trg_base* getTriggerEmu() {return mTrgSim;}
-    void runStage2(link_t ecal[], link_t hcal[], link_t pres[], geom_t geo, link_t output[]){
-      mTrgSim->stage_2(ecal,hcal,pres,geo,output);
-    }
+    void runStage2(link_t ecal[], link_t hcal[], link_t pres[], geom_t& geo, link_t output[]);
 
 private:
     StFcsDb* mFcsDb=0;
@@ -48,7 +47,6 @@ private:
     int mSimMode=0;      //! 0 from data, 1 for MC
     int mTrgTimebin=52;  //! center timebin for data
 
-    fcs_data_c* mFcsDataC;
     fcs_trg_base* mTrgSim;
 
     char* mPresMask=0;


### PR DESCRIPTION
Hide sys/types.h from rootcint by using forward declarations

StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.h includes sys/types.h from StRoot/RTS/src/TRG_FCS/fcs_trg_base.h and that causes a conflict with rootcint (ROOT5). The trick is to move declaration of `fcs_trg_base` type into the implementation file StRoot/StSpinPool/StFcsTriggerSimMaker/StFcsTriggerSimMaker.cxx

Also remove unused `fcs_data_c* StFcsTriggerSimMaker::mFcsDataC`

[skip ci] as StRoot/StSpinPool is not included in the CI build