### PR TITLE
Add RC files for ROOT

### DIFF
--- a/StRoot/macros/.rootrc
+++ b/StRoot/macros/.rootrc
@@ -1,3 +1,4 @@
-Gui.Style:                  windows
-Gui.Backend:                qt
-Gui.Factory:                qtgui
+Rint.Logon:                $(STAR)/StRoot/macros/rootlogon.C
+Rint.Logoff:               $(STAR)/StRoot/macros/rootlogoff.C
+Unix.*.Root.MacroPath:     .:$(STAR)/StRoot/macros:$(ROOTSYS)/macros
+Unix.*.Root.DynamicPath:   .:$(STAR_LIB):$(ROOTSYS)/lib

--- a/StRoot/macros/rootlogoff.C
+++ b/StRoot/macros/rootlogoff.C
@@ -1,0 +1,11 @@
+{
+  if (TClassTable::GetDict("StMaker"))
+  {
+    StMaker* mk = StMaker::GetChain();
+    if (mk) {
+      mk->Finish();
+    }
+  }
+
+  std::cout << "\nThis is the end of STAR ROOT -- Goodbye\n" << std::endl;
+}

--- a/StRoot/macros/rootlogon.C
+++ b/StRoot/macros/rootlogon.C
@@ -1,0 +1,34 @@
+{
+  gSystem->Load("libStarClassLibrary");
+  gSystem->Load("libGeom");
+  gSystem->Load("libTable");
+  gSystem->Load("libPhysics");
+  gSystem->Load("libEG");
+  gSystem->Load("libStarRoot");
+
+  if (gSystem->GetLibraries("*libTable*"))
+  {
+    gInterpreter->ProcessLine("typedef TCL              StCL;");
+    gInterpreter->ProcessLine("typedef TDataSet         St_DataSet ;");
+    gInterpreter->ProcessLine("typedef TDataSetIter     St_DataSetIter;");
+    gInterpreter->ProcessLine("typedef TFileSet         St_FileSet;");
+    gInterpreter->ProcessLine("typedef TVolume          St_Node;");
+    gInterpreter->ProcessLine("typedef TVolumePosition  St_NodePosition;");
+    gInterpreter->ProcessLine("typedef TVolumeView      St_NodeView;");
+    gInterpreter->ProcessLine("typedef TVolumeViewIter  St_NodeViewIter;");
+    gInterpreter->ProcessLine("typedef TObjectSet       St_ObjectSet;");
+    gInterpreter->ProcessLine("typedef TPoints3D        St_Points3D;");
+    gInterpreter->ProcessLine("typedef TPointsArray3D   St_PointsArray3D;");
+    gInterpreter->ProcessLine("typedef TPolyLineShape   St_PolyLineShape;");
+    gInterpreter->ProcessLine("typedef TTable           St_Table;");
+    gInterpreter->ProcessLine("typedef TTable3Points    St_Table3Points;");
+    gInterpreter->ProcessLine("typedef TTableIter       St_TableIter;");
+    gInterpreter->ProcessLine("typedef TTablePoints     St_TablePoints;");
+    gInterpreter->ProcessLine("typedef TTableSorter     St_TableSorter;");
+    gInterpreter->ProcessLine("typedef TTableDescriptor St_tableDescriptor;");
+  }
+
+  std::cout << " *** Start at Date : " << TDatime().AsString() << std::endl;
+
+  gSystem->AddIncludePath(" -I. -I./.$STAR_HOST_SYS/include -I./StRoot -I$STAR/.$STAR_HOST_SYS/include -I$STAR/StRoot -I/usr/include/mysql");
+}


### PR DESCRIPTION
It turns out the rootlogon.C and rootlogoff.C scripts were never saved in the repository, although they are used by every root4star job executed on the farm nodes. In fact, the jobs cannot properly run out of the box without the commands executed in these scripts. For reproducibility and analysis preservation reasons the RC scripts must be provided along with the code.

I took the currently used scripts from the default ROOT5 prefix in /afs and clean them up to keep only the minimally necessary commands. This revision works for me, but of course comments and suggestions are welcome.

It is expected that modifications for ROOT6 will be necessary and tracking such changes is essential.