### PR TITLE
Remove reference to unsupported ROOT Qt class

### DIFF
--- a/StarVMC/GeoTestMaker/StMCStepping2Hist.cxx
+++ b/StarVMC/GeoTestMaker/StMCStepping2Hist.cxx
@@ -30,7 +30,6 @@
 #include "TStyle.h"
 #include "TCanvas.h"
 #include "TSystem.h"
-//#include "TQtCanvas2Html.h"
 #include "StTProfile2D.h"
 #include "StiELossTrk.h"
 
@@ -384,15 +383,6 @@ void My2Hist::Save()
      PadClean(mC[0][i]);
      mC[0][i]->Print(".C");
      if (i>5) continue;
-#ifdef ROOT_TQtCanvas2Html
-     TString ts(mC[0][i]->GetName());ts.Replace(0,1,"HTM");
-     TQtCanvas2Html WebSite(mC[0][i],1.8,ts.Data());
-#endif 
-//        char cc[500];
-//        sprintf(cc,"TQtCanvas2Html WebSite((TCanvas*)%p,1.8,\"%s\");"
-//               ,(void*)mC[0][i],mC[0][i]->GetName());
-// 
-//        gROOT->ProcessLine(cc);
    }
 }
 //_____________________________________________________________________________

--- a/docker/Dockerfile.root5
+++ b/docker/Dockerfile.root5
@@ -89,7 +89,6 @@ RUN source star-spack/setup.sh && spack env activate star-env-root5 \
  && cd /star-sw \
  && cons +StarVMC/Geometry \
  && cons %pams/sim/g2r %OnlTools \
-         %StarVMC/GeoTestMaker \
          %StRoot/StarGenerator/Kinematics \
          %StRoot/StEEmcPool %StRoot/StFgtPool %StRoot/StHighptPool \
          %StRoot/StJetFinder \

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -90,7 +90,6 @@ RUN source star-spack/setup.sh && spack env activate star-env-root6 \
  && cd /star-sw \
  && cons +StarVMC/Geometry \
  && cons %pams/sim/g2r %OnlTools \
-         %StarVMC/GeoTestMaker \
          %StRoot/StarGenerator/Kinematics \
          %StRoot/StEEmcPool %StRoot/StFgtPool %StRoot/StHighptPool \
          %StRoot/StJetFinder \

--- a/mgr/Conscript-standard
+++ b/mgr/Conscript-standard
@@ -199,9 +199,6 @@ if ( $pkg eq "Jevp") {
 	      .   $main::PATH_SEPARATOR .  $CPPPATH;
     $CPPFLAGS .= " -DQT_THREAD_SUPPORT -DQT_SHARED -DQT_NO_DEBUG ";
 }
-if ( $pkg eq "GeoTestMaker") {
-  $LIBS = "-lQtGui";
-}
 
 #$CPPFLAGS .= " -DNEW_DAQ_READER -D__NO_STRANGE_MUDST__  ";
 $CPPFLAGS .= " -DNEW_DAQ_READER ";


### PR DESCRIPTION
Support for Qt library as dependency for STAR software has stopped some time ago.