### PR TITLE
ci: Run build action on all pushes and pull requests to any branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,8 +1,6 @@
 name: CI Build
 
-on:
-  pull_request:
-    branches: main
+on: [push, pull_request]
 
 jobs:
   ROOT5:


### PR DESCRIPTION
It doesn't make sense to treat non-main branch PR's specially.

It's also desirable to run actions on direct-pushed tags and we also want users to be able to run CI in their forks before creating the PR.