### PR TITLE
[root6] Include StRoot/StFgtPool into CI build

### DIFF
--- a/StRoot/StFgtPool/StFgtPedMaker/StFgtPedMaker.h
+++ b/StRoot/StFgtPool/StFgtPedMaker/StFgtPedMaker.h
@@ -78,10 +78,6 @@ class StFgtPedMaker : public StMaker {
    // Get CVS
    virtual const char *GetCVS() const;
 
- protected:
-   // mask for which time bins to save
-   Short_t mTimeBinMask;
-
    // to hold sums
    struct pedData_t {
       Int_t n;
@@ -97,6 +93,11 @@ class StFgtPedMaker : public StMaker {
 
       pedData_t( Int_t nIn=0, Float_t s=0, Float_t ssq=0, Float_t f=0 ) : n(nIn), sum(s), sumsq(ssq), fracClose(f) { /* */ };
    };
+
+ protected:
+   // mask for which time bins to save
+   Short_t mTimeBinMask;
+
    typedef std::vector< pedData_t > pedDataVec_t;
 
    pedDataVec_t mDataVec;

--- a/StRoot/StFgtPool/StFgtPedMaker/StFgtPedReader.h
+++ b/StRoot/StFgtPool/StFgtPedMaker/StFgtPedReader.h
@@ -71,6 +71,17 @@ class StFgtPedReader {
    // pedistal.
    void setTimeBinMask( Short_t mask = 0xFF );
 
+   // ped structure
+   struct ped_t {
+      Float_t ped;
+      Float_t err;
+
+      ped_t( Float_t p=0, Float_t err=1e10 );
+      operator float() const;
+      Float_t getPed();
+      Float_t getErr();
+   };
+
  protected:
    // mask for which time bins to read
    Short_t mTimeBinMask;
@@ -85,17 +96,6 @@ class StFgtPedReader {
       key_t( Int_t elecId = 0, Int_t timeBin = 0);
       //Bool_t operator<( const key_t& rhs ) const;
       operator int() const;
-   };
-
-   // ped structure
-   struct ped_t {
-      Float_t ped;
-      Float_t err;
-
-      ped_t( Float_t p=0, Float_t err=1e10 );
-      operator float() const;
-      Float_t getPed();
-      Float_t getErr();
    };
 
    typedef std::vector< ped_t > PedVec_t;

--- a/StRoot/StFgtPool/StFgtStatusMaker/StFgtStatusMaker.h
+++ b/StRoot/StFgtPool/StFgtStatusMaker/StFgtStatusMaker.h
@@ -82,6 +82,15 @@ class StFgtStatusMaker : public StMaker {
    // Get CVS
    virtual const char *GetCVS() const;
 
+   typedef UChar_t status_t;
+
+   struct apvData_t {
+      Int_t numDead;
+      std::vector< status_t* > stripStatusVec;
+
+      apvData_t() : numDead( kFgtNumChannels ) { /* */ };   // Default to 128, i.e. all dead
+   };
+
  protected:
    // for the ped maker
    std::string mPedMkrName;
@@ -101,13 +110,6 @@ class StFgtStatusMaker : public StMaker {
    Int_t saveToFile();
 
    // internal data
-   typedef UChar_t status_t;
-   struct apvData_t {
-      Int_t numDead;
-      std::vector< status_t* > stripStatusVec;
-
-      apvData_t() : numDead( kFgtNumChannels ) { /* */ };   // Default to 128, i.e. all dead
-   };
    typedef std::vector< apvData_t > apvDataVec_t;
 
    status_t* mStatus;

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -127,7 +127,7 @@ RUN source /etc/profile \
  && cons +StarVMC/Geometry \
  && cons %OnlTools \
          %StRoot/StarGenerator/Kinematics \
-         %StRoot/StEEmcPool %StRoot/StFgtPool \
+         %StRoot/StEEmcPool \
          %StRoot/StShadowMaker %StRoot/StHbtMaker \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 


### PR DESCRIPTION
Declare nested types public in StRoot/StFgtPool

This affects persistent classes processed by ROOT to create dictionaries and
streamers. Unlike rootcint in ROOT5, rootcling seemingly respects the access
modifiers and needs all such types to be publicly defined.

Similar to 9bce66cfe89a6f3cc69b449547726e9b1d32b516