### PR TITLE
Revert "ci: run build action on all pushes and pull requests to any branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,6 +1,8 @@
 name: CI Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: main
 
 jobs:
   ROOT5:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,8 +1,6 @@
 name: CI Build
 
-on:
-  pull_request:
-    branches: main
+on: [pull_request]
 
 jobs:
   ROOT5:


### PR DESCRIPTION
This reverts commit c25a2fdf215f9deafdf4e727aea8fab19818c1ea.

The original commit caused duplication of CI jobs triggered by both push and
pull_request events