### PR TITLE
[SL12d_embed] mgr/cons: workaround `'.' is no longer in @INC`

### DIFF
--- a/mgr/cons
+++ b/mgr/cons
@@ -1,4 +1,5 @@
 #!/usr/bin/env perl
+use lib '.';
 #use strict;
 use Env;
 use English;


### PR DESCRIPTION
Allegedly the current directory was removed from `@INC` in Perl 5.26 for security reasons, and it seems like this was recently backported on RCF.
    
    do "StarVMC/g2Root/Conscript" failed, '.' is no longer in @INC; did you mean do "./StarVMC/g2Root/Conscript"? at mgr/cons line 866.
    Run Conscript-standard in StarVMC/geant3                  for geant3
            [minicern] (possible name clash) changed to StarMiniCern
    Run Conscript-standard in StarVMC/minicern                for StarMiniCern
    do "StarVMC/pgf77/Conscript" failed, '.' is no longer in @INC; did you mean do "./StarVMC/pgf77/Conscript"? at mgr/cons line 866.
    Run Conscript-standard in StarVMC/xgeometry               for xgeometry
    do "asps/Simulation/agetof/Conscript" failed, '.' is no longer in @INC; did you mean do "./asps/Simulation/agetof/Conscript"? at mgr/cons line 866.
    Run Conscript-standard in asps/Simulation/gcalor          for gcalor
    do "asps/Simulation/geant321/Conscript" failed, '.' is no longer in @INC; did you mean do "./asps/Simulation/geant321/Conscript"? at mgr/cons line 866.
    do "asps/Simulation/starsim/Conscript" failed, '.' is no longer in @INC; did you mean do "./asps/Simulation/starsim/Conscript"? at mgr/cons line 866.
    do "asps/rexe/Conscript" failed, '.' is no longer in @INC; did you mean do "./asps/rexe/Conscript"? at mgr/cons line 866.
    do "asps/staf/sdd/Conscript" failed, '.' is no longer in @INC; did you mean do "./asps/staf/sdd/Conscript"? at mgr/cons line 866.
