### PR TITLE
ci: Increase log size limit to 10 MB

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10000000
 
       - name: Build with Docker
         uses: docker/build-push-action@v2
@@ -29,6 +31,8 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10000000
 
       - name: Build with Docker
         uses: docker/build-push-action@v2


### PR DESCRIPTION
The output logs appear to be truncated:

 [output clipped, log limit 2MiB reached]