### PR TITLE
ci: restrict branch names for build-containers workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,6 +1,12 @@
 name: Build Containers
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - 'SL*'
+    tags:
+      - '*'
 
 jobs:
   ROOT5:


### PR DESCRIPTION
This prevents the workflow from failing on pr/ branches pushed directly into the main repo. Feature branches could temporarily relax this constraint as needed.

Alternatively we could set `on.push.branches-ignore` to `'pr/*'`.