### PR TITLE
starsim: disable cernlib's signal handler

### DIFF
--- a/asps/Simulation/starsim/atmain/agmain.age
+++ b/asps/Simulation/starsim/atmain/agmain.age
@@ -155,6 +155,12 @@
       CALL KGETAR  (CHARGS)         ! pawint does not know the length
       if (ILOG==0) CALL AFNAME (PAWLOGF,'.logon.kumac')
       CALL PAWINT2 (0,'+?',AgPAWE,IWTYP)  ! type of PAW, HBOOK, command
+
+* PAWINT2 calls KUINIT which unconditionally enables a useless signal handler
+* that may deadlock. This disables it back, but does not however restore
+* Root.ErrorHandlers
+      CALL KUEXEC('/KUIP/SET_SHOW/BREAK OFF')
+
       CALL FMLOGL  (-3)
       IF (LENOCC(FATCAT)>0) CALL FMSTRT(62,63,%L(FATCAT),Irc)
 


### PR DESCRIPTION
Fixes https://github.com/star-bnl/star-sw/issues/137 by disabling a useless signal handler that only prints some useless messages:
https://github.com/apc-llc/cernlib/blob/master/2006/src/packlib/kuip/code_kuip/kienbr.c#L68-L195
https://github.com/apc-llc/cernlib/blob/6e32ba8132318864a244021366708ddbdbebf8ea/2006/src/packlib/kernlib/kerngen/tcgen/traceq.F#L15-L28