### PR TITLE
Publish generated particle data and the particle stack as ".const"

### DIFF
--- a/StRoot/StarGenerator/BASE/StarPrimaryMaker.cxx
+++ b/StRoot/StarGenerator/BASE/StarPrimaryMaker.cxx
@@ -60,12 +60,12 @@ StarPrimaryMaker::StarPrimaryMaker()  :
   SetAttr("usestarsim", int(1) );
 
   // Publish the stack
-  AddObj( mStack, ".data" );  
+  AddObj( mStack, ".const" );  
 
   // Register the particle database with this maker
   StarParticleData &pdb = StarParticleData::instance();
   //  Shunt( &pdb );
-  AddData( &pdb, ".data" );
+  AddData( &pdb, ".const" );
 
   SetAttr("FilterKeepHeader", int(1) );
 


### PR DESCRIPTION
Particle data and the particle stack should be set as ".const" rather
than ".data" members, because they are expected to persist through
the lifetime of the run, rather than the lifetime of the event.