### PR TITLE
Star buildgeom fix

### DIFF
--- a/docker/Dockerfile.root5
+++ b/docker/Dockerfile.root5
@@ -122,7 +122,6 @@ diff --git a/asps/rexe/Conscript b/asps/rexe/Conscript \n\
 
 RUN source /etc/profile \
  && cd /star-sw \
- && cons +StarVMC/Geometry \
  && cons %StRoot/StShadowMaker \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -125,7 +125,6 @@ RUN source /etc/profile \
  # Override default Vc version
  && export Vc_DIR=/opt/software/linux-scientific7-x86_64/gcc-4.8.5/vc_-0.7.4-gqbhzu2x5u2dbe5tafxnl36xj5qbwov4 \
  && cd /star-sw \
- && cons +StarVMC/Geometry \
  && cons %StRoot/StShadowMaker \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 

--- a/mgr/Conscript-standard
+++ b/mgr/Conscript-standard
@@ -376,11 +376,11 @@ if ( $pkg !~ /^sim$/ && $pkg !~ /^gen$/ ) {
 			$env->{ENV}->{AGML_WARNINGS} = 1==1; # $param::debug;
 
 			if ( $xml =~ m/Compat/ ){
-			    Depends $env ["#".$agE], ("#$xml", "#$agml_cmd");
+			    Depends $env ["#".$agE], "#$xml";
 			    Command $env ["#".$agE], ("#$xml"), qq($agml_cmd --file=%1 --module=$agM --export=Mortran > %>);
 
 			} else {
-			    Depends $env ["#".$agX, "#".$agH, "#".$agE], ("#$xml", "#$agml_cmd");
+			    Depends $env ["#".$agX, "#".$agH, "#".$agE], "#$xml";
 			    # Depends $env --> some rule to build extra dict on the fly
 
 			    Command $env ["#".$agX], ("#$xml"), qq($agml_cmd --file=%1 --module=$agM --export=AgROOT --path=%>:d);

--- a/mgr/Dyson/Export/AgROOT.py
+++ b/mgr/Dyson/Export/AgROOT.py
@@ -1192,7 +1192,7 @@ class Module ( Handler ):
         # ---------------------------------------------------------------    
         # Global scope of implementation file
         # ---------------------------------------------------------------        
-        document.impl('#include "%s.h"' % document.agmodule, unit='global')
+        document.impl('#include "StarVMC/StarGeometry/%s.h"' % document.agmodule, unit='global')
         document.impl( banner, unit='global' )
 ##        document.impl('ClassImp(%s);'   % document.agmodule, unit='global')
         document.impl(seperator, unit='global')


### PR DESCRIPTION
Propose fix to issue #45.   When building the (.h, .cxx) files from the .xml sources, the dependence on the agmlParser.py is no longer required.  This may fix issue #45 as well.  When I remove the dependency, I can reliably build the geometry in a freshly cloned directory.