### PR TITLE
Use std::ostringstream in place of STAR's ostrstream

### DIFF
--- a/StRoot/StDbBroker/DbUse.cxx
+++ b/StRoot/StDbBroker/DbUse.cxx
@@ -176,7 +176,7 @@ uint num_latest;
 int latestDirDate;
 int latestDirTime;
 
-if (mysql_real_query(&mysql,Query.str(),Query.pcount()-1))
+if (mysql_real_query(&mysql, Query.str().c_str(), int(Query.tellp())-1))
   {
     LOG_ERROR << "Failed to query: Error: " <<  mysql_error(&mysql) << endm;
     mysql_close(&mysql);
@@ -252,7 +252,7 @@ int latestStrID=99999;
 uint sizeOfDbStruct=99999;
 uint nDbVar=99999;
 
-if (mysql_real_query(&mysql,Query.str(),Query.pcount()-1))
+if (mysql_real_query(&mysql, Query.str().c_str(), int(Query.tellp())-1))
   {
     LOG_ERROR << "Failed to query: Error: " <<  mysql_error(&mysql) << endm;
      mysql_close(&mysql);
@@ -338,7 +338,7 @@ Query<<"SELECT name, type, offset, nDims, firstDim FROM headers WHERE strID="
      << latestStrID << " ORDER BY offset" << std::ends;
   //cout << "database query: " << Query.str() << endl;
 
-if (mysql_real_query(&mysql,Query.str(),Query.pcount()-1))
+if (mysql_real_query(&mysql, Query.str().c_str(), int(Query.tellp())-1))
   {
     LOG_ERROR << "Failed to query: Error: " << mysql_error(&mysql) << endm;
     mysql_close(&mysql);
@@ -480,7 +480,7 @@ Query << "SELECT bytes FROM bytes WHERE instanceID="<<latestDirID<< std::ends;
  
 // cout << "database query: " << Query.str() << endl;
 
-if (mysql_real_query(&mysql,Query.str(),Query.pcount()-1))
+if (mysql_real_query(&mysql, Query.str().c_str(), int(Query.tellp())-1))
   {
     LOG_ERROR << "Failed to query: Error: " <<  mysql_error(&mysql) << endm;
     LOG_ERROR << "database query: " << Query.str() << endm;
@@ -662,7 +662,7 @@ uint num_next;
 int nextDirDate;
 int nextDirTime;
 
-if (mysql_real_query(&mysql,Query.str(),Query.pcount()-1))
+if (mysql_real_query(&mysql, Query.str().c_str(), int(Query.tellp())-1))
   {
     LOG_ERROR << "Failed to query: Error: " <<  mysql_error(&mysql) << endm;
      mysql_close(&mysql);

--- a/StRoot/StDbBroker/DbUse.cxx
+++ b/StRoot/StDbBroker/DbUse.cxx
@@ -100,7 +100,7 @@ unsigned int num_rows;
 //unsigned int num_struct;
 
 //const int MAXBUF=1024;
-ostrstream Query;
+std::ostringstream Query;
 char temps[128];
 
 char validFrom[20];

--- a/StRoot/StHbtMaker/Base/StHbtRoot1DCF.cc
+++ b/StRoot/StHbtMaker/Base/StHbtRoot1DCF.cc
@@ -105,7 +105,7 @@ void StHbtRoot1DCF::Finish(){
 
 //____________________________
 StHbtString StHbtRoot1DCF::Report(){
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << GetName() << " Correlation Function Report:"<< endl;
   tStr << "Number of entries in numerator: " << mNumerator->GetEntries() << endl;;
   tStr << "Number of entries in denominator: " << mDenominator->GetEntries() << endl;

--- a/StRoot/StHbtMaker/Base/StHbtRoot2DCF.cc
+++ b/StRoot/StHbtMaker/Base/StHbtRoot2DCF.cc
@@ -107,7 +107,7 @@ void StHbtRoot2DCF::Finish(){
 
 //____________________________
 StHbtString StHbtRoot2DCF::Report(){
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << GetName() << " Correlation Function Report:"<< endl;
   tStr << "Number of entries in numerator: " << mNumerator->GetEntries() << endl;;
   tStr << "Number of entries in denominator: " << mDenominator->GetEntries() << endl;

--- a/StRoot/StHbtMaker/Base/StHbtRoot3DCF.cc
+++ b/StRoot/StHbtMaker/Base/StHbtRoot3DCF.cc
@@ -108,7 +108,7 @@ void StHbtRoot3DCF::Finish(){
 
 //____________________________
 StHbtString StHbtRoot3DCF::Report(){
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << GetName() << " Correlation Function Report:"<< endl;
   tStr << "Number of entries in numerator: " << mNumerator->GetEntries() << endl;;
   tStr << "Number of entries in denominator: " << mDenominator->GetEntries() << endl;

--- a/StRoot/StHbtMaker/Base/StHbtThPair.cc
+++ b/StRoot/StHbtMaker/Base/StHbtThPair.cc
@@ -90,7 +90,7 @@ void StHbtThPair::UpdateWeight() {
       tCom << "echo ---> " << mWeightNum << " " 
 	   << mEmPoint1 << " " << mEmPoint2 << " " 
 	   << mMomentum1 << " " << mMomentum2 << " >> Err.txt" << ends;
-      system(tCom.str());
+      system(tCom.str().c_str());
       mWeightNum=1;
     }
   } else {

--- a/StRoot/StHbtMaker/Base/StHbtThPair.cc
+++ b/StRoot/StHbtMaker/Base/StHbtThPair.cc
@@ -86,7 +86,7 @@ void StHbtThPair::UpdateWeight() {
     mWeightNum=(mWeightNum-1.)*mPairPurity+1.;
     mWeightDen=mWeight->GetWeightDen();
     if(mWeightNum<=0. || mWeightNum>1000.){
-      ostrstream tCom;
+      std::ostringstream tCom;
       tCom << "echo ---> " << mWeightNum << " " 
 	   << mEmPoint1 << " " << mEmPoint2 << " " 
 	   << mMomentum1 << " " << mMomentum2 << " >> Err.txt" << ends;
@@ -101,7 +101,7 @@ void StHbtThPair::UpdateWeight() {
 }
 
 StHbtString StHbtThPair::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Default StHbtThPair Report" << endl;
   if (mWeight) {
     tStr << mWeight->Report() << endl;

--- a/StRoot/StHbtMaker/Cut/HitMergingPairCut.cxx
+++ b/StRoot/StHbtMaker/Cut/HitMergingPairCut.cxx
@@ -75,8 +75,8 @@ StHbtString HitMergingPairCut::Report(){
   return returnThis;
 }
 //__________________
-ostrstream* HitMergingPairCut::finalReport() const{
-  ostrstream* tFinalReport = new ostrstream;
+std::ostringstream* HitMergingPairCut::finalReport() const{
+  std::ostringstream* tFinalReport = new std::ostringstream;
   (*tFinalReport) <<  "_____ HitMerging pair Cut _____ " << endl
 		  << " N pairs passed : " << mNPairsPassed << endl 
 		  << " N pairs failed : " << mNPairsFailed << endl 

--- a/StRoot/StHbtMaker/Cut/HitMergingPairCut.h
+++ b/StRoot/StHbtMaker/Cut/HitMergingPairCut.h
@@ -28,8 +28,9 @@
 //#include "StMaker.h"
 //#endif
 
+#include <sstream>
+
 #include "StHbtMaker/Base/StHbtPairCut.h"
-class std::ostringstream;
 
 class HitMergingPairCut : public StHbtPairCut{
 public:

--- a/StRoot/StHbtMaker/Cut/HitMergingPairCut.h
+++ b/StRoot/StHbtMaker/Cut/HitMergingPairCut.h
@@ -29,7 +29,7 @@
 //#endif
 
 #include "StHbtMaker/Base/StHbtPairCut.h"
-class ostrstream;
+class std::ostringstream;
 
 class HitMergingPairCut : public StHbtPairCut{
 public:
@@ -47,7 +47,7 @@ public:
   void setDefaultHalfFieldMergingPar();
   void setDefaultFullFieldMergingPar();
 
-  virtual ostrstream* finalReport() const;
+  virtual std::ostringstream* finalReport() const;
 
 protected:
   long mNPairsPassed;

--- a/StRoot/StHbtMaker/Cut/adamsPairCut.cxx
+++ b/StRoot/StHbtMaker/Cut/adamsPairCut.cxx
@@ -97,8 +97,8 @@ StHbtString adamsPairCut::Report(){
   return returnThis;
 }
 //__________________
-ostrstream* adamsPairCut::finalReport() const{
-  ostrstream* tFinalReport = new ostrstream;
+std::ostringstream* adamsPairCut::finalReport() const{
+  std::ostringstream* tFinalReport = new std::ostringstream;
   (*tFinalReport) <<  "_____ Adams pair Cut _____ " << endl
 		  << " N pairs passed : " << mNPairsPassed << endl 
 		  << " N pairs failed : " << mNPairsFailed << endl 

--- a/StRoot/StHbtMaker/Cut/adamsPairCut.h
+++ b/StRoot/StHbtMaker/Cut/adamsPairCut.h
@@ -24,7 +24,7 @@
 //#endif
 
 #include "Cut/HitMergingPairCut.h"
-class ostrstream;
+class std::ostringstream;
 
 class adamsPairCut : public HitMergingPairCut{
 public:
@@ -42,7 +42,7 @@ public:
   void setPiPairPIDMax (double aPiPIDMax);
   void setKPairPIDMax  (double aKPIDMax);
   void SetPIDPThreshold(const float&);
-  ostrstream* finalReport() const;
+  std::ostringstream* finalReport() const;
 
 private:
   double mElSigma;

--- a/StRoot/StHbtMaker/Cut/adamsPairCut.h
+++ b/StRoot/StHbtMaker/Cut/adamsPairCut.h
@@ -23,8 +23,9 @@
 //#include "StMaker.h"
 //#endif
 
+#include <sstream>
+
 #include "Cut/HitMergingPairCut.h"
-class std::ostringstream;
 
 class adamsPairCut : public HitMergingPairCut{
 public:

--- a/StRoot/StHbtMaker/Cut/adamsTrackCut.cxx
+++ b/StRoot/StHbtMaker/Cut/adamsTrackCut.cxx
@@ -149,7 +149,7 @@ StHbtString adamsTrackCut::Report()  {
 }
 
 
-ostrstream* adamsTrackCut::finalReport() const{
+std::ostringstream* adamsTrackCut::finalReport() const{
   return franksTrackCut::finalReport();
 }
 

--- a/StRoot/StHbtMaker/Cut/adamsTrackCut.h
+++ b/StRoot/StHbtMaker/Cut/adamsTrackCut.h
@@ -44,7 +44,7 @@ class adamsTrackCut : public franksTrackCut
 
   adamsTrackCut* Clone();
 
-  ostrstream* finalReport() const;
+  std::ostringstream* finalReport() const;
 
  private:   // here are the quantities I want to cut on...
   float             mPIDPThreshold;

--- a/StRoot/StHbtMaker/Cut/fabricesPairCut.cxx
+++ b/StRoot/StHbtMaker/Cut/fabricesPairCut.cxx
@@ -89,8 +89,8 @@ StHbtString fabricesPairCut::Report(){
   return returnThis;
 }
 //__________________
-ostrstream* fabricesPairCut::finalReport() const{
-  ostrstream* tFinalReport = new ostrstream;
+std::ostringstream* fabricesPairCut::finalReport() const{
+  std::ostringstream* tFinalReport = new std::ostringstream;
   (*tFinalReport) <<  "_____ Fabrices pair Cut _____ " << endl
 		  << " N pairs passed : " << mNPairsPassed << endl 
 		  << " N pairs failed : " << mNPairsFailed << endl 

--- a/StRoot/StHbtMaker/Cut/fabricesPairCut.h
+++ b/StRoot/StHbtMaker/Cut/fabricesPairCut.h
@@ -67,7 +67,7 @@
 //#endif
 
 #include "Cut/HitMergingPairCut.h"
-class ostrstream;
+class std::ostringstream;
 
 class fabricesPairCut : public HitMergingPairCut{
 public:
@@ -83,7 +83,7 @@ public:
   void setElPairMaxProbability(double aElPairMaxProb);
   void setPiPiPairMaxProbability(double aPiPiPairMaxProb);
   void setKKPairMaxProbability(double aKKPairMaxProb);
-  ostrstream* finalReport() const;
+  std::ostringstream* finalReport() const;
 
 private:
   double mPiKPairMinProb;

--- a/StRoot/StHbtMaker/Cut/fabricesPairCut.h
+++ b/StRoot/StHbtMaker/Cut/fabricesPairCut.h
@@ -66,8 +66,9 @@
 //#include "StMaker.h"
 //#endif
 
+#include <sstream>
+
 #include "Cut/HitMergingPairCut.h"
-class std::ostringstream;
 
 class fabricesPairCut : public HitMergingPairCut{
 public:

--- a/StRoot/StHbtMaker/Cut/franksTrackCut.cxx
+++ b/StRoot/StHbtMaker/Cut/franksTrackCut.cxx
@@ -244,8 +244,8 @@ StHbtString franksTrackCut::Report(){
 }
 
 
-ostrstream* franksTrackCut::finalReport() const{
-  ostrstream* tFinalReport = new ostrstream;
+std::ostringstream* franksTrackCut::finalReport() const{
+  std::ostringstream* tFinalReport = new std::ostringstream;
   (*tFinalReport) <<  "_____ Track Cut _____ " << endl
 		  << "Charge = " << mCharge << endl
 		  << mNSigmaPion[0] << " < Sigma pion < " 

--- a/StRoot/StHbtMaker/Cut/franksTrackCut.h
+++ b/StRoot/StHbtMaker/Cut/franksTrackCut.h
@@ -68,7 +68,7 @@ class franksTrackCut : public StHbtTrackCut
 
   franksTrackCut* Clone();
 
-  ostrstream* finalReport() const;
+  std::ostringstream* finalReport() const;
 
   //private:   // here are the quantities I want to cut on...
  protected:

--- a/StRoot/StHbtMaker/ThCorrFctn/StHbtFsiLednicky.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/StHbtFsiLednicky.cxx
@@ -150,7 +150,7 @@ double StHbtFsiLednicky::GetWeight(const StHbtThPair* aThPair){
 };
 
 StHbtString StHbtFsiLednicky::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Lednicky afterburner calculation for  Correlation -  Report" << endl;
   tStr << "    Setting : Quantum : " << ((mIqs) ? "On" : "Off"); 
   tStr << " - Coulbomb : " << ((mIch) ? "On" : "Off") ;

--- a/StRoot/StHbtMaker/ThCorrFctn/StHbtFsiLednickyPurity.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/StHbtFsiLednickyPurity.cxx
@@ -117,7 +117,7 @@ double StHbtFsiLednickyPurity::GetWeight(const StHbtThPair* aThPair){
 };
 
 StHbtString StHbtFsiLednickyPurity::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Lednicky afterburner calculation for  Correlation -  Report" << endl;
   tStr << "    Setting : Quantum : " << ((mIqs) ? "On" : "Off"); 
   tStr << " - Coulbomb : " << ((mIch) ? "On" : "Off") ;

--- a/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFGaussFit.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFGaussFit.cxx
@@ -85,7 +85,7 @@ void StHbtThCFGaussFit::Finish() {
 }
 
 StHbtString StHbtThCFGaussFit::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Correlation - Gaussian Fit Manager Report" << endl;
   tStr << mPair.Report() ;
 

--- a/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFGaussSize.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFGaussSize.cxx
@@ -80,7 +80,7 @@ void StHbtThCFGaussSize::Finish() {
 }
 
 StHbtString StHbtThCFGaussSize::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Gaussian Size Report - Size=(X="<< mSizeX <<"Y="<< mSizeY 
        <<"Z="<< mSizeZ<< "T="<< mTime << ")" << endl;
   tStr << mThCorrFctnColl.size() << " Correlation Function Plugged " << endl;

--- a/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFManager.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/StHbtThCFManager.cxx
@@ -55,7 +55,7 @@ void StHbtThCFManager::Finish() {
 
 
 StHbtString StHbtThCFManager::Report() {
-  ostrstream tStr; 
+  std::ostringstream tStr; 
   tStr << "Theoretical Correlation Function Manager Report" << endl;
   if (!(mThPair)) {
     tStr << "ERROR : No Theoretical Pair Plugged " << endl;

--- a/StRoot/StHbtMaker/ThCorrFctn/ThBPCorrFctn.cxx
+++ b/StRoot/StHbtMaker/ThCorrFctn/ThBPCorrFctn.cxx
@@ -140,7 +140,7 @@ ThBPCorrFctn::ThBPCorrFctn(const ThBPCorrFctn& ThCf)
 
 StHbtString ThBPCorrFctn::Report() 
 {
-  ostrstream *out = new ostrstream();
+  std::ostringstream *out = new std::ostringstream();
   (*out) << "Report form the ThBPLCMS Correlation function" << endl;
   return out->str();
 }

--- a/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
@@ -1829,7 +1829,7 @@ string StMuDstMaker::dirname(string s){
 }
 
 void StMuDstMaker::setProbabilityPidFile(const char* file) {
-  ostrstream flnm;
+  std::ostringstream flnm;
 
   if ( ! file ){
     const char *PIDtable="PIDTableP01gl.root";

--- a/StRoot/StStarLogger/StLoggerManager.cxx
+++ b/StRoot/StStarLogger/StLoggerManager.cxx
@@ -141,7 +141,7 @@ if (gErrorIgnoreLevel == kUnset) {
 //________________________________________
 std::ostream& StLoggerManager::OperatorShift(std::ostream& os, StMessage* stm) {
 // std::ostream& operator<<(std::ostream& os, StMessage* stm) {
-  ostrstream &thisStream =  Stream();
+  std::ostringstream &thisStream =  Stream();
   if ( (&thisStream == &os) && (stm == endm) ) {
     // There was a StMessage terminator
      os << ends;
@@ -309,7 +309,7 @@ StMessMgr* StLoggerManager::StarLoggerInit() {
   return mInstance;
 }
 //______________________________________________________________________________
-ostrstream &StLoggerManager::Stream()
+std::ostringstream &StLoggerManager::Stream()
 {
    // return the stream allocated for the particular "fCurType"
    // Create the new stream if there was none.
@@ -342,7 +342,7 @@ bool  StLoggerManager::isQAInfoEnabled() const{ return fgQALogger? fgQALogger->i
 //______________________________________________________________________________
 bool  StLoggerManager::isUCMInfoEnabled() const{ return fgUCMLogger? fgUCMLogger->isInfoEnabled():false; }
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Message(const char* mess, const char* type,
+std::ostringstream& StLoggerManager::Message(const char* mess, const char* type,
   const char* opt,const char *sourceFileName,int lineNumber) {
 //
 // Message declarator - creates a new message if mess is not empty,
@@ -560,7 +560,7 @@ void StLoggerManager::PrintInfo() {
 //
 // Info Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Info(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::Info(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "I", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 int StLoggerManager::PrintInfos()
@@ -597,7 +597,7 @@ messVec* StLoggerManager::FindInfoList(const char* s1, const char* s2,
 //
 // Warning Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Warning(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::Warning(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "W", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 int StLoggerManager::PrintWarnings()
@@ -634,7 +634,7 @@ messVec* StLoggerManager::FindWarningList(const char* s1, const char* s2,
 //
 // Error Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Error(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::Error(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "E", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 int StLoggerManager::PrintErrors()
@@ -671,7 +671,7 @@ messVec* StLoggerManager::FindErrorList(const char* s1, const char* s2,
 //
 // Debug Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Debug(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::Debug(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "D", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 int StLoggerManager::PrintDebug()
@@ -706,13 +706,13 @@ _NO_IMPLEMENTATION_;   return 0;
 //
 // QAInfo Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::QAInfo(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::QAInfo(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "Q", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 //
 // UCMInfo Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::UCMInfo(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
+std::ostringstream& StLoggerManager::UCMInfo(const char* mess, const char* opt,const char *sourceFileName,int lineNumber)
 { return Message(mess, "U", opt,sourceFileName,lineNumber);}
 //_____________________________________________________________________________
 void StLoggerManager::IgnoreRepeats()
@@ -797,15 +797,15 @@ _NO_IMPLEMENTATION_;   return 0;
 }
 
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::Fatal(const char* mess, const char* opt,const char *sourceFileName, int lineNumber)
+std::ostringstream& StLoggerManager::Fatal(const char* mess, const char* opt,const char *sourceFileName, int lineNumber)
 { return Message(mess,"F",opt,sourceFileName,lineNumber);}
 
 // "As is" Messages:
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::out(const char* mess)
+std::ostringstream& StLoggerManager::out(const char* mess)
 {return Message(mess,"I","OP-");}
 //_____________________________________________________________________________
-ostrstream& StLoggerManager::err(const char* mess)
+std::ostringstream& StLoggerManager::err(const char* mess)
 {return Message(mess,"E","EP-");}
 
 
@@ -979,7 +979,7 @@ const char *GetName()
   // Instantiate the (singleton) class upon loading
   //
 // static StMessMgr* temp=StLoggerManager::Instance();
-// ostrstream& gMess = *(StMessMgr *)StLoggerManager::Instance();
+// std::ostringstream& gMess = *(StMessMgr *)StLoggerManager::Instance();
 
 //_____________________________________________________________________________
 // $Id: StLoggerManager.cxx,v 1.50 2013/07/23 20:03:05 dmitry Exp $

--- a/StRoot/StStarLogger/StLoggerManager.h
+++ b/StRoot/StStarLogger/StLoggerManager.h
@@ -58,7 +58,7 @@ class StLoggerManager : public StMessMgr {
 #ifndef __CINT__
    std::vector<std::string>  fSourceFileNames;
    std::string fLastMessage;
-   ostrstream fStreams[7];
+   std::ostringstream fStreams[7];
 #endif
    int   fLineNumbers[10];
    int   fAllowRepeat;        // the total number one and the same message can be printed out
@@ -85,7 +85,7 @@ class StLoggerManager : public StMessMgr {
   void SetStarOptionFilter(const log4cxx::varia::StarOptionFilterPtr& filter);
   const log4cxx::varia::StarOptionFilterPtr& GetStarOptionFilter() const;
   log4cxx::varia::StarOptionFilterPtr& GetStarOptionFilter();
-  ostrstream &Stream();
+  std::ostringstream &Stream();
 #endif
 
 protected:
@@ -118,7 +118,7 @@ protected:
    static  void setColorEnabled(bool t = true) {mColorEnabled = t;}
 
 // Generic Messages:
-   virtual ostrstream& Message(const char* mess="", const char* type="",
+   virtual std::ostringstream& Message(const char* mess="", const char* type="",
          const char* opt=0,const char *sourceFileName=0, int lineNumber=-1);
    virtual       void Print();
 //    virtual        int PrintList(messVec* list);
@@ -152,7 +152,7 @@ protected:
 //   virtual const char *GetName();
 
 // Info Messages:
-   virtual ostrstream& Info(const char* mess="", const char* opt="O"
+   virtual std::ostringstream& Info(const char* mess="", const char* opt="O"
                           ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintInfos();
    virtual const messVec* GetInfos();
@@ -162,7 +162,7 @@ protected:
          const char* s3="", const char* s4="");
 
 // Warning Messages:
-   virtual ostrstream& Warning(const char* mess="", const char* opt="E"
+   virtual std::ostringstream& Warning(const char* mess="", const char* opt="E"
                              ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintWarnings();
    virtual const messVec* GetWarnings();
@@ -172,7 +172,7 @@ protected:
          const char* s3="", const char* s4="");
 
 // Error Messages:
-   virtual ostrstream& Error(const char* mess="", const char* opt="E"
+   virtual std::ostringstream& Error(const char* mess="", const char* opt="E"
                            ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintErrors();
    virtual const messVec* GetErrors();
@@ -182,7 +182,7 @@ protected:
          const char* s3="", const char* s4="");
 
 // Debug Messages:
-   virtual ostrstream& Debug(const char* mess="", const char* opt="OT"
+   virtual std::ostringstream& Debug(const char* mess="", const char* opt="OT"
                            ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintDebug();
    virtual const messVec* GetDebugs();
@@ -192,7 +192,7 @@ protected:
          const char* s3="", const char* s4="");
 
 // QAInfo Messages:
-   virtual ostrstream& QAInfo(const char* mess="", const char* opt="OS"
+   virtual std::ostringstream& QAInfo(const char* mess="", const char* opt="OS"
                             ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintQAInfo();
    virtual const messVec* GetQAInfos();
@@ -202,7 +202,7 @@ protected:
          const char* s3="", const char* s4="");
 
 // UCMInfo Messages:
-   virtual ostrstream& UCMInfo(const char* mess="", const char* opt="OS"
+   virtual std::ostringstream& UCMInfo(const char* mess="", const char* opt="OS"
                             ,const char *sourceFileName=0, int lineNumber=-1);
    virtual        int PrintUCMInfo();
    virtual const messVec* GetUCMInfos();
@@ -212,13 +212,13 @@ protected:
          const char* s3="", const char* s4="");
    
 // "As is" Messages:
-   virtual ostrstream& out(const char* mess="");
-   virtual ostrstream& err(const char* mess="");
+   virtual std::ostringstream& out(const char* mess="");
+   virtual std::ostringstream& err(const char* mess="");
 
    virtual       void PrintInfo();
 
    // Fatal Messages:
-   virtual ostrstream& Fatal(const char* mess="", const char* opt="F",const char *sourceFileName=0, int lineNumber=-1);
+   virtual std::ostringstream& Fatal(const char* mess="", const char* opt="F",const char *sourceFileName=0, int lineNumber=-1);
 
    //  "Extra Logger" methods
    void PrintLogger(const char* mess, unsigned char type, const char* opt, const char *sourceFileName=0, int lineNumber=-1);

--- a/StRoot/StUtilities/StMessage.cxx
+++ b/StRoot/StUtilities/StMessage.cxx
@@ -21,12 +21,12 @@
 using namespace std;
 static StMessageCounter* messCounter = StMessageCounter::Instance();
 
-static ostrstream messBuffer;
+static std::ostringstream messBuffer;
 static char space = ' ';
 static char tab = '\t';
 
 int StMessage::repeats=1;
-static ostrstream lastMessBuffer;
+static std::ostringstream lastMessBuffer;
 
 #ifdef __ROOT__
 ClassImp(StMessage)

--- a/StRoot/StUtilities/StMessage.cxx
+++ b/StRoot/StUtilities/StMessage.cxx
@@ -108,19 +108,19 @@ int StMessage::Print(int nChars) {
   }
   const char* addedMessage=0;
   if (nChars == 0) {
-    addedMessage = messCounter->str();                   // Any limit message
+    addedMessage = messCounter->str().c_str();                   // Any limit message
   } else {
     if (nChars>0) {
       if (messBuffer.tellp() >= nChars)
         messBuffer.seekp(nChars-1);   // set end-of-string at nChars
-      int noReturns = strcspn(messBuffer.str(),endofline);
+      int noReturns = strcspn(messBuffer.str().c_str(),endofline);
       if (noReturns < messBuffer.tellp()) messBuffer.seekp(noReturns);
     } else
       nChars = 0;
   }
   messBuffer << ends;
   if (!repeats) {
-    if (!strcmp(messBuffer.str(),lastMessBuffer.str())) {
+    if (!strcmp(messBuffer.str().c_str(),lastMessBuffer.str().c_str())) {
       return messBuffer.tellp();
     } else {
       lastMessBuffer.seekp(0);

--- a/StRoot/StUtilities/StMessageCounter.cxx
+++ b/StRoot/StUtilities/StMessageCounter.cxx
@@ -15,7 +15,7 @@ using namespace std;
 StMessageCounter* StMessageCounter::mInstance = 0;
 
 //_____________________________________________________________________________
-StMessageCounter::StMessageCounter() : ostrstream(),
+StMessageCounter::StMessageCounter() : std::ostringstream(),
 limitMessage(" - COUNT LIMIT REACHED!\n") {
   messTypeList = StMessTypeList::Instance();
   yesLimits = 0;

--- a/StRoot/StUtilities/StMessageCounter.h
+++ b/StRoot/StUtilities/StMessageCounter.h
@@ -19,7 +19,7 @@ typedef StVector(char*) messCharVec;
 typedef StVector(char*)::iterator messCharVecIter;
 
 
-class StMessageCounter : public ostrstream {
+class StMessageCounter : public std::ostringstream {
  private:
    static StMessageCounter* mInstance;
    StMessTypeList* messTypeList;

--- a/StRoot/StUtilities/StMessageManager.cxx
+++ b/StRoot/StUtilities/StMessageManager.cxx
@@ -115,7 +115,7 @@ StMessMgr* StMessageManager::Instance() {
   return mInstance;
 }
 //_____________________________________________________________________________
-ostrstream& StMessageManager::Message(const char* mess, const char* type,
+std::ostringstream& StMessageManager::Message(const char* mess, const char* type,
   const char* opt,const char *,int) {
 //
 // Message declarator - creates a new message if mess is not empty,

--- a/StRoot/StUtilities/StMessageManager.cxx
+++ b/StRoot/StUtilities/StMessageManager.cxx
@@ -221,7 +221,7 @@ void StMessageManager::Print() {
       *this << std::ends;
     }
 
-    BuildMessage(str(), curType, curOpt);
+    BuildMessage(str().c_str(), curType, curOpt);
     building = 0;
 
   } else {

--- a/StRoot/StUtilities/StMessageManager.h
+++ b/StRoot/StUtilities/StMessageManager.h
@@ -59,7 +59,7 @@ class StMessageManager : public StMessMgr {
    virtual std::ostream& OperatorShift(std::ostream& os, StMessage* stm);
 
 // Generic Messages:
-   virtual ostrstream& Message(const char* mess="", const char* type="",
+   virtual std::ostringstream& Message(const char* mess="", const char* type="",
          const char* opt=0,const char *sourceFileName=0, int lineNumber=-1);
    virtual       void Print();
    virtual        int PrintList(messVec* list);
@@ -94,7 +94,7 @@ class StMessageManager : public StMessMgr {
    virtual        int ListTypes() {return messTypeList->ListTypes();}
 
 // Info Messages:
-   virtual ostrstream& Info(const char* mess="", const char* opt="O",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& Info(const char* mess="", const char* opt="O",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "I", opt);}
    virtual        int PrintInfos() {return PrintList(messCollection[1]); }
    virtual const messVec* GetInfos() {return (messCollection[1]);}
@@ -106,7 +106,7 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[1]);}
 
 // Warning Messages:
-   virtual ostrstream& Warning(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& Warning(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "W", opt,sourceFileName,lineNumber);}
    virtual        int PrintWarnings() {return PrintList(messCollection[2]); }
    virtual const messVec* GetWarnings() {return (messCollection[2]);}
@@ -118,7 +118,7 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[2]);}
 
 // Error Messages:
-   virtual ostrstream& Error(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& Error(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "E", opt,sourceFileName,lineNumber);}
    virtual        int PrintErrors() {return PrintList(messCollection[3]); }
    virtual const messVec* GetErrors() {return (messCollection[3]);}
@@ -130,7 +130,7 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[3]);}
 
 // Debug Messages:
-   virtual ostrstream& Debug(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& Debug(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "D", opt,sourceFileName,lineNumber);}
    virtual        int PrintDebug() {return PrintList(messCollection[4]); }
    virtual const messVec* GetDebugs() {return (messCollection[4]);}
@@ -142,7 +142,7 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[4]);}
 
 // QAInfo Messages:
-   virtual ostrstream& QAInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& QAInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "Q", opt,sourceFileName,lineNumber);}
    virtual        int PrintQAInfo() {return PrintList(messCollection[5]); }
    virtual const messVec* GetQAInfos() {return (messCollection[5]);}
@@ -154,7 +154,7 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[5]);}
 
 // UCMInfo Messages:
-   virtual ostrstream& UCMInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& UCMInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1)
          { return Message(mess, "U", opt,sourceFileName,lineNumber);}
    virtual        int PrintUCMInfo() {return PrintList(messCollection[6]); }
    virtual const messVec* GetUCMInfos() {return (messCollection[6]);}
@@ -166,14 +166,14 @@ class StMessageManager : public StMessMgr {
 	 {return FindMessageList(s1,s2,s3,s4,messCollection[6]);}
 
 // "As is" Messages:
-   virtual ostrstream& out(const char* mess="")
+   virtual std::ostringstream& out(const char* mess="")
 	 {return Message(mess,"I","OP-");}
-   virtual ostrstream& err(const char* mess="")
+   virtual std::ostringstream& err(const char* mess="")
 	 {return Message(mess,"E","EP-");}
 
    virtual       void PrintInfo();
 // Fatal Messages:
-   virtual ostrstream& Fatal(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
+   virtual std::ostringstream& Fatal(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)
    { return Message(mess, "E", opt,sourceFileName,lineNumber);}
 
 };

--- a/StRoot/St_base/StMessMgr.cxx
+++ b/StRoot/St_base/StMessMgr.cxx
@@ -10,7 +10,7 @@ StMessage* endm     = 0;
 StMessage* gMessage = 0;
 
 //______________________________________________________________________________
-StMessMgr::StMessMgr() : ostrstream() {}
+StMessMgr::StMessMgr() : std::ostringstream() {}
 
 //  Manager factory
 //  The default version of the manager factory provide the singleton object

--- a/StRoot/St_base/StMessMgr.h
+++ b/StRoot/St_base/StMessMgr.h
@@ -105,7 +105,7 @@ class messVec;
 #include <Stsstream.h>
 #include <Stiostream.h>
 
-class StMessMgr : public ostrstream {
+class StMessMgr : public std::ostringstream {
    friend ostream& operator<<(ostream& ,StMessage*);
    friend ostream& operator++(StMessMgr&);
    friend ostream& operator-(StMessMgr&);
@@ -132,7 +132,7 @@ class StMessMgr : public ostrstream {
    virtual std::ostream& OperatorShift(std::ostream& os, StMessage* stm) = 0;
 
 // Generic Messages:
-   virtual ostrstream& Message(const char* mess="", const char* type="",
+   virtual std::ostringstream& Message(const char* mess="", const char* type="",
          const char* opt=0,const char *sourceFileName=0, int lineNumber=-1)= 0;
    virtual       void Print() =0;
    virtual        int PrintList(messVec* list) =0;
@@ -208,7 +208,7 @@ protected:
          
 public:
 // Info Messages:
-   virtual ostrstream& Info(const char* mess="", const char* opt="O",const char *sourceFileName=0, int lineNumber=-1)=0;
+   virtual std::ostringstream& Info(const char* mess="", const char* opt="O",const char *sourceFileName=0, int lineNumber=-1)=0;
    virtual        int PrintInfos() =0;
    virtual const messVec* GetInfos() =0;
    virtual StMessage* FindInfo(const char* s1, const char* s2="",
@@ -217,7 +217,7 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // Warning Messages:
-   virtual ostrstream& Warning(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)= 0;
+   virtual std::ostringstream& Warning(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1)= 0;
    virtual        int PrintWarnings() =0;
    virtual const messVec* GetWarnings() =0;
    virtual StMessage* FindWarning(const char* s1, const char* s2="",
@@ -226,7 +226,7 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // Error Messages:
-   virtual ostrstream& Error(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1) = 0;
+   virtual std::ostringstream& Error(const char* mess="", const char* opt="E",const char *sourceFileName=0, int lineNumber=-1) = 0;
    virtual        int PrintErrors() =0;
    virtual const messVec* GetErrors() =0;
    virtual StMessage* FindError(const char* s1, const char* s2="",
@@ -235,7 +235,7 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // Debug Messages:
-   virtual ostrstream& Debug(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)= 0;
+   virtual std::ostringstream& Debug(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)= 0;
    virtual        int PrintDebug() =0;
    virtual const messVec* GetDebugs() =0;
    virtual StMessage* FindDebug(const char* s1, const char* s2="",
@@ -244,7 +244,7 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // QAInfo Messages:
-   virtual ostrstream& QAInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1) = 0;
+   virtual std::ostringstream& QAInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1) = 0;
    virtual        int PrintQAInfo() =0;
    virtual const messVec* GetQAInfos() =0;
    virtual StMessage* FindQAInfo(const char* s1, const char* s2="",
@@ -253,7 +253,7 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // UCMInfo Messages:
-   virtual ostrstream& UCMInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1) = 0;
+   virtual std::ostringstream& UCMInfo(const char* mess="", const char* opt="OS",const char *sourceFileName=0, int lineNumber=-1) = 0;
    virtual        int PrintUCMInfo() =0;
    virtual const messVec* GetUCMInfos() =0;
    virtual StMessage* FindUCMInfo(const char* s1, const char* s2="",
@@ -262,12 +262,12 @@ public:
          const char* s3="", const char* s4="") =0;
 
 // "As is" Messages:
-   virtual ostrstream& out(const char* mess="") = 0;
-   virtual ostrstream& err(const char* mess="") = 0;
+   virtual std::ostringstream& out(const char* mess="") = 0;
+   virtual std::ostringstream& err(const char* mess="") = 0;
 
    virtual       void PrintInfo() =0;
    // Fatal Messages:
-   virtual ostrstream& Fatal(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)= 0;
+   virtual std::ostringstream& Fatal(const char* mess="", const char* opt="OT",const char *sourceFileName=0, int lineNumber=-1)= 0;
 
 #ifdef __ROOT__
    ClassDef(StMessMgr,0)

--- a/StRoot/St_base/Stsstream.h
+++ b/StRoot/St_base/Stsstream.h
@@ -12,20 +12,6 @@
 #include "Rstrstream.h"
 #ifdef R__SSTREAM
 using std::streamsize;
-class ostrstream : public std::ostringstream {
-std::string myString;
-public:
-const char *str()         
-{
-  std::string tmp = std::ostringstream::str();
-  if (myString != tmp) myString=tmp;
-  return myString.c_str();
-}	
-int        pcount()       {return int(tellp()) ;}
-void       seekp(int pos) {if (int(tellp())>=0) std::ostringstream::seekp(pos);}
-void freeze(bool) const{;}
-};	
-
 
 class istrstream : public std::istringstream {
 public:


### PR DESCRIPTION
Another attempt to resolve #126

To summarize, we get rid of `ostrstream` as implemented in ` StRoot/St_base/Stsstream.h` and switch to using `std::ostringstream` class instead. This transition is more or less straightforward as the STAR's implementation of `ostrstream` inherited from `std::ostringstream`.