### PR TITLE
StJetMaker: add idTruth to StJetTrack

### DIFF
--- a/StRoot/StJetMaker/StJetMaker2009.cxx
+++ b/StRoot/StJetMaker/StJetMaker2009.cxx
@@ -396,6 +396,9 @@ void StJetMaker2009::copyTrack(const StMuTrackEmu* t, StJetTrack* track)
   track->mNSigmaTofKaon      = t->nSigmaTofKaon();
   track->mNSigmaTofProton    = t->nSigmaTofProton();
   track->mNSigmaTofElectron  = t->nSigmaTofElectron();
+
+  track->mIdTruth            = t->idTruth();
+  track->mQaTruth            = t->qaTruth();
 }
 
 void StJetMaker2009::copyTower(const StMuTowerEmu* t, StJetTower* tower)

--- a/StRoot/StJetMaker/StUEMaker2009.cxx
+++ b/StRoot/StJetMaker/StUEMaker2009.cxx
@@ -235,6 +235,9 @@ void StUEMaker2009::copyTrack(const StjTrack& t, StJetTrack* track)
   track->mNSigmaTofKaon     = t.nSigmaTofKaon;
   track->mNSigmaTofProton   = t.nSigmaTofProton;
   track->mNSigmaTofElectron = t.nSigmaTofElectron;
+	
+  track->mIdTruth           = t.idTruth;
+  track->mQaTruth           = t.qaTruth;
 }
 
 void StUEMaker2009::copyTower(const StjTowerEnergy& t, StJetTower* tower)

--- a/StRoot/StJetMaker/emulator/StMuTrackEmu.h
+++ b/StRoot/StJetMaker/emulator/StMuTrackEmu.h
@@ -40,6 +40,8 @@ public:
     , _dEdx(0)
     , _beta(0)
     , _trackIndex(0)
+    , _idTruth(0)
+    , _qaTruth(0)
     , _id(0)
     , _detectorId(0)
     , _btofTrayId(0)
@@ -82,6 +84,8 @@ public:
   const TVector3& firstPoint() const { return _firstPoint; }
   const TVector3&  lastPoint() const { return _lastPoint;  }
   int            trackIndex()  const { return _trackIndex; }
+  int            idTruth()     const { return _idTruth; }
+  int            qaTruth()     const { return _qaTruth; }
   short          id()          const { return _id; }
   short          detectorId()  const { return _detectorId; }
 
@@ -127,6 +131,9 @@ private:
   TVector3       _lastPoint;
 
   int            _trackIndex;
+
+  int            _idTruth;
+  int            _qaTruth;
 
   short          _id;
   short          _detectorId;

--- a/StRoot/StJetMaker/emulator/StjeTrackListToStMuTrackFourVecList.cxx
+++ b/StRoot/StJetMaker/emulator/StjeTrackListToStMuTrackFourVecList.cxx
@@ -66,6 +66,8 @@ StMuTrackEmu* StjeTrackListToStMuTrackFourVecList::createTrackEmu(const StjTrack
   ret->_lastPoint      =  track.lastPoint             ;
   ret->_trackIndex     =  track.trackIndex            ; 
   ret->_id             =  track.id                    ;
+  ret->_idTruth        =  track.idTruth               ;
+  ret->_qaTruth        =  track.qaTruth               ;
   ret->_detectorId     =  track.detectorId    	      ;
   ret->_btofTrayId         =  track.btofTrayId        ; 
   ret->_nSigmaTofPion      =  track.nSigmaTofPion     ;

--- a/StRoot/StJetMaker/mudst/StjTPCMuDst.cxx
+++ b/StRoot/StJetMaker/mudst/StjTPCMuDst.cxx
@@ -159,6 +159,8 @@ StjTrack StjTPCMuDst::createTrack(const StMuTrack* mutrack, int i, double magnet
   track.beta = mutrack->globalTrack() ? mutrack->globalTrack()->btofPidTraits().beta() : 0;
   track.trackIndex = i;
   track.id = mutrack->id();
+  track.idTruth = mutrack->idTruth();
+  track.qaTruth = mutrack->qaTruth();
   track.firstPoint = mutrack->firstPoint().xyz();
   track.lastPoint  = mutrack->lastPoint().xyz();
 

--- a/StRoot/StJetMaker/tracks/StjTrackList.h
+++ b/StRoot/StJetMaker/tracks/StjTrackList.h
@@ -57,7 +57,7 @@ public:
   double         nSigmaTofProton;
   double         nSigmaTofElectron;
 
-  ClassDef(StjTrack,5);
+  ClassDef(StjTrack,6);
 };
 
 typedef std::vector<StjTrack> StjTrackList;

--- a/StRoot/StJetMaker/tracks/StjTrackList.h
+++ b/StRoot/StJetMaker/tracks/StjTrackList.h
@@ -46,6 +46,8 @@ public:
   double         beta;
   int            trackIndex;
   short          id;
+  int            idTruth;
+  int            qaTruth;
   TVector3       firstPoint;
   TVector3       lastPoint;
 
@@ -99,6 +101,8 @@ inline bool operator==(const StjTrack& v1, const StjTrack& v2)
   if(v1.nSigmaTofKaon     != v2.nSigmaTofKaon)     return false;
   if(v1.nSigmaTofProton   != v2.nSigmaTofProton)   return false;
   if(v1.nSigmaTofElectron != v2.nSigmaTofElectron) return false;
+  if(v1.idTruth           != v2.idTruth)           return false;
+  if(v1.qaTruth           != v2.qaTruth)           return false;
   return true;
 }
 

--- a/StRoot/StSpinPool/StJetEvent/StJetTrack.h
+++ b/StRoot/StSpinPool/StJetEvent/StJetTrack.h
@@ -37,6 +37,8 @@ public:
     , mNSigmaTofKaon(0)
     , mNSigmaTofProton(0)
     , mNSigmaTofElectron(0)
+    , mIdTruth(0)
+    , mQaTruth(0)
   {
   }
 
@@ -67,6 +69,8 @@ public:
   float nSigmaKaon()           const { return mNSigmaKaon; }
   float nSigmaProton()         const { return mNSigmaProton; }
   float nSigmaElectron()       const { return mNSigmaElectron; }
+  int   idTruth()              const { return mIdTruth; }
+  int   qaTruth()              const { return mQaTruth; }
   float m()                    const { return (beta() > 0 && beta() < 1) ? momentum().Mag()*TMath::Sqrt(1/(beta()*beta())-1) : -999; }
 
   int btofTrayId()             const { return mBTofTrayId; }
@@ -104,7 +108,10 @@ private:
   double   mNSigmaTofProton;
   double   mNSigmaTofElectron;
 
-  ClassDef(StJetTrack,6); 
+  int      mIdTruth;
+  int      mQaTruth;
+
+  ClassDef(StJetTrack, 7);
 };
 
 #endif // ST_JET_TRACK_H


### PR DESCRIPTION
This should be useful for studies of simulation (e.g. select real tracks vs pile-up), to match tracks to the Pythia particles. For matching to secondary particles an external geant.root or minimc.root would be required.