### PR TITLE
Introduce FXT chain option to enable anything FXT-specific

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1207,6 +1207,7 @@ Bfc_st BFC[] = { // standard chains
   {"paw"         ,""  ,"",""                                      ,"","","Allocate memory for pawc",kFALSE},
   {"AllEvent"    ,""  ,"","Tree"                               ,"","","Write whole event to StTree",kFALSE},
   {"AllTables"   ,""  ,"","",""                                     ,"St_Tables","Load Star Tables",kFALSE},
+  {"FXT"         ,""  ,"","",""                                  ,"","enable anything FXT-specific",kFALSE},
   {"Corr1"       ,""  ,"","AlignSectors,ExB,OBmap,OClock,OPr13","",""
    ,                                                  "... AlignSectors,ExB,OBmap,OClock,OPr13 ...",kFALSE},
   {"Corr2"       ,""  ,"","Corr1,OTwist,OIFC"                     ,"","","...Corr1+OTwist,OIFC ...",kFALSE},

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -290,6 +290,9 @@ Int_t StBFChain::Instantiate()
 	  // Determine flavors
 	  TString flavors = "ofl"; // default flavor for offline
 
+	  // fixed target flavor
+	  if (GetOption("FXT")) flavors.Prepend("FXT+");
+
 	  // simulation flavors
 	  if (GetOption("Simu") && ! GetOption("NoSimuDb")) flavors.Prepend("sim+");
 


### PR DESCRIPTION
FXT chain option and database flavor will facilitate calibrations of fixed target datasets which were interspersed between other non-FXT dataset in time during BES-II data-taking.

Note: the TPC group has already been using this flavor, triggered by particular test on a beam conditions database. This chain option will provide a more robust switch to ensure the use of desired database tables and any other actions of interest in the code.