### PR TITLE
fixed a logical error for the PicoVtxMod::Mtd in StPicoDstMaker.cxx

### DIFF
--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -2574,48 +2574,49 @@ bool StPicoDstMaker::selectVertex() {
     } //if (mBTofHeader && fabs(mBTofHeader->vpdVz()) < 200)
   } //else if (mVtxMode == PicoVtxMode::Vpd || mVtxMode == PicoVtxMode::VpdOrDefault)
   else if ( mVtxMode == PicoVtxMode::Mtd ) {
-    
-    // Set the first primary vertex as a default vertex
-    mMuDst->setVertexIndex(0);
-    // Set pointer to the first primary vertex
-    selectedVertex = mMuDst->primaryVertex();
 
-    // Loop over primary vertices
-    for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++) {
+      // Set the first primary vertex as a default vertex
+      int VtxIndex = 0;
 
-      // Set pointer to i-th primary vertex
-      mMuDst->setVertexIndex( iVtx );
+      // Loop over primary vertices
+      for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++) {
 
-      // Counter for primary tracks that matched MTD
-      int nMtdMatched = 0;
+          // Set pointer to i-th primary vertex
+          mMuDst->setVertexIndex( iVtx );
 
-      // Loop over primary tracks
-      for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++) {
+          // Counter for primary tracks that matched MTD
+          int nMtdMatched = 0;
 
-	// Retrieve i-th primary track from that belongs
-	// to the current primary vertex
-	StMuTrack* pTrack = mMuDst->primaryTracks( iTrk );
-	// Track must exist
-	if( !pTrack ) continue;
+          // Loop over primary tracks
+          for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++) {
 
-	// Check if track matches MTD
-	if( pTrack->index2MtdHit()<0 ) continue;
-	// Increment number of tracks that matched MTD
-	nMtdMatched++;
-       
-      } // for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++)
+              // Retrieve i-th primary track from that belongs
+              // to the current primary vertex
+              StMuTrack* pTrack = mMuDst->primaryTracks( iTrk );
+              // Track must exist
+              if( !pTrack ) continue;
 
-	// Take the first primary vertex that has at least 2 tracks
-	// that matched MTD
-      if( nMtdMatched >= 2 ) {
-	// Reset vertex index
-	mMuDst->setVertexIndex( iVtx );
-	// Reset pointer to the primary vertex
-	selectedVertex = mMuDst->primaryVertex();
-	// Quit vertex loop
-	break;
-      } // if( nMtdMatched >= 2 )
-    } // for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++)
+              // Check if track matches MTD
+              if( pTrack->index2MtdHit()<0 ) continue;
+              // Increment number of tracks that matched MTD
+              nMtdMatched++;
+
+          } // for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++)
+
+          // Take the first primary vertex that has at least 2 tracks
+          // that matched MTD
+          if( nMtdMatched >= 2 ) {
+              // Change vertex index
+              VtxIndex = iVtx;
+              // Quit vertex loop
+              break;
+          } // if( nMtdMatched >= 2 )
+      } // for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++)
+
+      // Set the vertex index
+      mMuDst->setVertexIndex(VtxIndex);
+      // Set pointer to the primary vertex
+      selectedVertex = mMuDst->primaryVertex();
   } //  else if ( mVtxMode == PicoVtxMode::Mtd )
   else { // default case
     LOG_ERROR << "Pico Vtx Mode not set!" << endm;

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -2575,48 +2575,48 @@ bool StPicoDstMaker::selectVertex() {
   } //else if (mVtxMode == PicoVtxMode::Vpd || mVtxMode == PicoVtxMode::VpdOrDefault)
   else if ( mVtxMode == PicoVtxMode::Mtd ) {
 
-      // Set the first primary vertex as a default vertex
-      int VtxIndex = 0;
+    // Set the first primary vertex as a default vertex
+    int VtxIndex = 0;
 
-      // Loop over primary vertices
-      for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++) {
+    // Loop over primary vertices
+    for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++) {
 
-          // Set pointer to i-th primary vertex
-          mMuDst->setVertexIndex( iVtx );
+      // Set pointer to i-th primary vertex
+      mMuDst->setVertexIndex( iVtx );
 
-          // Counter for primary tracks that matched MTD
-          int nMtdMatched = 0;
+      // Counter for primary tracks that matched MTD
+      int nMtdMatched = 0;
 
-          // Loop over primary tracks
-          for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++) {
+      // Loop over primary tracks
+      for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++) {
 
-              // Retrieve i-th primary track from that belongs
-              // to the current primary vertex
-              StMuTrack* pTrack = mMuDst->primaryTracks( iTrk );
-              // Track must exist
-              if( !pTrack ) continue;
+        // Retrieve i-th primary track from that belongs
+        // to the current primary vertex
+        StMuTrack* pTrack = mMuDst->primaryTracks( iTrk );
+        // Track must exist
+        if( !pTrack ) continue;
 
-              // Check if track matches MTD
-              if( pTrack->index2MtdHit()<0 ) continue;
-              // Increment number of tracks that matched MTD
-              nMtdMatched++;
+        // Check if track matches MTD
+        if( pTrack->index2MtdHit()<0 ) continue;
+        // Increment number of tracks that matched MTD
+        nMtdMatched++;
 
-          } // for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++)
+      } // for(unsigned int iTrk=0; iTrk<mMuDst->numberOfPrimaryTracks(); iTrk++)
 
-          // Take the first primary vertex that has at least 2 tracks
-          // that matched MTD
-          if( nMtdMatched >= 2 ) {
-              // Change vertex index
-              VtxIndex = iVtx;
-              // Quit vertex loop
-              break;
-          } // if( nMtdMatched >= 2 )
-      } // for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++)
+      // Take the first primary vertex that has at least 2 tracks
+      // that matched MTD
+      if( nMtdMatched >= 2 ) {
+        // Change vertex index
+        VtxIndex = iVtx;
+        // Quit vertex loop
+        break;
+      } // if( nMtdMatched >= 2 )
+    } // for(unsigned int iVtx=0; iVtx<mMuDst->numberOfPrimaryVertices(); iVtx++)
 
-      // Set the vertex index
-      mMuDst->setVertexIndex(VtxIndex);
-      // Set pointer to the primary vertex
-      selectedVertex = mMuDst->primaryVertex();
+    // Set the vertex index
+    mMuDst->setVertexIndex(VtxIndex);
+    // Set pointer to the primary vertex
+    selectedVertex = mMuDst->primaryVertex();
   } //  else if ( mVtxMode == PicoVtxMode::Mtd )
   else { // default case
     LOG_ERROR << "Pico Vtx Mode not set!" << endm;


### PR DESCRIPTION
I fixed a logical error for the PicoVtxMod::Mtd in StPicoDstMaker.cxx

Origianl:
1. Select default vertex first
2. Select each vertex in the vertex loop in order to find the vertex with at least 2 MTD matched primary tracks
3. Select MTD vertex if it is found
-> If the MTD vertex is not found (most of the cases), the vertex loop will continue to the end and the last one is selected.

Fixed:
1. Instead of selecting the vertex directly, I store the default vertex index in a variable VtxIndex.
2. VtxIndex will be changed if MTD vertex is found in the vertex loop.
3. Select the vertex after the vertex loop.
-> Default vertex will be selected if no MTD vertex is found in the loop.

Detail can be found at: https://drupal.star.bnl.gov/STAR/system/files/TeChuan_Run17_SL21c_vtxQA.pdf