### PR TITLE
Getter/setter for user weights

### DIFF
--- a/StRoot/StarGenerator/EVENT/StarGenEvent.h
+++ b/StRoot/StarGenerator/EVENT/StarGenEvent.h
@@ -205,6 +205,12 @@ class StarGenEvent : public TObject
   /// Returns the filter result
   UInt_t GetFilterResult(){ return mFilterResult; }
 
+  /// Attach a user-weight to the event
+  void AddUserWeight( double w ){ mWeights.push_back(w); }
+
+  /// Retrieve the user weights vector
+  const std::vector<double>& GetUserWeights(){ return mWeights; }
+
  private:
   /// Copy ctor is private.  
   StarGenEvent( const StarGenEvent &other );

--- a/StRoot/StarGenerator/EVENT/StarGenEvent.h
+++ b/StRoot/StarGenerator/EVENT/StarGenEvent.h
@@ -209,7 +209,9 @@ class StarGenEvent : public TObject
   void AddUserWeight( double w ){ mWeights.push_back(w); }
 
   /// Retrieve the user weights vector
-  const std::vector<double>& GetUserWeights(){ return mWeights; }
+  const std::vector<double>& GetUserWeights()       { return mWeights; }
+  /// Retrieve the user weights vector
+  const std::vector<double>& GetUserWeights() const { return mWeights; }
 
  private:
   /// Copy ctor is private.  


### PR DESCRIPTION
Adding a "get" and "set" method for the user weights defined in the event generator record.  These were previously missing, and will be required for upcoming hard diffraction simulations.