### PR TITLE
Geometry update for 2022

### DIFF
--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -157,8 +157,9 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
   {"y2021a",      20201215,     1, "y2021a",   "y2021 first production geometry, AgML,xgeometry"},   
 
   {"y2022",       20211010,     0, "y2021",    "y2021 development geometry, AgML,xgeometry"},   
-  
-  {"dev2022",     21221210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},
+
+  {"dev2021",     21201210,     1, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},  
+  {"dev2022",     21211210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},
 
   //
   // Move DEVT and upgrade series +100 years along timeline else they interfere with y2018+ runs

--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -156,7 +156,7 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
   {"y2021",       20201215,     0, "y2021",    "y2021 development geometry, AgML,xgeometry"},   
   {"y2021a",      20201215,     1, "y2021a",   "y2021 first production geometry, AgML,xgeometry"},   
 
-  {"y2022",       20211010,     0, "y2021",    "y2021 development geometry, AgML,xgeometry"},   
+  {"y2022",       20211015,     0, "y2022",    "y2022 first cut geometry, AgML,xgeometry"},   
 
   {"dev2021",     21201210,     1, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},  
   {"dev2022",     21211210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},

--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -155,9 +155,10 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
 
   {"y2021",       20201215,     0, "y2021",    "y2021 development geometry, AgML,xgeometry"},   
   {"y2021a",      20201215,     1, "y2021a",   "y2021 first production geometry, AgML,xgeometry"},   
+
+  {"y2022",       20211010,     0, "y2021",    "y2021 development geometry, AgML,xgeometry"},   
   
-  {"dev2021",     20221210,     0, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},
-  {"dev2022",     20221210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},
+  {"dev2022",     21221210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},
 
   //
   // Move DEVT and upgrade series +100 years along timeline else they interfere with y2018+ runs

--- a/StarDb/AgMLGeometry/Geometry.y2022.C
+++ b/StarDb/AgMLGeometry/Geometry.y2022.C
@@ -1,0 +1,32 @@
+#include "CreateGeometry.h"
+TDataSet *CreateTable() 
+{
+  // Name of the macro including the full path
+  TString myname = gInterpreter->GetCurrentMacroName();
+  
+  // Get an array of TString separated by "/"
+  TObjArray *array = myname.Tokenize("/");
+
+  // Get the name of the macro itself
+  TString name = ((TObjString *)array->Last())->GetString();
+
+  // Isolate the geometry tag
+  array = name.Tokenize(".");
+
+  // Get the geometry tag
+  TString tag = ((TObjString *)array->At(1))->GetString();
+
+  // Ensure that we are not looking at the template
+  if ( tag=="C" )
+    {
+      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
+      std::cout << "to instantiate the geometry specified by the " << std::endl;
+      std::cout << "given [TAG]." << std::endl;
+      return NULL;
+    }
+
+  // Return the requested geometry
+  return CreateGeometry(tag);
+
+}
+

--- a/StarVMC/Geometry/StarGeo.xml
+++ b/StarVMC/Geometry/StarGeo.xml
@@ -14,34 +14,6 @@
 	 C chamber
     -->
  
-  <Geometry tag="dev2021" comment="DEPRECATED.  USE dev2022.  (development tag for the forward star upgrade)">
-    <Construct sys="cave" config="CAVE06"  />
-    <Construct sys="upst" config="UPSTon"  />
-    <Construct sys="shld" config="SHLDon"  />
-    <Construct sys="zcal" config="ZCALon"  />
-    <Construct sys="scon" config="SCON14"  />
-    <Construct sys="pipe" config="PIPE12"/>
-<!-- Temporarily removed so that we do not need to introduce overlapping volumes -->
-<!--    <Construct sys="pipe" config="PIPE12ft" -->
-<!--    <Construct sys="targ" config="TARGv1"  /> --><!-- fixed target geometry -->
-    <Construct sys="tpce" config="TPCEv6"  />
-    <Construct sys="btof" config="BTOFv8"  />
-    <Construct sys="vpdd" config="VPDD08"  />
-    <Construct sys="calb" config="CALB02"  />
-    <Construct sys="ecal" config="ECALv6"  />
-    <Construct sys="bbcm" config="BBCMin"  />
-    <Construct sys="epdm" config="EPDMv1"  />
-    <Construct sys="magp" config="MAGPon"  />
-    <Construct sys="mutd" config="MUTD16"  />
-    <Construct sys="fstm" config="FSTMv1s" />
-    <Construct sys="stgm" config="STGCv1" />
-    <!-- Construct sys="etof" config="ETOFv14f"  -->
-    <Construct sys="wcal" config="WCALv1" simu="1" />
-    <Construct sys="hcal" config="HCALv1" simu="1" />
-    <Construct sys="plat" config="PLATon" simu="2" />
-    <Construct sys="pres" config="PRESof" simu="2" /> 
-  </Geometry>
-
   <Geometry tag="dev2022" comment="development tag for the 2022 forward star upgrade">
     <Construct sys="cave" config="CAVE06"  />
     <Construct sys="upst" config="UPSTon"  />
@@ -69,6 +41,33 @@
     <Construct sys="plat" config="PLATon" simu="2" />
     <Construct sys="pres" config="PRESof" simu="2" /> 
   </Geometry>
+
+
+  <Geometry tag="y2022" comment="STAR initial cut tag">
+    <Construct sys="cave" config="CAVE06"  />
+    <Construct sys="upst" config="UPSTon"  />
+    <Construct sys="shld" config="SHLDon"  />
+    <Construct sys="zcal" config="ZCALon"  />
+    <Construct sys="scon" config="SCON14"  />
+    <Construct sys="pipe" config="PIPE12ft" />
+    <Construct sys="targ" config="TARGv1"  /> 
+    <Construct sys="tpce" config="TPCEv6"  />
+    <Construct sys="btof" config="BTOFv8"  />
+    <Construct sys="vpdd" config="VPDD08"  />
+    <Construct sys="calb" config="CALB02"  />
+    <Construct sys="ecal" config="ECALv6"  />
+    <Construct sys="bbcm" config="BBCMin"  />
+    <Construct sys="epdm" config="EPDMv1"  />
+    <Construct sys="magp" config="MAGPon"  />
+    <Construct sys="mutd" config="MUTD16"  />
+    <Construct sys="wcal" config="WCALv1" simu="1" />
+    <Construct sys="hcal" config="HCALv1" simu="1" />
+    <!-- Note:  These versions of the forward trackers have significant overlaps which need to be resolved -->
+    <Construct sys="fstm" config="FSTMv1" />
+    <Construct sys="stgm" config="STGCv1" />
+    <Construct sys="etof" config="ETOFv14f"  />
+  </Geometry>
+
 
   <Geometry tag="y2021" comment="STAR production tag w/ FCS installation">
     <Construct sys="cave" config="CAVE06"  />

--- a/StarVMC/Geometry/StarGeo.xml
+++ b/StarVMC/Geometry/StarGeo.xml
@@ -14,7 +14,35 @@
 	 C chamber
     -->
  
-  <Geometry tag="dev2022" comment="development tag for the 2022 forward star upgrade">
+   <Geometry tag="dev2021" comment="DEPRECATED.  USE dev2022.  (development tag for the forward star upgrade)">
+    <Construct sys="cave" config="CAVE06"  />
+    <Construct sys="upst" config="UPSTon"  />
+    <Construct sys="shld" config="SHLDon"  />
+    <Construct sys="zcal" config="ZCALon"  />
+    <Construct sys="scon" config="SCON14"  />
+    <Construct sys="pipe" config="PIPE12"/>
+<!-- Temporarily removed so that we do not need to introduce overlapping volumes -->
+<!--    <Construct sys="pipe" config="PIPE12ft" -->
+<!--    <Construct sys="targ" config="TARGv1"  /> --><!-- fixed target geometry -->
+    <Construct sys="tpce" config="TPCEv6"  />
+    <Construct sys="btof" config="BTOFv8"  />
+    <Construct sys="vpdd" config="VPDD08"  />
+    <Construct sys="calb" config="CALB02"  />
+    <Construct sys="ecal" config="ECALv6"  />
+    <Construct sys="bbcm" config="BBCMin"  />
+    <Construct sys="epdm" config="EPDMv1"  />
+    <Construct sys="magp" config="MAGPon"  />
+    <Construct sys="mutd" config="MUTD16"  />
+    <Construct sys="fstm" config="FSTMv1s" /> <!-- simplified FST for tracking --> 
+    <Construct sys="stgm" config="STGCv1" />
+    <!-- Construct sys="etof" config="ETOFv14f"  -->
+    <Construct sys="wcal" config="WCALv1" simu="1" />
+    <Construct sys="hcal" config="HCALv1" simu="1" />
+    <Construct sys="plat" config="PLATon" simu="2" />
+    <Construct sys="pres" config="PRESof" simu="2" /> 
+  </Geometry>
+
+ <Geometry tag="dev2022" comment="development tag for the 2022 forward star upgrade">
     <Construct sys="cave" config="CAVE06"  />
     <Construct sys="upst" config="UPSTon"  />
     <Construct sys="shld" config="SHLDon"  />
@@ -42,8 +70,9 @@
     <Construct sys="pres" config="PRESof" simu="2" /> 
   </Geometry>
 
-
   <Geometry tag="y2022" comment="STAR initial cut tag">
+    <!-- Note:  Current version of sTGC has overlaps which are being resolved.  
+         I anticipate updates to forward detectors during the run. -->
     <Construct sys="cave" config="CAVE06"  />
     <Construct sys="upst" config="UPSTon"  />
     <Construct sys="shld" config="SHLDon"  />
@@ -62,7 +91,6 @@
     <Construct sys="mutd" config="MUTD16"  />
     <Construct sys="wcal" config="WCALv1" simu="1" />
     <Construct sys="hcal" config="HCALv1" simu="1" />
-    <!-- Note:  These versions of the forward trackers have significant overlaps which need to be resolved -->
     <Construct sys="fstm" config="FSTMv1" />
     <Construct sys="stgm" config="STGCv1" />
     <Construct sys="etof" config="ETOFv14f"  />

--- a/StarVMC/xgeometry/xgeometry.age
+++ b/StarVMC/xgeometry/xgeometry.age
@@ -2536,8 +2536,8 @@ If LL>0
   case y2021 { y2021: y2021 first cut geometry; Geom =        'y2021     '; call geom_y2021;} 
   case y2021a { y2021a: y2021 first production geometry; Geom =        'y2021a    '; call geom_y2021a;} 
 
+  case y2022 { y2022: y2022 first cut geometry; Geom =        'y2022     '; call geom_y2022;} 
 
-  case dev2021 { dev2021:  First cut forward upgrades; Geom =        'dev2021   '; call geom_dev2021;} 
   case dev2022 { dev2022:  First cut forward upgrades; Geom =        'dev2022   '; call geom_dev2022;} 
 
   Case ftsver1  { y2017 : y2017 baseline w/ ids and fts v1;     Geom = 'ftsver1   '; call geom_ftsver1;}

--- a/StarVMC/xgeometry/xgeometry.age
+++ b/StarVMC/xgeometry/xgeometry.age
@@ -2538,6 +2538,7 @@ If LL>0
 
   case y2022 { y2022: y2022 first cut geometry; Geom =        'y2022     '; call geom_y2022;} 
 
+  case dev2021 { dev2021:  First cut forward upgrades; Geom =        'dev2021   '; call geom_dev2021;} 
   case dev2022 { dev2022:  First cut forward upgrades; Geom =        'dev2022   '; call geom_dev2022;} 
 
   Case ftsver1  { y2017 : y2017 baseline w/ ids and fts v1;     Geom = 'ftsver1   '; call geom_ftsver1;}


### PR DESCRIPTION
- Implement first cut of the y2022 geometry @ timestamp 20211010.000000
-- sTGC and forward silicon detectors are still in development / expecting to fold in updates as they become available
-- overlaps are a concern for the initial geometries

- Remove deprecated dev2021 geometry model
- Advance dev2022 timestamp by 100 years to not interfere