### PR TITLE
Add Anti-H4 Lambda decay to Anti-He4 + pion-

### DIFF
--- a/StRoot/StarClassLibrary/StHyperNuclei.cc
+++ b/StRoot/StarClassLibrary/StHyperNuclei.cc
@@ -3,3 +3,7 @@
 StH4Lambda  StH4Lambda::mH4Lambda;
 StHe4Lambda StHe4Lambda::mHe4Lambda;
 StHe5Lambda StHe5Lambda::mHe5Lambda;
+
+StH4LambdaBar  StH4LambdaBar::mH4LambdaBar;
+StHe4LambdaBar StHe4LambdaBar::mHe4LambdaBar;
+StHe5LambdaBar StHe5LambdaBar::mHe5LambdaBar;

--- a/StRoot/StarClassLibrary/StHyperNuclei.hh
+++ b/StRoot/StarClassLibrary/StHyperNuclei.hh
@@ -18,8 +18,7 @@
 #include "StarPDGEncoding.hh"
 #include "SystemOfUnits.h"
 
-
-class StH4Lambda : public StIon {
+class StH4Lambda  : public StIon {
 public:
     static StH4Lambda* instance() {
       return &mH4Lambda;
@@ -86,6 +85,88 @@ private:
 		  double mass =4.83978 *GeV,
 		  double width=0.0*MeV, /* TODO */
 		  double charge=+3 *eplus,
+		  int              iSpin=0,
+		  int              iParity=0,
+		  int              iConjugation=0,
+		  int              iIsospin=0,   
+		  int              iIsospinZ=0, 
+		  int              gParity=0,
+		  const string  &  pType="hypernucleus",
+		  int              lepton=0,
+		  int              baryon=4,
+ 		  int              encoding=hid(2,4,1),
+		  bool             stable=false,
+		double           lifetime=2.632e-10) : StIon(aName,mass,width,charge,iSpin,iParity,iConjugation,iIsospin,iIsospinZ,gParity,pType,lepton,baryon,encoding,stable,lifetime)
+  { /* nada */ }
+};
+
+class StH4LambdaBar  : public StIon {
+public:
+    static StH4LambdaBar* instance() {
+      return &mH4LambdaBar;
+    };
+    
+private:
+    static StH4LambdaBar mH4LambdaBar;
+    
+    StH4LambdaBar(const string  &aName="H4LambdaBar",  
+		  double mass =3.92727 *GeV,
+		  double width=0.0*MeV, /* TODO */
+		  double charge=-1 *eplus,
+		  int              iSpin=0,
+		  int              iParity=0,
+		  int              iConjugation=0,
+		  int              iIsospin=0,   
+		  int              iIsospinZ=0, 
+		  int              gParity=0,
+		  const string  &  pType="hypernucleus",
+		  int              lepton=0,
+		  int              baryon=4,
+                  int              encoding=hid(1,3,1),
+		  bool             stable=false,
+    	       double           lifetime=2.632e-10) : StIon(aName,mass,width,charge,iSpin,iParity,iConjugation,iIsospin,iIsospinZ,gParity,pType,lepton,baryon,encoding,stable,lifetime)
+  { /* nada */ }
+};
+class StHe4LambdaBar : public StIon {
+public:
+    static StHe4LambdaBar* instance() {
+      return &mHe4LambdaBar;
+    };
+    
+private:
+    static StHe4LambdaBar mHe4LambdaBar;
+    
+    StHe4LambdaBar(const string  &aName="He4LambdaBar",  
+		  double mass =3.92168 *GeV,
+		  double width=0.0*MeV, /* TODO */
+		  double charge=-2 *eplus,
+		  int              iSpin=0,
+		  int              iParity=0,
+		  int              iConjugation=0,
+		  int              iIsospin=0,   
+		  int              iIsospinZ=0, 
+		  int              gParity=0,
+		  const string  &  pType="hypernucleus",
+		  int              lepton=0,
+		  int              baryon=4,
+   		  int              encoding=hid(2,3,1),
+		  bool             stable=false,
+		double           lifetime=2.632e-10) : StIon(aName,mass,width,charge,iSpin,iParity,iConjugation,iIsospin,iIsospinZ,gParity,pType,lepton,baryon,encoding,stable,lifetime)
+  { /* nada */ }
+};
+class StHe5LambdaBar : public StIon {
+public:
+    static StHe5LambdaBar* instance() {
+      return &mHe5LambdaBar;
+    };
+    
+private:
+    static StHe5LambdaBar mHe5LambdaBar;
+    
+    StHe5LambdaBar(const string  &aName="He5LambdaBar",  
+		  double mass =4.83978 *GeV,
+		  double width=0.0*MeV, /* TODO */
+		  double charge=-3 *eplus,
 		  int              iSpin=0,
 		  int              iParity=0,
 		  int              iConjugation=0,

--- a/StRoot/StarClassLibrary/StParticleTable.cc
+++ b/StRoot/StarClassLibrary/StParticleTable.cc
@@ -412,9 +412,12 @@ StParticleTable::StParticleTable()
        Geant2Pdg( 63053, kHyperTriton,         H3(Lambda) --> quasi 2 body);
        Geant2Pdg( 63054, kAntiHyperTriton, AntiH3(Lambda) --> quasi 2 body);
 
-       Geant2Pdg( 61055, hid(1,3,1), H4(Lambda) --> He4 proton piminus );
+       Geant2Pdg( 61055, hid(1,3,1), H4(Lambda) --> He4 piminus );
        Geant2Pdg( 61057, hid(2,3,1), He4(Lambda) --> He3 proton piminus );
        Geant2Pdg( 61059, hid(2,4,1), He5(Lambda) --> He4 proton piminus );
+
+       Geant2Pdg( 61056, -hid(1,3,1), H4(Lambda)Bar --> He4Bar piplus );
+
 
     ///@}
 

--- a/pams/sim/gstar/gstar_part.g
+++ b/pams/sim/gstar/gstar_part.g
@@ -854,6 +854,18 @@ Particle H4Lambda_He4_pi_minus    code = 61055       ,
                                   bratio = {1,}      , 
                                   mode = {004709,}
 
+Particle H4LambdaBar_He4Bar_pi_plus    code = 61056  , 
+                                  mass = 3.92727     , 
+                                  tlife = 2.6329e-10 , 
+                                  charge = -1        , 
+                                  pdg  = UNDEFINED   , 
+                                  trktyp = kGtHadr   ,  
+                                  bratio = {1,}      
+
+     uw = { 0, 8, 50047 }
+     Call GSPART( %code, %title, %trktyp, %mass, %charge, %tlife, uw, nw )
+
+
 Particle He4Lambda_He3_p_pi_minus code = 61057       , 
                                   mass = 3.92168     , 
                                   tlife = 2.6320e-10 , 


### PR DESCRIPTION
Add the  anti-H4 Lambda decay to Anti-He4 + pion- in support of embedding requests

https://drupal.star.bnl.gov/STAR/starsimrequests/2021/sep/10/anti-h4l-isobar-2018
https://drupal.star.bnl.gov/STAR/starsimrequests/2021/sep/10/anti-h4l-uu193gev-2012
https://drupal.star.bnl.gov/STAR/starsimrequests/2021/sep/10/anti-h4l-auau200gev-2011
https://drupal.star.bnl.gov/STAR/starsimrequests/2021/sep/10/anti-h4l-auau200gev-2010

