### PR TITLE
STGC: Add timing and charge plots, outline detectors.

### DIFF
--- a/OnlTools/Jevp/StJevpBuilders/fttBuilder.cxx
+++ b/OnlTools/Jevp/StJevpBuilders/fttBuilder.cxx
@@ -43,10 +43,10 @@ const std::string fttBuilder::quadLabels[4] = {"A", "B", "C", "D"};
 const std::string fttBuilder::dirLabels[4]  = {"Horizontal", "Vertical", "Diagonal", "Unknown"};
 
 void fttBuilder::initialize(int argc, char *argv[]) {
-	
+    
 
     // Control draw/visiblity options
-    std::vector<std::string> setLogy   = { "hitsPerPlane", "hitsPerQuad", "hitsPerFob", "hitsPerVMM", "hitsVMMPerPlane0", "hitsVMMPerPlane1", "hitsVMMPerPlane2", "hitsVMMPerPlane3", "nStripsFired" };
+    std::vector<std::string> setLogy   = { "hitsPerTb", "chargePerPlane0", "chargePerPlane1", "chargePerPlane2", "chargePerPlane3", "hitsTbPerPlane0", "hitsTbPerPlane1", "hitsTbPerPlane2", "hitsTbPerPlane3", "hitsPerPlane", "hitsPerQuad", "hitsPerFob", "hitsPerVMM", "hitsVMMPerPlane0", "hitsVMMPerPlane1", "hitsVMMPerPlane2", "hitsVMMPerPlane3", "nStripsFired" };
     std::vector<std::string> setLogz   = { "hitsPerPlaneQuad", "hitsFobQuadPerPlane0", "hitsFobQuadPerPlane1", "hitsFobQuadPerPlane2", "hitsFobQuadPerPlane3" };
     std::vector<std::string> showStats = {  };
 
@@ -62,6 +62,8 @@ void fttBuilder::initialize(int argc, char *argv[]) {
         contents.hitsPerQuad              = new TH1D( "hitsPerQuad", "sTGC (hits / Quadrant); Plane & Quadrant; counts (hits)", nQuad,0.5, nQuad + 0.5 );
         contents.hitsPerFob               = new TH1D( "hitsPerFob", "sTGC (hits / Fob); Fob; counts (hits)", nFob,0.5, nFob + 0.5 );
         contents.hitsPerVMM               = new TH1D( "hitsPerVMM", "sTGC (hits / VMM); VMM Index (96VMM / Plane); counts (hits)", nVMM,0.5, nVMM + 0.5 );
+        contents.hitsPerTb                = new TH1D( "hitsPerTb", "sTGC (hits / Timebin); Tb; counts (hits)", 338, minTb, maxTb );
+        contents.hitsPerTb400             = new TH1D( "hitsPerTb400", "sTGC (hits / Timebin); Tb; counts (hits)", 400, -400, 400 );
         contents.hitsPerPlaneQuad         = new TH2D( "hitsPerPlaneQuad", "sTGC (hits / Quadrant); Plane; Quadrant", nPlane,0.5, nPlane + 0.5, nQuadPerPlane, 0.5, nQuadPerPlane + 0.5);
         contents.hitsPerVMMPlane          = new TH2D( "hitsPerVMMPlane", "sTGC (hits / VMM / Plane); VMM index; Plane", nVMMPerPlane, 0.5, nVMMPerPlane+0.5, nPlane,0.5, nPlane + 0.5);
         contents.adcVMM                   = new TH2D( "adcVMM", "sTGC; VMM; ADC", nVMM,0.5, nVMM + 0.5, maxADC/10.0, 0, maxADC);
@@ -77,13 +79,13 @@ void fttBuilder::initialize(int argc, char *argv[]) {
         for ( u_char iPlane = 0; iPlane < fttBuilder::nPlane; iPlane ++ ){
             contents.hitsFobQuadPerPlane[iPlane]    = new TH2D( TSF("hitsFobQuadPerPlane%d", iPlane), TSF("sTGC Plane %d (hits / Fob); Fob index; Quadrant", iPlane+1), nFobPerQuad, 0.5, nFobPerQuad+0.5, nQuadPerPlane, 0.5, nQuadPerPlane+0.5 );
             setQuadLabels( contents.hitsFobQuadPerPlane[iPlane]->GetYaxis() );
-
-
             contents.hitsVMMPerPlane[iPlane]        = new TH1D( TSF("hitsVMMPerPlane%d", iPlane), TSF("sTGC Plane %d (hits / VMM); VMM; counts (hits)", iPlane+1), nVMMPerPlane, 0.5, nVMMPerPlane + 0.5 );
+            contents.hStripPerPlane[iPlane]         = new TH2D( TSF("hStripPerPlane%d", iPlane), TSF("sTGC Horizontal Strips, Plane %d (hits / Strip); x; y", iPlane+1), 140, -700, 700, 438, -700, 700 );
+            contents.vStripPerPlane[iPlane]         = new TH2D( TSF("vStripPerPlane%d", iPlane), TSF("sTGC Vertical Strips, Plane %d (hits / Strip); x; y", iPlane+1), 438, -700, 700, 140, -700, 700 );
+            contents.dStripPerPlane[iPlane]         = new TH2D( TSF("dStripPerPlane%d", iPlane), TSF("sTGC Diagonal Strips, Plane %d (hits / Strip); x; y", iPlane+1), 438, -700, 700, 438, -700, 700 );
 
-
-            contents.hStripPerPlane[iPlane]    = new TH2D( TSF("hStripPerPlane%d", iPlane), TSF("sTGC Horizontal Strips, Plane %d (hits / Strip); x; y", iPlane+1), 140, -700, 700, 438, -700, 700 );
-            contents.vStripPerPlane[iPlane]    = new TH2D( TSF("vStripPerPlane%d", iPlane), TSF("sTGC Vertical Strips, Plane %d (hits / Strip); x; y", iPlane+1), 438, -700, 700, 140, -700, 700 );
+            contents.hitsTbPerPlane[iPlane]        = new TH1D( TSF("hitsTbPerPlane%d", iPlane), TSF("sTGC Plane %d (Timing); Tb; counts (hits)", iPlane+1), 400, -400, 400 );
+            contents.chargePerPlane[iPlane]        = new TH1D( TSF("chargePerPlane%d", iPlane), TSF("sTGC Plane %d (Charge); ADC; counts (hits)", iPlane+1), maxADC/10.0, 0, maxADC );
 
 
             for ( u_char iQuad = 0; iQuad < nQuadPerPlane; iQuad ++ ){
@@ -98,19 +100,21 @@ void fttBuilder::initialize(int argc, char *argv[]) {
                 if ( iPlane == 0 ){
                     contents.hitsPerPlaneQuad->GetYaxis()->SetBinLabel( iQuadPerFtt+1, TSF( "%s", quadLabels[iQuad].c_str() ) );
                 }
-                // for ( u_char iFob = 0; iFob < nFobPerQuad; iFob ++ ){
-                //     int iFobPerFtt = iFob + ( iQuad * nFobPerQuad ) + ( iPlane * nFobPerPlane );
-                //     contents.adcChPerFob[ iFobPerFtt ] = new TH2D( TSF( "adcChPerFob%d",iFobPerFtt ), TSF("sTGC (Plane %d, Quadule %d, Fob %d); Channel; ADC;", iPlane+1, iQuad+1, iFob+1), nChPerFob, 0.5, nChPerFob + 0.5, maxADC, 0, maxADC );
-                // }
+                for ( u_char iFob = 0; iFob < nFobPerQuad; iFob ++ ){
+                    int iFobPerFtt = iFob + ( iQuad * nFobPerQuad ) + ( iPlane * nFobPerPlane );
+                    // contents.adcChPerFob[ iFobPerFtt ] = new TH2D( TSF( "adcChPerFob%d",iFobPerFtt ), TSF("sTGC (Plane %d, Quadule %d, Fob %d); Channel; ADC;", iPlane+1, iQuad+1, iFob+1), nChPerFob, 0.5, nChPerFob + 0.5, maxADC, 0, maxADC );
+                    contents.chargePerFob[iFobPerFtt] = new TH1D( TSF("chargePerFob%d", iFobPerFtt), TSF("sTGC Fob %d (Charge); ADC; counts (hits)", iFobPerFtt+1), maxADC/10.0, 0, maxADC );
+                    setLogy.push_back( TSF("chargePerFob%d", iFobPerFtt).Data() );
+                }
 
             }
         }
 
 
     ////////////////////////////////////////////////////////////////////////
-	// Add root histograms to Plots
-	int np = sizeof(contents) / sizeof(TH1 *);
-	JevpPlot *plots[np];
+    // Add root histograms to Plots
+    int np = sizeof(contents) / sizeof(TH1 *);
+    JevpPlot *plots[np];
 
 
     // Add all of the plots
@@ -140,14 +144,23 @@ void fttBuilder::initialize(int argc, char *argv[]) {
     // Set up the mapping for the VMM electronics
     ////////////////////////////////////////////////////////////////////////
     mHardwareMap = std::make_shared<VMMHardwareMap>();
-    mHardwareMap->loadMap( string(confdatadir)+"/ftt/vmm_map.dat" );
+    
 } // initialize
-	
+    
 void fttBuilder::startrun(daqReader *rdr) {
-	resetAllPlots();
+    resetAllPlots();
     // Set the "time" window for accepting data
     ((daq_stgc *)rdr->det("stgc"))->xing_min = -65000 ;
     ((daq_stgc *)rdr->det("stgc"))->xing_max = 65000 ;
+
+    // Draw plane outlines
+    for ( int iPlane = 0; iPlane < nPlane; iPlane++ ){
+        drawOutline( contents.hStripPerPlane[ iPlane ], VMMHardwareMap::StripOrientation::Horizontal );
+        drawOutline( contents.vStripPerPlane[ iPlane ], VMMHardwareMap::StripOrientation::Vertical );
+    }
+
+    // reload the map every run for fast updates
+    mHardwareMap->loadMap( string(confdatadir)+"/ftt/vmm_map.dat" );
 }
 
 void fttBuilder::stoprun(daqReader *rdr) {
@@ -215,10 +228,76 @@ void fttBuilder::drawStrip( TH2 * h2, int row, int strip, VMMHardwareMap::Quadra
         const int ix0 = ax->FindBin( x0 + strip * sPitch );
         const int ix1 = ax->FindBin( x0 + (strip) * sPitch );
         floodFill( h2, ix0, iy0, ix1, iy1 );
+    } else if ( VMMHardwareMap::StripOrientation::Diagonal == so ){
+        double l0 = VMMHardwareMap::stripPitch * 5;
+        double l = l0 + VMMHardwareMap::stripPitch * strip;
+        double x0 = l0 / sqrt(2);
+        double y0 = x0;
     }
+} // drawStrip
 
 
-}
+void fttBuilder::drawOutline( TH2 * h2, VMMHardwareMap::StripOrientation so ) {
+    
+    double val = 1e-6;
+    for ( int ix = 1; ix < h2->GetNbinsX() + 1; ix++ ){
+        for ( int iy = 1; iy < h2->GetNbinsY() + 1; iy++ ){
+            float x = h2->GetXaxis()->GetBinCenter( ix );
+            float y = h2->GetYaxis()->GetBinCenter( iy );
+
+
+            if ( so == VMMHardwareMap::StripOrientation::Horizontal ){
+                int hStrip = 1000;
+                int hRow = 100;
+                
+                hStrip = y / VMMHardwareMap::stripPitch;
+                if ( y > 0 )
+                    hRow = x / VMMHardwareMap::rowLength;
+                else if ( x > 0 )
+                    hRow = ( x - 60 ) / VMMHardwareMap::rowLength;
+                else if ( x < 0 )
+                    hRow = ( x + 60 ) / VMMHardwareMap::rowLength;
+                
+                if ( hRow == 0 && abs(hStrip) > 166 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(hRow) == 1 && abs(hStrip) > 152 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(hRow) == 2 && abs(hStrip) > 93 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(hRow) > 2 || abs(hStrip) > 166 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( y < 0 && x > -60 && x < 60 )
+                    h2->SetBinContent( ix, iy, val );
+            }
+
+            if ( so == VMMHardwareMap::StripOrientation::Vertical ){
+                int vStrip = 1000;
+                int vRow = 100;
+                
+                if ( y > 0 )
+                    vStrip = x / VMMHardwareMap::stripPitch;
+                else if( x > 0 )
+                    vStrip = (x-60) / VMMHardwareMap::stripPitch;
+                else if( x < 0 )
+                    vStrip = (x+60) / VMMHardwareMap::stripPitch;
+
+                vRow = y / VMMHardwareMap::rowLength;
+                
+                if ( vRow == 0 && abs(vStrip) > 166 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(vRow) == 1 && abs(vStrip) > 152 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(vRow) == 2 && abs(vStrip) > 93 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( abs(vRow) > 2 || abs(vStrip) > 166 )
+                    h2->SetBinContent( ix, iy, val );
+                if ( y < 0 && x > -60 && x < 60 )
+                    h2->SetBinContent( ix, iy, val );
+            }
+
+        }
+    }
+} // drawOutline
 
 void fttBuilder::processVMMHit( int iPlane, VMMHardwareMap::Quadrant quad, stgc_vmm_t rawVMM ){
 
@@ -253,11 +332,16 @@ void fttBuilder::processVMMHit( int iPlane, VMMHardwareMap::Quadrant quad, stgc_
     contents.hitsPerQuad->Fill( iQuadPerFtt+1 ); // quad index
     contents.hitsPerFob->Fill( iFobPerFtt+1 ); // Fob index
     contents.hitsPerVMM->Fill( iVMMPerFtt+1 ); // VMM index
+    contents.hitsPerTb->Fill( rawVMM.tb );
+    contents.hitsPerTb400->Fill( rawVMM.tb );
     contents.hitsPerPlaneQuad->Fill( thePlane, theQuad ); // 2D Quadule vs. Plane
     contents.hitsPerVMMPlane->Fill( iVMMPerPlane+1, iPlane + 1 );
 
     contents.hitsVMMPerPlane[ iPlane ]->Fill( iVMMPerPlane + 1 );
     contents.hitsFobQuadPerPlane[ iPlane ]->Fill( theFob, theQuad );
+    contents.hitsTbPerPlane[ iPlane ] ->Fill( rawVMM.tb );
+    contents.chargePerPlane[ iPlane ] ->Fill( rawVMM.adc );
+    contents.chargePerFob[iFobPerFtt] ->Fill( rawVMM.adc );
 
 
     contents.hitsVMMChPerPlaneQuad[ iQuadPerFtt % nQuad ]->Fill( iVMMPerQuad + 1, theCh );
@@ -277,20 +361,42 @@ void fttBuilder::processVMMHit( int iPlane, VMMHardwareMap::Quadrant quad, stgc_
     VMMHardwareMap::StripOrientation stripDir;
     mHardwareMap->get( /*rob=*/iQuadPerFtt+1, iFob+1, iVMM+1, iCh, iRow, iStrip, stripDir );
 
-    if ( false && (iRow == -1 || iStrip == -1) ){
-        printf( "\n\n------>START\n" );
-        printf( "ROB=%d, FOB=%d, VMM=%d, CH=%d", iQuadPerFtt+1, iFob+1, iVMM+1, iCh ); puts("");
-        printf( "Row=%d, Strip=%d, dir=%s\n", iRow, iStrip, dirLabels[(int)stripDir].c_str() );
-        printf( "<------STOP\n\n" );
+    if ( (iRow == -1 || iStrip == -1) ){
+        // printf( "\n\n------>START\n" );
+        // printf( "ROB=%d, FOB=%d, VMM=%d, CH=%d", iQuadPerFtt+1, iFob+1, iVMM+1, iCh ); puts("");
+        // printf( "Row=%d, Strip=%d, dir=%s\n", iRow, iStrip, dirLabels[(int)stripDir].c_str() );
+        // printf( "<------STOP\n\n" );
+    } else {
+        if ( VMMHardwareMap::StripOrientation::Horizontal == stripDir ){
+            drawStrip(contents.hStripPerPlane[ iPlane ], iRow, iStrip, quad, stripDir );
+        }
+        else if ( VMMHardwareMap::StripOrientation::Vertical == stripDir ){
+            drawStrip(contents.vStripPerPlane[ iPlane ], iRow, iStrip, quad, stripDir );
+        }
+        else if ( VMMHardwareMap::StripOrientation::Diagonal == stripDir ){
+            drawStrip(contents.dStripPerPlane[ iPlane ], iRow, iStrip, quad, stripDir );
+        }
     }
 
-    if ( VMMHardwareMap::StripOrientation::Horizontal == stripDir ){
-        drawStrip(contents.hStripPerPlane[ iPlane ], iRow, iStrip, quad, stripDir );
-    }
-    if ( VMMHardwareMap::StripOrientation::Vertical == stripDir ){
-        drawStrip(contents.vStripPerPlane[ iPlane ], iRow, iStrip, quad, stripDir );
-    }
+    // outline detector
+    // drawStrip(contents.hStripPerPlane[ 0 ], 0, 167, VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    // drawStrip(contents.hStripPerPlane[ 0 ], 1, 153, VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    // drawStrip(contents.hStripPerPlane[ 0 ], 2, 94,  VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    // for ( int i = 0; i < 300; i++ ){
+    //     drawStrip(contents.hStripPerPlane[ 0 ], 3, i,  VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    //     if ( i > 93 )
+    //         drawStrip(contents.hStripPerPlane[ 0 ], 2, i,  VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    //     if ( i > 152 )
+    //         drawStrip(contents.hStripPerPlane[ 0 ], 1, i,  VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    //     if ( i > 166 )
+    //         drawStrip(contents.hStripPerPlane[ 0 ], 0, i,  VMMHardwareMap::Quadrant::A, VMMHardwareMap::StripOrientation::Horizontal );
+    // }
 
+    // drawStrip(contents.hStripPerPlane[ 0 ], 0, 167, VMMHardwareMap::Quadrant::B, VMMHardwareMap::StripOrientation::Horizontal );
+    // drawStrip(contents.hStripPerPlane[ 0 ], 1, 153, VMMHardwareMap::Quadrant::B, VMMHardwareMap::StripOrientation::Horizontal );
+    // drawStrip(contents.hStripPerPlane[ 0 ], 2, 94,  VMMHardwareMap::Quadrant::B, VMMHardwareMap::StripOrientation::Horizontal );
+
+    // drawOutline( contents.hStripPerPlane[ 0 ] );
 }
 
 void fttBuilder::processVMM(daqReader *rdr) {
@@ -321,12 +427,12 @@ void fttBuilder::processVMM(daqReader *rdr) {
 } // processVMM
 
 void fttBuilder::event(daqReader *rdr) {
-	LOG(DBG, "-------> START EVENT, #%d",rdr->seq);
+    LOG(DBG, "-------> START EVENT, #%d",rdr->seq);
     processVMM(rdr);
 }
 
 void fttBuilder::main(int argc, char *argv[])
 {
-	fttBuilder me;  
-	me.Main(argc, argv);
+    fttBuilder me;  
+    me.Main(argc, argv);
 }

--- a/OnlTools/Jevp/StJevpBuilders/fttBuilder.h
+++ b/OnlTools/Jevp/StJevpBuilders/fttBuilder.h
@@ -16,6 +16,7 @@
 
 #ifndef __CINT__
 #include <assert.h>
+#include <fstream>
 /*********************************************************/
 // class for mapping the VMM electronics
 // 
@@ -61,11 +62,13 @@ public:
     }
 
     void loadMap( std::string fn ){
-        ifstream inf;
+        std::ifstream inf;
         inf.open( fn.c_str() );
 
+        mMap.clear();
         if ( !inf ) return;
 
+        mMap.clear();
         string hs0, hs1, hs2, hs3, hs4;
         // HEADER:
         // Row_num    FEB_num    VMM_num    VMM_ch         strip_ch
@@ -184,17 +187,9 @@ class VMMHardwareMap;
 #endif
 
 
+// DAQ RTS format for sTGC data
 class stgc_vmm_t;
 
-// This is the one PlotSet that is guarenteed to always exist
-// It's main purpose is to provide the run information 
-// To the server...
-//
-// It has no plots (currently)
-//
-
-// class VMMHardwareMap;
-// enum class Quadrant: int;
 
 class fttBuilder : public JevpBuilder {
  public:
@@ -233,7 +228,10 @@ class fttBuilder : public JevpBuilder {
   static const size_t nCh          = nChPerPlane * nPlane; // 6144 * 4 = 24576 Ch per Plane
   
   static const size_t maxADC       = 1024 + 1; // 10 bits;
-  static const size_t maxBCID      = 65536 + 1; // 16 bits;
+  static const size_t maxBCID      = 4096 + 1; // 12 bits;
+  static const int minTb        = -32768 - 1000; // get the under and overflow
+  static const int maxTb        = 32768 + 1000;
+
   static const std::string quadLabels[4];
   static const std::string dirLabels[4];
 
@@ -246,14 +244,17 @@ class fttBuilder : public JevpBuilder {
         TH1 *hitsPerQuad; // all disks
         TH1 *hitsPerFob; // all disks
         TH1 *hitsPerVMM; // all Quadrants, all Planes
+        TH1 *hitsPerTb;
+        TH1 *hitsPerTb400;
         // TH1 *SEC0;
         TH2 *hitsPerPlaneQuad; 
         TH2 *hitsPerVMMPlane; 
         // TH2 *SECRDO0; 
         TH2 *hitsFobQuadPerPlane[nPlane];
         TH1 *hitsVMMPerPlane[nPlane];
+        TH1 *hitsTbPerPlane[nPlane];
+        TH1 *chargePerPlane[nPlane];
         TH2 *hitsVMMChPerPlaneQuad[nQuad];
-
         TH2 *adcVMMChPerPlaneQuad[nQuad];
         TH2 *adcVMM;
         TH2 *bcidVMM;
@@ -261,6 +262,8 @@ class fttBuilder : public JevpBuilder {
         TH2 *hStripPerPlane[nPlane];
         TH2 *vStripPerPlane[nPlane];
         TH2 *dStripPerPlane[nPlane];
+
+        TH1 *chargePerFob[nFob];
         
         TH1 *nStripsFired;
     };
@@ -290,15 +293,13 @@ class fttBuilder : public JevpBuilder {
         }
     }
   }
-  
-
-  
-
 
   static void main(int argc, char *argv[]);
 
 #ifndef __CINT__
-  void drawStrip( TH2 * h2, int row, int strip, VMMHardwareMap::Quadrant q, VMMHardwareMap::StripOrientation so );
+    void drawLine( TH2 * h2, int dx, int dy );
+    void drawOutline( TH2 * h2, VMMHardwareMap::StripOrientation so );
+    void drawStrip( TH2 * h2, int row, int strip, VMMHardwareMap::Quadrant q, VMMHardwareMap::StripOrientation so );
     void processVMMHit( int iPlane, VMMHardwareMap::Quadrant iQuad, stgc_vmm_t rawVMM);
     shared_ptr<VMMHardwareMap> mHardwareMap;
 #endif


### PR DESCRIPTION
Update sTGC plots to add timing and charge. Update layout as follows:

remove Plane 1, 2, 3, 4 instead group differently so shift crew can see the "whole" detector on each page:

Critical 1
- hStripPerPlane0
- hStripPerPlane1
- hStripPerPlane2
- hStripPerPlane3
Critical 2
- vStripPerPlane0
- vStripPerPlane1
- vStripPerPlane2
- vStripPerPlane3
Critical 3
- dStripPerPlane0 (these are booked now, but still empty)
- dStripPerPlane1
- dStripPerPlane2
- dStripPerPlane3

Then add the following new plots:

Timing 1
- hitsPerTb
- hitsPerTb400
Timing 2
- hitsTbPerPlane0
- hitsTbPerPlane1
- hitsTbPerPlane2
- hitsTbPerPlane3
Charge Plane 1
- chargePerPlane0
- chargePerFob0 - chargePerFob23
Charge Plane 2
- chargePerPlane1
- chargePerFob24
- chargePerFob47
Charge Plane 3
- chargePerPlane2
- chargePerFob48
- chargePerFob71
Charge Plane 4
- chargePerPlane3
- chargePerFob72
- chargePerFob95

