### PR TITLE
Add BUILD_CMD arg to Dockerfile

### DIFF
--- a/docker/Dockerfile.root5
+++ b/docker/Dockerfile.root5
@@ -100,6 +100,8 @@ RUN ln -s $MYSQL/include /usr/include/mysql
 
 FROM base-stage AS build-stage
 
+ARG BUILD_CMD="cons"
+
 COPY . /star-sw
 
 # XXX TEMP XXX: Don't force mysql static libraries to be linked into root4star
@@ -122,7 +124,8 @@ diff --git a/asps/rexe/Conscript b/asps/rexe/Conscript \n\
 
 RUN source /etc/profile \
  && cd /star-sw \
- && cons \
+ && install -m 755 <(echo "${BUILD_CMD}") build_cmd.sh \
+ && ./build_cmd.sh \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 
 RUN install /star-sw/StRoot/macros/.rootrc .

--- a/docker/Dockerfile.root5
+++ b/docker/Dockerfile.root5
@@ -124,8 +124,7 @@ diff --git a/asps/rexe/Conscript b/asps/rexe/Conscript \n\
 
 RUN source /etc/profile \
  && cd /star-sw \
- && install -m 755 <(echo "${BUILD_CMD}") build_cmd.sh \
- && ./build_cmd.sh \
+ && echo "${BUILD_CMD}" | bash -xe \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 
 RUN install /star-sw/StRoot/macros/.rootrc .

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -101,6 +101,8 @@ RUN ln -s $MYSQL/include /usr/include/mysql
 
 FROM base-stage AS build-stage
 
+ARG BUILD_CMD="cons"
+
 COPY . /star-sw
 
 # XXX TEMP XXX: Don't force mysql static libraries to be linked into root4star
@@ -125,7 +127,8 @@ RUN source /etc/profile \
  # Override default Vc version
  && export Vc_DIR=/opt/software/linux-scientific7-x86_64/gcc-4.8.5/vc_-0.7.4-gqbhzu2x5u2dbe5tafxnl36xj5qbwov4 \
  && cd /star-sw \
- && cons \
+ && install -m 755 <(echo "${BUILD_CMD}") build_cmd.sh \
+ && ./build_cmd.sh \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 
 RUN install /star-sw/StRoot/macros/.rootrc .

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -127,8 +127,7 @@ RUN source /etc/profile \
  # Override default Vc version
  && export Vc_DIR=/opt/software/linux-scientific7-x86_64/gcc-4.8.5/vc_-0.7.4-gqbhzu2x5u2dbe5tafxnl36xj5qbwov4 \
  && cd /star-sw \
- && install -m 755 <(echo "${BUILD_CMD}") build_cmd.sh \
- && ./build_cmd.sh \
+ && echo "${BUILD_CMD}" | bash -xe \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 
 RUN install /star-sw/StRoot/macros/.rootrc .


### PR DESCRIPTION
The users may optionally specify their own build command when building containers.
This may be used to build older releases where some packages need to be excluded from the build, e.g.:

```
docker build --build-arg BUILD_CMD="cons %OnlTools" ...
```

or when a two-stage build is required, e.g.:

```
docker build --build-arg BUILD_CMD="cons +StarVMC/Geometry && cons %ShadowMaker" ...
```