### PR TITLE
StRoot/Stv*: replace sys/types.h with stdint.h

### DIFF
--- a/StRoot/Stv/Factory/FactoryT.h
+++ b/StRoot/Stv/Factory/FactoryT.h
@@ -37,17 +37,17 @@ public:
   static  int Alive(void *obj);
 
   void setFastDelete()	{fFastDel=1;}
-  void setMaxIncrementCount(uint maxCount)	{fMaxCount=maxCount;}
-  uint getMaxIncrementCount() const		{return fMaxCount;  }
-  uint getCurrentSize()  const 			{return fCurCount;  }
-  uint getCurrentCount() const 			{return fCurCount;  }
+  void setMaxIncrementCount(unsigned int maxCount)	{fMaxCount=maxCount;}
+  unsigned int getMaxIncrementCount() const		{return fMaxCount;  }
+  unsigned int getCurrentSize()  const 			{return fCurCount;  }
+  unsigned int getCurrentCount() const 			{return fCurCount;  }
 protected:
-  uint fMaxCount;
-  uint fCurCount;
-  uint fUseCount;
-  uint fFastDel;
-  uint fInstCount;
-  uint fFreeCount;
+  unsigned int fMaxCount;
+  unsigned int fCurCount;
+  unsigned int fUseCount;
+  unsigned int fFastDel;
+  unsigned int fInstCount;
+  unsigned int fFreeCount;
 static double fgTotal;  
 };
 

--- a/StRoot/Stv/Factory/StvFactory.h
+++ b/StRoot/Stv/Factory/StvFactory.h
@@ -33,7 +33,7 @@ public:
 enum {kSize=100};
      StvBlock(StvBlock **bTop,StvHolder<Object> **hTop,char *buf);
 void reset(StvBlock **bTop,StvHolder<Object> **hTop);
-uint getSize() const {return kSize;}
+unsigned int getSize() const {return kSize;}
 
 StvBlock *fNext;
 char     *fBuff;
@@ -119,7 +119,7 @@ Abstract *StvFactory<Concrete,Abstract>::getInstance()
             this->fCurCount < this->fMaxCount);
 
     if (this->fFastDel)    {
-       uint   nBuf = sizeof(StvBlock<Concrete>) + FENCE;
+       unsigned int   nBuf = sizeof(StvBlock<Concrete>) + FENCE;
        char *cBuf = new char[nBuf];
        cBuf[nBuf-1]=46;
        new((StvBlock<Concrete>*)cBuf) StvBlock<Concrete>(&fBTop,&fHTop,cBuf);
@@ -144,7 +144,7 @@ Abstract *StvFactory<Concrete,Abstract>::getInstance()
 template <class Concrete, class Abstract>
 void StvFactory<Concrete,Abstract>::free(Abstract *obj)
 {
-  static const uint shift = (char*)(&(((StvHolder<Concrete>*)1)->fObj))-(char*)1;
+  static const unsigned int shift = (char*)(&(((StvHolder<Concrete>*)1)->fObj))-(char*)1;
   obj->unset();
   StvHolder<Concrete>* h = (StvHolder<Concrete>*)((char*)obj-shift);
   assert(h->fFact == this); 

--- a/StRoot/StvMaker/StvHitLoader.cxx
+++ b/StRoot/StvMaker/StvHitLoader.cxx
@@ -226,7 +226,7 @@ static int knt=0;knt++;
        if (tk->GetHA(x)<1./1000) seed = 0;
    } }
 //VP   if (mStvHit->IsCombo()) seed = 0;
-   hard *= (uint)kMaxDetectorId; hard+=(uint)did;
+   hard *= (unsigned int)kMaxDetectorId; hard+=(unsigned int)did;
    
    const StHitPlane *hp = tgh->AddHit(mStvHit,mDetId,xyz,hard,seed);
    sure =  tgh->IsGoodHit();


### PR DESCRIPTION
ROOT5 doesn't always work with sys/types.h, types from stdint are the ISO C standard