### PR TITLE
starsim: make seed overflow into a fatal error

### DIFF
--- a/asps/Simulation/starsim/atutil/aranlux.F
+++ b/asps/Simulation/starsim/atutil/aranlux.F
@@ -256,8 +256,11 @@ C                    Entry to initialize from one or three integers
 #endif
       ENDIF
       IN24 = 0
-      IF (INS .LT. 0)  WRITE (6,'(A)')
+      IF (INS .LT. 0)  THEN
+        WRITE (6,'(A)')
      +   ' Illegal initialization by RLUXGO, negative input seed'
+        CALL ABORT
+      ENDIF
       IF (INS .GT. 0)  THEN
         JSEED = INS
 #ifndef SILENT_RANLUX


### PR DESCRIPTION
The value of bigger than 0x7FFFFFFF will overflow ISEQ and make it
wrap around into a negative values. The current behavior is to print a
warning message and reset the seed to a default value. Because of that
an unsuspecting user can easily initialize a fraction of their
simulation production with the same seed.