### PR TITLE
Adding option to read from MuDst in StFcsRawHitMaker

### DIFF
--- a/StRoot/StFcsFastSimulatorMaker/macro/runMudst.C
+++ b/StRoot/StFcsFastSimulatorMaker/macro/runMudst.C
@@ -1,0 +1,64 @@
+void runMudst(char* file="st_cosmic_adc_22326042_raw_0000005.MuDst.root", 
+	      int ifile=-1, Int_t nevt=-1, char* outdir=".", int readMuDst=1){  
+    gROOT->Macro("Load.C");
+    gROOT->Macro("$STAR/StRoot/StMuDSTMaker/COMMON/macros/loadSharedLibraries.C");
+    gSystem->Load("StEventMaker");
+    gSystem->Load("StFcsDbMaker");
+    gSystem->Load("StFcsRawHitMaker");
+    gSystem->Load("StFcsWaveformFitMaker");
+    gSystem->Load("StFcsClusterMaker");
+    gSystem->Load("libMinuit");
+    gSystem->Load("StFcsPointMaker");
+
+    StChain* chain = new StChain("StChain"); chain->SetDEBUG(0);
+    StMuDstMaker* muDstMaker = new StMuDstMaker(0, 0, "", file,".", 1000, "MuDst");
+    int n=muDstMaker->tree()->GetEntries();
+    printf("Found %d entries in Mudst\n",n);
+    int start=0, stop=n;
+    if(ifile>=0){
+	int start=ifile*nevt;
+	int stop=(ifile+1)*nevt-1;
+	if(n<start) {printf(" No event left. Exiting\n"); return;}
+	if(n<stop)  {printf(" Overwriting end event# stop=%d\n",n); stop=n;}
+    }else if(nevt>=0 && nevt<n){
+	stop=nevt;
+    }else if(nevt==-2){
+	stop=2000000000; 
+    }
+    printf("Doing Event=%d to %d\n",start,stop);
+    
+    St_db_Maker* dbMk = new St_db_Maker("db","MySQL:StarDb","$STAR/StarDb"); 
+    if(dbMk){
+	dbMk->SetAttr("blacklist", "tpc");
+	dbMk->SetAttr("blacklist", "svt");
+	dbMk->SetAttr("blacklist", "ssd");
+	dbMk->SetAttr("blacklist", "ist");
+	dbMk->SetAttr("blacklist", "pxl");
+	dbMk->SetAttr("blacklist", "pp2pp");
+	dbMk->SetAttr("blacklist", "ftpc");
+	dbMk->SetAttr("blacklist", "emc");
+	dbMk->SetAttr("blacklist", "eemc");
+	dbMk->SetAttr("blacklist", "mtd");
+	dbMk->SetAttr("blacklist", "pmd");
+	dbMk->SetAttr("blacklist", "tof");
+	dbMk->SetAttr("blacklist", "etof");
+	dbMk->SetAttr("blacklist", "rhicf");
+    }
+    
+    StFcsDbMaker *fcsDbMkr= new StFcsDbMaker();
+    StFcsDb* fcsDb = (StFcsDb*) chain->GetDataSet("fcsDb");
+    StEventMaker* eventMk = new StEventMaker();
+    StFcsRawHitMaker* hit = new StFcsRawHitMaker();  
+    hit->setReadMuDst(readMuDst);
+    StFcsWaveformFitMaker *wff= new StFcsWaveformFitMaker();
+    StFcsClusterMaker *clu= new StFcsClusterMaker();
+    StFcsPointMaker *poi= new StFcsPointMaker();
+    wff->SetDebug();
+    clu->SetDebug();
+    poi->SetDebug();
+
+    chain->Init();
+    chain->EventLoop(start,stop);
+    chain->Finish();
+    delete chain;
+}

--- a/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.cxx
+++ b/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.cxx
@@ -11,6 +11,8 @@
 #include "StRoot/StEvent/StFcsCollection.h"
 #include "StRoot/StEvent/StFcsHit.h"
 #include "StRoot/StFcsDbMaker/StFcsDb.h"
+#include "StMuDSTMaker/COMMON/StMuTypes.hh"
+#include "StMuDSTMaker/COMMON/StMuFcsUtil.h"
 
 StFcsRawHitMaker::StFcsRawHitMaker( const char* name) :
     StRTSBaseMaker("fcs",name){
@@ -37,6 +39,9 @@ int StFcsRawHitMaker::Make() {
       AddData(mEvent);
       LOG_INFO <<"Added StEvent"<<endm;
     }
+
+    if(mReadMuDst>0) return readMuDst();
+
     mFcsCollectionPtr=mEvent->fcsCollection();
     if(!mFcsCollectionPtr) {
       mFcsCollectionPtr=new StFcsCollection();
@@ -46,6 +51,7 @@ int StFcsRawHitMaker::Make() {
       mFcsCollectionPtr=mEvent->fcsCollection();
       LOG_DEBUG <<"Found StFcsCollection"<<endm;
     }
+
 
     StRtsTable* dd=0;
     int nData=0, nValidData=0;
@@ -90,6 +96,16 @@ int StFcsRawHitMaker::Make() {
     if(nData>0 && GetDebug()) mFcsCollectionPtr->print(3);
     return kStOK;
 };
+
+int StFcsRawHitMaker::readMuDst() {
+    StMuDst* mudst = (StMuDst*)GetInputDS("MuDst");
+    if(!mudst){LOG_ERROR<<"StFcsRawHitMaker::readMuDst() found no MuDst"<<endm; return kStErr;}
+    StMuFcsCollection* mufcsColl= mudst->muFcsCollection();
+    if(!mufcsColl){LOG_ERROR<<"StFcsRawHitMaker::readMuDst found no MuFcsCollection"<<endm; return kStErr;}
+    StMuFcsUtil util;    
+    mFcsCollectionPtr = util.getFcs(mufcsColl);
+    mEvent->setFcsCollection(mFcsCollectionPtr);
+}
 
 void StFcsRawHitMaker::Clear( Option_t *opts ){};
 

--- a/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.h
+++ b/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.h
@@ -25,7 +25,8 @@ public:
 
     void setReadMode(int v) {mReadMode=v;}
     void setDebug(int v=1) {SetDebug(v);}  //!backward compatubility     
-    
+    void setReadMuDst(int v=1) {mReadMuDst=v;} //!reading Mudst/StMuFcsHit into StEvent/StFcsHit
+
     // Get CVS
     virtual const char *GetCVS() const;
     
@@ -35,6 +36,9 @@ private:
     unsigned int mRun=0;
     StFcsDb* mFcsDb=0;
     unsigned int mReadMode=1;
+    unsigned int mReadMuDst=0; 
+
+    int readMuDst();
 
     ClassDef(StFcsRawHitMaker,1);
 };

--- a/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.h
+++ b/StRoot/StFcsRawHitMaker/StFcsRawHitMaker.h
@@ -35,8 +35,8 @@ private:
     StFcsCollection *mFcsCollectionPtr;
     unsigned int mRun=0;
     StFcsDb* mFcsDb=0;
-    unsigned int mReadMode=1;
-    unsigned int mReadMuDst=0; 
+    int mReadMode=1;
+    int mReadMuDst=0; 
 
     int readMuDst();
 


### PR DESCRIPTION
Adding option to read from MuDst in StFcsRawHitMaker, and example macro to read from MuDst, re-create StFcsHits in StEvent on memory, and re-run FCS reconstruction makers.