### PR TITLE
StFmsBsQaMaker: fix invaild ClassDef

### DIFF
--- a/StRoot/StSpinPool/StFmsBsQaMaker/StFmsBsQaMaker.h
+++ b/StRoot/StSpinPool/StFmsBsQaMaker/StFmsBsQaMaker.h
@@ -43,7 +43,7 @@ class StFmsBsQaMaker : public StMaker
 		TH2F* mH2_bs_data[nDet];
 		TH2F* mH2_chMap[nDet];
 
-		ClassDef(StFmsBsQaMaker, 1.0);
+		ClassDef(StFmsBsQaMaker, 0);
 };
 
 #endif


### PR DESCRIPTION
With ROOT6:

    error: static assertion failed: ClassDef(Inline) macro: the specified class version number is not an integer.