### PR TITLE
StMiniMcMaker: use const reference to TString in setters

### DIFF
--- a/StRoot/StMiniMcMaker/StMiniMcMaker.h
+++ b/StRoot/StMiniMcMaker/StMiniMcMaker.h
@@ -262,8 +262,8 @@ class StMiniMcMaker : public StMaker{
   void  setOutDir(const char* dir= "./") 	{ mOutDir = dir; }  
   void  setPtCut(Float_t minPt=0, Float_t maxPt=9999) 
     						{ mMinPt=minPt; mMaxPt=maxPt; }
-  void  setFileName(TString& val)      		{ mInFileName = val; }
-  void  setFilePrefix(TString& val)      	{ mInFilePrefix = val; }
+  void  setFileName(const TString& val)      		{ mInFileName = val; }
+  void  setFilePrefix(const TString& val)      	{ mInFilePrefix = val; }
 
  private:
   //static const Float_t mSharedHitsCut = .5;


### PR DESCRIPTION
    QA :INFO  - ProcessLine ((StMiniMcMaker *) 0x101ebfc0)->setFileName("rcf12002_1_100evts.root");
    input_line_617:2:46: error: non-const lvalue reference to type 'TString' cannot bind to a value of unrelated type 'const char [24]'
     ((StMiniMcMaker *) 0x101ebfc0)->setFileName("rcf12002_1_100evts.root");
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
    .sl73_x8664_gcc485/obj/StRoot/StMiniMcMaker/StMiniMcMaker.h:265:30: note: passing argument to parameter 'val' here
      void  setFileName(TString& val)               { mInFileName = val; }
                                 ^