### PR TITLE
mgr/Conscript-standard: fix build of StarVMC/StarGeometry with ROOT6 that doesn't ship ttables

### DIFF
--- a/mgr/Conscript-standard
+++ b/mgr/Conscript-standard
@@ -314,8 +314,11 @@ if ( $pkg !~ /^sim$/ && $pkg !~ /^gen$/ ) {
 	#print "\tAfter  ".($#src)." ".($#inc)."\n";
 
         if ($Dir =~ m#StarVMC/StarGeometry#) {
+            my($cpppath) = $env->_subst($env->{CPPPATH});
+            my($cscanner) = find scan::cpp($env->{_cwd}, $cpppath);
+            $env->{_IFLAGS} = "%(" . $cscanner->iflags($env) . "%)";
             Command $env ["$OBJ/StarVMC/StarGeometry/StarGeo_Cint.cxx", "$OBJ/StarVMC/StarGeometry/StarGeo_Cint.h"],
-                         ("$OBJ/StarVMC/StarGeometry/StarGeo.h", "#StarVMC/Geometry/StarGeoLinkDef.h"), qq(rootcint -f %> -c %1 %2);
+                         ("$OBJ/StarVMC/StarGeometry/StarGeo.h", "#StarVMC/Geometry/StarGeoLinkDef.h"), qq(rootcint -f %> -c %_IFLAGS %1 %2);
             push(@srcL, "$OBJ/StarVMC/StarGeometry/StarGeo_Cint.cxx");
         }
 


### PR DESCRIPTION
```
rootcint -f .sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo_Cint.cxx -c .sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo.h StarVMC/Geomet
ry/StarGeoLinkDef.h
In file included from input_line_9:3:
./.sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo.h:949:10: fatal error: 'TDataSet.h' file not found
#include "TDataSet.h"
         ^~~~~~~~~~~~
Error: rootcint: compilation failure (.sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo_Cint3c991d560d_dictUmbrella.h)
cons: *** [.sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo_Cint.cxx] Error 1
cons: errors constructing .sl73_x8664_gcc485/obj/StarVMC/StarGeometry/StarGeo_Cint.h
```