### PR TITLE
docker: install the same version of pyparsing as on SDCC

### DIFF
--- a/docker/Dockerfile.root5
+++ b/docker/Dockerfile.root5
@@ -69,7 +69,7 @@ RUN yum update -q -y \
  && yum clean all
 
 # Install extra python modules used by the STAR software
-RUN pip install pyparsing
+RUN pip install pyparsing==2.2.0
 
 ENV MODULEPATH=/opt/linux-scientific7-x86_64
 

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -69,7 +69,7 @@ RUN yum update -q -y \
  && yum clean all
 
 # Install extra python modules used by the STAR software
-RUN pip install pyparsing
+RUN pip install pyparsing==2.2.0
 
 ENV MODULEPATH=/opt/linux-scientific7-x86_64
 


### PR DESCRIPTION
This is not urgent, but our dockerfiles seem to be broken right now as they install an incompatible version (3.x) of pyparsing needed for mgr/agmlParser.py