### PR TITLE
Hot fix for FastOffline

### DIFF
--- a/StRoot/StFcsDbMaker/StFcsDbMaker.cxx
+++ b/StRoot/StFcsDbMaker/StFcsDbMaker.cxx
@@ -139,7 +139,7 @@ StFcsDbMaker::StFcsDbMaker(const char *name) : StMaker(name){
 }; 
 
 StFcsDbMaker::~StFcsDbMaker() {
-  delete mFcsDb;
+  //delete mFcsDb;   //already deleted by chain because AddData in constructor
 }
 
 int StFcsDbMaker::Init(){

--- a/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.h
+++ b/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.h
@@ -181,7 +181,7 @@ public:
 
     char *mMeasureTime=0;                //! output file for measuring fitting time
 
-    int mEnergySelect=0;                 //! 0=MC (straight from dE), >0 see above
+    int mEnergySelect=10;                //! 0=MC (straight from dE), >0 see above
     int mCenterTB=50;                    //! center timebin for triggered crossing
     int mMinTB=0;                        //! center timebin for triggered crossing
     int mMaxTB=512;                      //! center timebin for triggered crossing

--- a/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
+++ b/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
@@ -228,15 +228,18 @@ Int_t StFcsPi0FinderForEcal::Make() {
       mNEvents++;
       cout << "current event:" << mNEvents << endl;
       if (mFilter == 1 && mFcsColl->numberOfHits(0) + mFcsColl->numberOfHits(1) + mFcsColl->numberOfHits(2) + mFcsColl->numberOfHits(3) == 0) return kStOK;
-
-      /*
-      //TOF mult
-      StTriggerData* trg = event->triggerData();
-      int tofMult = trg->tofMultiplicity();
-      //                cout<<"TOF mult="<<tofMult<<endl;
-      if (tofMult > 20) return kStOK;
-      */
+      
+      //TOF mult cut
       int tofMult = 0;
+      const StTriggerData* trgdata = event->triggerData();
+      if(!trgdata && StMuDst::event()) trgdata = StMuDst::event()->triggerData();
+      if(trgdata){
+	  tofMult = trgdata->tofMultiplicity();
+	  LOG_DEBUG<<"TOF mult="<<tofMult<<endm;
+	  if (tofMult > 100) return kStOK;
+      }else{
+	  LOG_WARN << "No TriggerData found in StEvent nor Mudst. No TOFMult cut"<<endm;
+      }
 
       mNAccepted++;
       int total_nc = 0;

--- a/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
+++ b/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
@@ -231,18 +231,6 @@ Int_t StFcsPi0FinderForEcal::Make() {
       if (mFilter == 1 && mFcsColl->numberOfHits(0) + mFcsColl->numberOfHits(1) + mFcsColl->numberOfHits(2) + mFcsColl->numberOfHits(3) == 0) return kStOK;
 
       /*
-      //trigger ID
-      int trigID = -1;
-      int HaveTrig = 0;
-      const StTriggerIdCollection* trig = event->triggerIdCollection();
-      const StTriggerId* trigIdList = trig->nominal();
-      for (int trigi = 0; trigi < 10; trigi++) {
-         trigID = trigIdList->triggerId(trigi);
-         //                        cout<<"trig ID:"<<trigID<<endl;
-         if (trigID == 860009 || trigID == 860000) HaveTrig = 1;
-      }
-      if (HaveTrig == 0) return kStOK;
-
       //TOF mult
       StTriggerData* trg = event->triggerData();
       int tofMult = trg->tofMultiplicity();

--- a/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
+++ b/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
@@ -230,6 +230,7 @@ Int_t StFcsPi0FinderForEcal::Make() {
       cout << "current event:" << mNEvents << endl;
       if (mFilter == 1 && mFcsColl->numberOfHits(0) + mFcsColl->numberOfHits(1) + mFcsColl->numberOfHits(2) + mFcsColl->numberOfHits(3) == 0) return kStOK;
 
+      /*
       //trigger ID
       int trigID = -1;
       int HaveTrig = 0;
@@ -240,7 +241,6 @@ Int_t StFcsPi0FinderForEcal::Make() {
          //                        cout<<"trig ID:"<<trigID<<endl;
          if (trigID == 860009 || trigID == 860000) HaveTrig = 1;
       }
-
       if (HaveTrig == 0) return kStOK;
 
       //TOF mult
@@ -248,6 +248,8 @@ Int_t StFcsPi0FinderForEcal::Make() {
       int tofMult = trg->tofMultiplicity();
       //                cout<<"TOF mult="<<tofMult<<endl;
       if (tofMult > 20) return kStOK;
+      */
+      int tofMult = 0;
 
       mNAccepted++;
       int total_nc = 0;

--- a/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
+++ b/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
@@ -46,12 +46,11 @@ StFcsPi0FinderForEcal::~StFcsPi0FinderForEcal() {}
 //-----------------------
 Int_t StFcsPi0FinderForEcal::Init() {
    mFcsDb = static_cast<StFcsDb*>(GetDataSet("fcsDb"));
-   mFcsDb->setDbAccess(0);
    if (!mFcsDb) {
       LOG_ERROR << "StFcsEventDisplay::InitRun Failed to get StFcsDbMaker" << endm;
       return kStFatal;
    }
-
+   
    h1_num_entries = new TH1F("h1_num_entries", "# of entries", 10, 0, 10);
    h1_inv_mass_cluster = new TH1F("h1_inv_mass_cluster", "invariant mass plot for FCS ECal cluster", bins, m_low, m_up);
    h1_inv_mass_cluster->SetXTitle("invariant mass [GeV]");
@@ -160,7 +159,7 @@ Int_t StFcsPi0FinderForEcal::Init() {
 Int_t StFcsPi0FinderForEcal::Finish() {
    if (filename.length() == 0) return kStOk;
    const char* fn = filename.c_str();
-   TFile* MyFile = new TFile(fn, "RECREATE");
+   TFile MyFile(fn, "RECREATE");
    h1_num_entries->Write();
    h1_inv_mass_cluster->Write();
    h1_Zgg_cluster->Write();
@@ -207,7 +206,7 @@ Int_t StFcsPi0FinderForEcal::Finish() {
    h2_cluster_dgg_vs_E1pE2->Write();
    h2_point_dgg_vs_E1pE2->Write();
 
-   MyFile->Close();
+   MyFile.Close();
    return kStOK;
 }
 


### PR DESCRIPTION
StFcsWaveformFitMaker default value for mEnergySelect to 10 (for data, default was 0 for MC before)
StFcsDbMaker remove delete mFcsDb from Finish, since it is double delete because of AddData in constructor
StSpinPool/StFcsPi0FinderForEcal remove TriggerId selection and ToFMult selection for FastOffline (not needed).