### PR TITLE
StRoot/StTof*: fix inconsistent validAdc/validTdc declarations

### DIFF
--- a/StRoot/StTofPool/StTofpNtupleMaker/StTofpNtupleMaker.h
+++ b/StRoot/StTofPool/StTofpNtupleMaker/StTofpNtupleMaker.h
@@ -79,8 +79,8 @@ private:
   Bool_t mYear4; //! STAR year4: TOFp+pVPD+TOFr'
   Bool_t mOuterTrackGeometry; //! select outer track geometry (true)
 
-  Bool_t validAdc(float const);
-  Bool_t validTdc(float const);
+  Bool_t validAdc(float);
+  Bool_t validTdc(float);
 
   // various cut-offs and ranges
   Float_t mMinValidTdc; //!
@@ -116,7 +116,7 @@ inline void StTofpNtupleMaker::setOuterTrackGeometry(){mOuterTrackGeometry=true;
 inline void StTofpNtupleMaker::setStandardTrackGeometry(){mOuterTrackGeometry=false;}
 inline void StTofpNtupleMaker::SetNtupleFileName(Char_t* filename){mTupleFileName=filename;}
 
-inline Bool_t StTofpNtupleMaker::validAdc(const float adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
-inline Bool_t StTofpNtupleMaker::validTdc(const float tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
+inline Bool_t StTofpNtupleMaker::validAdc(float adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
+inline Bool_t StTofpNtupleMaker::validTdc(float tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
 
 #endif

--- a/StRoot/StTofpMatchMaker/StTofpMatchMaker.h
+++ b/StRoot/StTofpMatchMaker/StTofpMatchMaker.h
@@ -126,8 +126,8 @@ private:
   Bool_t mOuterTrackGeometry; //! use outer track geometry (true) for extrapolation
   string mHistoFileName; //! name of histogram file, if empty no write-out
 
-  Bool_t validAdc(float const);
-  Bool_t validTdc(float const);
+  Bool_t validAdc(const);
+  Bool_t validTdc(const);
   Bool_t validEvent(StEvent *);
   Bool_t validTrack(StTrack*);
   Bool_t validTofTrack(StTrack*);
@@ -206,7 +206,7 @@ inline void StTofpMatchMaker::setMinFitPointsPerTrack(Int_t nfitpnts){mMinFitPoi
 inline void StTofpMatchMaker::setMaxDCA(Float_t maxdca){mMaxDCA=maxdca;}
 inline void StTofpMatchMaker::setHistoFileName(Char_t* filename){mHistoFileName=filename;}
 inline void StTofpMatchMaker::createHistograms(Bool_t histos){mHisto = histos;}
-inline bool StTofpMatchMaker::validAdc(const float adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
-inline bool StTofpMatchMaker::validTdc(const float tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
+inline bool StTofpMatchMaker::validAdc(float adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
+inline bool StTofpMatchMaker::validTdc(float tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
 
 #endif

--- a/StRoot/StTofpMatchMaker/StTofpMatchMaker.h
+++ b/StRoot/StTofpMatchMaker/StTofpMatchMaker.h
@@ -126,8 +126,8 @@ private:
   Bool_t mOuterTrackGeometry; //! use outer track geometry (true) for extrapolation
   string mHistoFileName; //! name of histogram file, if empty no write-out
 
-  Bool_t validAdc(const);
-  Bool_t validTdc(const);
+  Bool_t validAdc(float);
+  Bool_t validTdc(float);
   Bool_t validEvent(StEvent *);
   Bool_t validTrack(StTrack*);
   Bool_t validTofTrack(StTrack*);

--- a/StRoot/StTofrMatchMaker/StTofrMatchMaker.h
+++ b/StRoot/StTofrMatchMaker/StTofrMatchMaker.h
@@ -150,8 +150,8 @@ private:
     void bookHistograms();
     void writeHistogramsToFile();
     
-    Bool_t validAdc(Float_t const);
-    Bool_t validTdc(Float_t const);
+    Bool_t validAdc(Float_t);
+    Bool_t validTdc(Float_t);
     Bool_t validEvent(StEvent *);
     Bool_t validTrack(StTrack*);
     Bool_t validTrackRun8(StGlobalTrack*);
@@ -390,8 +390,8 @@ inline void StTofrMatchMaker::setCreateTreeFlag(Bool_t tree){mSaveTree = tree;}
 
 inline void StTofrMatchMaker::setSaveGeometry(Bool_t geomSave){mGeometrySave = geomSave; }
 
-inline Bool_t StTofrMatchMaker::validAdc(const Float_t adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
+inline Bool_t StTofrMatchMaker::validAdc(Float_t adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
 
-inline Bool_t StTofrMatchMaker::validTdc(const Float_t tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
+inline Bool_t StTofrMatchMaker::validTdc(Float_t tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
 
 #endif


### PR DESCRIPTION
Seems like rootcint gets a bit confused and emits code that doesn't compile with GCC 10:

    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx: In function 'int G__StTofpMatchMaker_Cint_563_0_43(G__value*, const char*, G
    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx:420:129: error: 'bool StTofpMatchMaker::validAdc(float)' is private within th
      420 |       G__letint(result7, 103, (long) ((StTofpMatchMaker*) G__getstructoffset())->validAdc((const float) G__double(libp->para[0])));
          |                                                                                                                                 ^
    In file included from .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.h:34,
                     from .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx:17:
    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker.h:209:13: note: declared private here
      209 | inline bool StTofpMatchMaker::validAdc(const float adc){return((adc>=mMinValidAdc) && (adc<=mMaxValidAdc));}
          |             ^~~~~~~~~~~~~~~~
    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx: In function 'int G__StTofpMatchMaker_Cint_563_0_44(G__value*, const char*, G
    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx:426:129: error: 'bool StTofpMatchMaker::validTdc(float)' is private within th
      426 |       G__letint(result7, 103, (long) ((StTofpMatchMaker*) G__getstructoffset())->validTdc((const float) G__double(libp->para[0])));
          |                                                                                                                                 ^
    In file included from .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.h:34,
                     from .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker_Cint.cxx:17:
    .sl79_gcc485/obj/StRoot/StTofpMatchMaker/StTofpMatchMaker.h:210:13: note: declared private here
      210 | inline bool StTofpMatchMaker::validTdc(const float tdc){return((tdc>=mMinValidTdc) && (tdc<=mMaxValidTdc));}
          |             ^~~~~~~~~~~~~~~~