### PR TITLE
StEEmcClusterMaker: avoid using operator++(bool&)

### DIFF
--- a/StRoot/StEEmcPool/StEEmcClusterMaker/StEEmc2x2ClusterMaker.cxx
+++ b/StRoot/StEEmcPool/StEEmcClusterMaker/StEEmc2x2ClusterMaker.cxx
@@ -352,7 +352,7 @@ Int_t StEEmc2x2ClusterMaker::buildSmdClusters()
 		  if ( energy > mSmdMinEnergy ) 
 		    {
 		      if ( !strip.fail() ) {
-			used[istrip]++;
+			used[istrip] = true;
 			cluster.add(strip);			
 		      }
 		      else
@@ -388,7 +388,7 @@ Int_t StEEmc2x2ClusterMaker::buildSmdClusters()
                   if ( energy > mSmdMinEnergy )
                     {
                       if ( !strip.fail() ) {
-			used[istrip]++;
+			used[istrip] = true;
 			cluster.add(strip);
 		      }
 		      else

--- a/StRoot/StEEmcPool/StEEmcClusterMaker/StMyClusterMaker.cxx
+++ b/StRoot/StEEmcPool/StEEmcClusterMaker/StMyClusterMaker.cxx
@@ -329,7 +329,7 @@ Int_t StMyClusterMaker::buildSmdClusters()
 		  if ( energy > mSmdMinEnergy ) 
 		    {
 		      if ( !strip.fail() ) {
-			used[istrip]++;
+			used[istrip] = true;
 			cluster.add(strip);			
 		      }
 		      else
@@ -365,7 +365,7 @@ Int_t StMyClusterMaker::buildSmdClusters()
                   if ( energy > mSmdMinEnergy )
                     {
                       if ( !strip.fail() ) {
-			used[istrip]++;
+			used[istrip] = true;
 			cluster.add(strip);
 		      }
 		      else


### PR DESCRIPTION
The code is roughly equivalent to:

```c++
    bool used[];
    for(;;) {
      // ...
      if (used[istrip]) break;
      // ...
      used[istrip]++;
      // ...
    }
```

The use of operator++ for a boolean value is not wrong, but is slightly confusing and leads to a compilation error in C++17:

    .sl79_gcc485/obj/StRoot/StEEmcPool/StEEmcClusterMaker/StEEmc2x2ClusterMaker.cxx:355:16: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
      355 |    used[istrip]++;
          |                ^~
    .sl79_gcc485/obj/StRoot/StEEmcPool/StEEmcClusterMaker/StEEmc2x2ClusterMaker.cxx:391:16: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
      391 |    used[istrip]++;
          |                ^~