### PR TITLE
bfc.C: fix for cling

### DIFF
--- a/StRoot/macros/bfc.C
+++ b/StRoot/macros/bfc.C
@@ -10,6 +10,9 @@
 class StBFChain;        
 class StMessMgr;
 
+#pragma cling load("StarRoot")
+#pragma cling load("St_base")
+#pragma cling load("StChain")
 #pragma cling load("StUtilities")
 #pragma cling load("StBFChain")
 

--- a/StRoot/macros/bfc.C
+++ b/StRoot/macros/bfc.C
@@ -9,7 +9,11 @@
 //////////////////////////////////////////////////////////////////////////
 class StBFChain;        
 class StMessMgr;
-#if !defined(__CINT__) || defined(__MAKECINT__)
+
+#pragma cling load("StUtilities")
+#pragma cling load("StBFChain")
+
+#if !(defined(__CINT__) || defined(__CLING__)) || defined(__MAKECINT__)
 
 #include "Stiostream.h"
 #include "TSystem.h"


### PR DESCRIPTION
cling needs to have libraries loaded before running a macro.

This disables the #include statements when ACLiC is not
used. Currently, cling can't parse those headers: there seems to be an
issue with how forward declarations interract with
`$clingAutoload$`. Fortunately, the `#pragma load` takes care of the
headers, like in ROOT5, so things just work.