### PR TITLE
Stabilize calculation of uncertainties for vertices extremely close to beam line

### DIFF
--- a/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -312,9 +312,7 @@ double StGenericVertexFinder::CalcChi2Beamline(const StThreeVectorD& point)
    // assume) and if they are zero they are unphysical anyway.
    if (dist_mag < 1e-7) return 0;
 
-   // A note for future optimizers: The expression sqrt(...) below is actually
-   // the distance from the point to the beam line. Unfortunately, it is
-   // calculated unnecessarily twice...
+   // TODO check if the value of denom_sqrt is the same as dist_mag
    double denom_sqrt = kx2_ky2_1 * sqrt( ( (kx*dy - ky*dx)*(kx*dy - ky*dx) + (ky*zv - dy)*(ky*zv - dy) + (kx*zv - dx)*(kx*zv - dx) ) /kx2_ky2_1);
    double denom = kx2_ky2_1 * denom_sqrt;
 

--- a/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -294,22 +294,28 @@ double StGenericVertexFinder::CalcChi2Beamline(const StThreeVectorD& point)
    double ky_dy_zv_2 = ky_dy_zv*ky_dy_zv;
    double kx_dx_zv_2 = kx_dx_zv*kx_dx_zv;
 
-   double denom_sqrt = kx2_ky2_1 * sqrt( ( (kx*dy - ky*dx)*(kx*dy - ky*dx) + (ky*zv - dy)*(ky*zv - dy) + (kx*zv - dx)*(kx*zv - dx) ) /kx2_ky2_1);
-
-   // The denominator is zero when the point is exactly on the beamline
-   // We just return a zero for the chi2 in this case. This makes sense for all
-   // non-zero errors and if they are zero they are unphysical anyway.
-   if (denom_sqrt == 0) return 0;
-
    // The distance between the line and the point
    StThreeVectorD dist_vec (
       (  (ky2 + 1)*dx -     kx*ky*dy -          kx*zv)/kx2_ky2_1,
       (    - kx*ky*dx + (kx2 + 1)*dy -          ky*zv)/kx2_ky2_1,
       (       - kx*dx -        ky*dy + (kx2 + ky2)*zv)/kx2_ky2_1
    );
+
    double dist_mag = dist_vec.mag();
+
+   // When the vertex (point) gets closer to the beamline there may not be
+   // enough precision to do the intermediate calculations for the
+   // transformation of the errors, i.e. the Jacobian below. The distance is
+   // measured in cm so, anything within a nanometer will be considered to be on
+   // the beam line and we just return a zero for the chi2 in such cases. This
+   // makes sense for all non-zero errors (that is what we actually expect and
+   // assume) and if they are zero they are unphysical anyway.
    if (dist_mag < 1e-7) return 0;
 
+   // A note for future optimizers: The expression sqrt(...) below is actually
+   // the distance from the point to the beam line. Unfortunately, it is
+   // calculated unnecessarily twice...
+   double denom_sqrt = kx2_ky2_1 * sqrt( ( (kx*dy - ky*dx)*(kx*dy - ky*dx) + (ky*zv - dy)*(ky*zv - dy) + (kx*zv - dx)*(kx*zv - dx) ) /kx2_ky2_1);
    double denom = kx2_ky2_1 * denom_sqrt;
 
    // The Jacobian for the distance w.r.t. measured beamline parameters, i.e. x0, y0, kx, and ky

--- a/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StRoot/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -307,7 +307,8 @@ double StGenericVertexFinder::CalcChi2Beamline(const StThreeVectorD& point)
       (    - kx*ky*dx + (kx2 + 1)*dy -          ky*zv)/kx2_ky2_1,
       (       - kx*dx -        ky*dy + (kx2 + ky2)*zv)/kx2_ky2_1
    );
-
+   double dist_mag = dist_vec.mag();
+   if (dist_mag < 1e-7) return 0;
 
    double denom = kx2_ky2_1 * denom_sqrt;
 
@@ -336,8 +337,7 @@ double StGenericVertexFinder::CalcChi2Beamline(const StThreeVectorD& point)
    // Finaly, calculate the covariance matrix along the vector connecting the beamline and the point
    // The result is a 1x1 matrix
    TRSymMatrix covarianceMprime(TRMatrix(1, 4, jacobian), TRArray::kAxSxAT, TRSymMatrix(4, covBeamline) );
-
-   double dist_mag = dist_vec.mag();
+   
    double chi2 = dist_mag*dist_mag/covarianceMprime[0];
 
    return chi2;


### PR DESCRIPTION
By running the following chain with DEV library, bfc always failed in 64Bit optimized version. 32Bit optimized version has no problem. I did not test the DEBUG version.
Yuri provided me with this fix and in my tests, it works.

```
root4star -b -q 'bfc.C(100,"pp2022,StiCA,BEmcChkStat,epdhit,-hitfilt,-evout,-fcsCluster,-fcsPoint ","/star/data03/daq/2022/010/23010027/st_physics_23010027_raw_1000015.daq")'
```
The error message is:
```
StiMaker:INFO  - StPPVertexFinder::evalVertex Vid=25 accepted, nAnyMatch=3 nAnyVeto=31
StiMaker:INFO  - StPPVertexFinder::evalVertex Vid=26 accepted, nAnyMatch=2 nAnyVeto=12
StiMaker:INFO  - StPPVertexFinder::evalVertex Vid=28 accepted, nAnyMatch=4 nAnyVeto=13
StiMaker:INFO  - StPPVertexFinder::evalVertex Vid=29 accepted, nAnyMatch=3 nAnyVeto=11
StiMaker:INFO  - StPPVertexFinder::evalVertex Vid=30 accepted, nAnyMatch=4 nAnyVeto=21
root4star: .sl73_x8664_gcc485/OBJ/StRoot/StarRoot/THelixTrack.cxx:802: double THelixTrack::Step(const double*, double*, double*) const: Assertion `iter' failed.
*** Problem in THElixTrack::Step(vtx) ***
double vtx[3]={nan,nan,nan};
 THelixTrack::this = 0x7ffdbbd964f0
 THelixTrack::fX[3] = { -0.478721 , -0.794980 ,110.145058 }
 THelixTrack::fP[3] = { -0.814047 , 0.490203 ,-0.311495 }
 THelixTrack::fRho  =   0.003078
```