### PR TITLE
cling bfc.C test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,29 +3,6 @@ name: CI Build
 on: [pull_request]
 
 jobs:
-  ROOT5:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10000000
-
-      - name: Build with Docker
-        uses: docker/build-push-action@v2
-        with:
-          cache-from: type=registry,ref=ghcr.io/star-bnl/star-sw-root5-base@sha256:4bed8a8b729fa9e6c8e92b2bdecd6b73869e67a07bfbde969936f921123d4c3e
-          push: false
-          tags: ghcr.io/star-bnl/star-sw-root5-build
-          file: docker/Dockerfile.root5
-          outputs: type=docker,dest=/tmp/star-sw-root5-build.tar
-
-      - name: Save built image for test jobs
-        uses: actions/upload-artifact@v2
-        with:
-          name: star-sw-root5-build
-          path: /tmp/star-sw-root5-build.tar
-
   ROOT6:
     runs-on: ubuntu-latest
     steps:
@@ -49,35 +26,6 @@ jobs:
           name: star-sw-root6-build
           path: /tmp/star-sw-root6-build.tar
 
-  ROOT5_test_setup:
-    runs-on: ubuntu-latest
-    needs: ROOT5
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v2
-      - run: echo "::set-output name=matrix::" $(cat tests/joblist_ci.json)
-        id: set-matrix
-
-  ROOT5_test:
-    runs-on: ubuntu-latest
-    needs: ROOT5_test_setup
-    strategy:
-      matrix:
-        test_id: ${{ fromJSON(needs.ROOT5_test_setup.outputs.matrix) }}
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: star-sw-root5-build
-          path: /tmp
-
-      - run: docker load --input /tmp/star-sw-root5-build.tar
-      - run: docker run --name star-test-data --volume /star ghcr.io/star-bnl/star-test-data:v2
-      - run: |
-             TEST_CMD=$(docker run --rm ghcr.io/star-bnl/star-sw-root5-build star-sw/tests/executest.py -c ${{ matrix.test_id }})
-             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root5-build sh -c "$TEST_CMD"
-
   ROOT6_test:
     runs-on: ubuntu-latest
     needs: ROOT6
@@ -97,4 +45,4 @@ jobs:
       - run: docker run --name star-test-data --volume /star ghcr.io/star-bnl/star-test-data:v2
       - run: |
              TEST_CMD=$(docker run --rm ghcr.io/star-bnl/star-sw-root6-build star-sw/tests/executest.py -c ${{ matrix.test_id }})
-             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root6-build sh -c "$TEST_CMD"
+             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root6-build sh -c "cd /star-sw/StRoot/macros; $TEST_CMD"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -77,3 +77,24 @@ jobs:
       - run: |
              TEST_CMD=$(docker run --rm ghcr.io/star-bnl/star-sw-root5-build star-sw/tests/executest.py -c ${{ matrix.test_id }})
              docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root5-build sh -c "$TEST_CMD"
+
+  ROOT6_test:
+    runs-on: ubuntu-latest
+    needs: ROOT6
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        test_id: [50, 52, 54, 90, 91, 92, 119, 120]
+        experimental: [true]
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: star-sw-root6-build
+          path: /tmp
+
+      - run: docker load --input /tmp/star-sw-root6-build.tar
+      - run: docker run --name star-test-data --volume /star ghcr.io/star-bnl/star-test-data:v2
+      - run: |
+             TEST_CMD=$(docker run --rm ghcr.io/star-bnl/star-sw-root6-build star-sw/tests/executest.py -c ${{ matrix.test_id }})
+             docker run --volumes-from star-test-data ghcr.io/star-bnl/star-sw-root6-build sh -c "$TEST_CMD"

--- a/StRoot/macros/bfc.C
+++ b/StRoot/macros/bfc.C
@@ -10,6 +10,8 @@
 class StBFChain;        
 class StMessMgr;
 
+#pragma cling load("St_base")
+#pragma cling load("StChain")
 #pragma cling load("StUtilities")
 #pragma cling load("StBFChain")
 

--- a/StRoot/macros/bfc.C
+++ b/StRoot/macros/bfc.C
@@ -9,7 +9,11 @@
 //////////////////////////////////////////////////////////////////////////
 class StBFChain;        
 class StMessMgr;
-#if !defined(__CINT__) || defined(__MAKECINT__)
+
+#pragma cling load("StUtilities")
+#pragma cling load("StBFChain")
+
+#if !(defined(__CINT__) || defined(__CLING__)) || defined(__MAKECINT__)
 
 #include "Stiostream.h"
 #include "TSystem.h"

--- a/asps/rexe/Conscript
+++ b/asps/rexe/Conscript
@@ -148,8 +148,13 @@ foreach $h (@h_files) {#print "h = $h\n";
  ENDL:
 }
 if ($#Defs > -1) {
-  my @CintFiles = 
-  ( $PKG . "_Cint.cxx", $PKG . "_Cint.h");
+  my @CintFiles = ("${PKG}_Cint.cxx", "${PKG}_Cint.h");
+
+  if ($env->{ENV}->{ROOT_VERSION_MAJOR} >= 6) {
+    push @CintFiles, "${PKG}_Cint_rdict.pcm";
+    Install $env $LIB, File::Basename::basename("${PKG}_Cint_rdict.pcm");
+  }
+
   my @defs = ();
   foreach my $def (@Defs) {
     next if $def =~ /LinkDef/;

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -129,8 +129,6 @@ RUN source /etc/profile \
  && cons \
  && find /star-sw/.$STAR_HOST_SYS -name *.o -exec rm '{}' \;
 
-RUN install /star-sw/StRoot/macros/.rootrc .
-
 # One might expect the single ENTRYPOINT command below to work but for some
 # reason it chokes on a complex command such as
 #

--- a/docker/Dockerfile.root6
+++ b/docker/Dockerfile.root6
@@ -87,6 +87,7 @@ ENV STAR_SYS=x8664_sl7
 ENV PATH=$CERN_ROOT/bin:$STAR_BIN:$STAR/mgr:$PATH
 ENV LD_LIBRARY_PATH=$STAR_LIB:$LD_LIBRARY_PATH
 ENV LIBPATH+=:/lib64:/lib
+ENV ROOT_INCLUDE_PATH=$STAR/.${STAR_HOST_SYS}/include
 
 ENV MYSQL=/opt/software/linux-scientific7-x86_64/gcc-4.8.5/mysql-5.7.27-pfyt3fwtkubcc5eazmoqfick3lgp67mf
 ENV LIBXML2_DIR=/opt/software/linux-scientific7-x86_64/gcc-4.8.5/libxml2-2.9.10-4lxsmpa57bm3xs2cs3xapk3qccxflkfl


### PR DESCRIPTION
I wonder if the CI failure is happening in the rootlogon.C macro even before bfc.C is processed. If that is the case, then there seems to be an error in CI that I don't see in my environment.

- Enable ROOT6 tests
- Disable rootlogon <- expect an error to change
- Enable fix <- why not try