### PR TITLE
Fix EMC data in picoDst data in DAQ production

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1949,6 +1949,8 @@ Bfc_st BFC[] = { // standard chains
 #endif /* __NoStrangeMuDst__ */
   {"RMuDST"    ,"","","CMuDST"   ,"","","reads Common MuDST, do not disactivate if no output files",kFALSE},
 
+  {"trgSimu"        ,"","",""       ,"StTriggerSimuMaker","StTriggerUtilities","trigger simu maker",kFALSE},
+
   {"picoWrite" ,"","PicoChain","picoDst","StPicoDstMaker",""               ,"Writes picoDST format",kFALSE},
   {"picoRead"  ,"","PicoChain","picoDst","StPicoDstMaker",""           ,"WritesRead picoDST format",kFALSE},
   {"PicoVtxDefault" ,"","",""                                       ,"" ,"","pico Vtx default mode",kFALSE},

--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1951,7 +1951,7 @@ Bfc_st BFC[] = { // standard chains
 
   {"trgSimu"        ,"","",""       ,"StTriggerSimuMaker","StTriggerUtilities","trigger simu maker",kFALSE},
 
-  {"picoWrite" ,"","PicoChain","picoDst","StPicoDstMaker",""               ,"Writes picoDST format",kFALSE},
+  {"picoWrite" ,"","PicoChain","trgSimu,picoDst","StPicoDstMaker",""       ,"Writes picoDST format",kFALSE},
   {"picoRead"  ,"","PicoChain","picoDst","StPicoDstMaker",""           ,"WritesRead picoDST format",kFALSE},
   {"PicoVtxDefault" ,"","",""                                       ,"" ,"","pico Vtx default mode",kFALSE},
   {"PicoVtxVpd"     ,"","","-PicoVtxDefault"             ,"" ,"","pico Vtx cut on Tof and VPD mode",kFALSE},

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -657,13 +657,7 @@ Int_t StBFChain::Instantiate()
 
     // trigger simu maker
     if ( maker == "StTriggerSimuMaker" && GetOption("picoWrite") ) {
-      TString cmd(Form("StTriggerSimuMaker *pTSMk = (StTriggerSimuMaker*) %p;",mk));
-      cmd += "pTSMk->setMC(false);";                                 // Set TriggerSimuMaker parameters
-      cmd += "pTSMk->useBemc();";
-      cmd += "pTSMk->useEemc();";
-      cmd += "pTSMk->useOfflineDB();";
-      cmd += "pTSMk->bemc->setConfig(StBemcTriggerSimu::kOffline);";
-      ProcessLine(cmd);
+      mk->SetMode(10);  // picoDst production
     }
 
     // MuDST and ezTree. Combinations are

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -655,6 +655,17 @@ Int_t StBFChain::Instantiate()
     if ( maker == "StEmcRawMaker" && GetOption("BEmcChkStat"))
       mk->SetAttr("BEmcCheckStatus",kTRUE);
 
+    // trigger simu maker
+    if ( maker == "StTriggerSimuMaker" && GetOption("picoWrite") ) {
+      TString cmd(Form("StTriggerSimuMaker *pTSMk = (StTriggerSimuMaker*) %p;",mk));
+      cmd += "pTSMk->setMC(false);";                                 // Set TriggerSimuMaker parameters
+      cmd += "pTSMk->useBemc();";
+      cmd += "pTSMk->useEemc();";
+      cmd += "pTSMk->useOfflineDB();";
+      cmd += "pTSMk->bemc->setConfig(StBemcTriggerSimu::kOffline);";
+      ProcessLine(cmd);
+    }
+
     // MuDST and ezTree. Combinations are
     //  ezTree         -> ezTree only
     //  CMuDST         -> regular MuDST only

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -29,6 +29,7 @@
 #include "StarClassLibrary/StPhysicalHelix.hh"
 #include "StarClassLibrary/PhysicalConstants.h"
 
+#include "StEvent/StEvent.h"
 #include "StEvent/StBTofHeader.h"
 #include "StEvent/StDcaGeometry.h"
 #include "StEvent/StEmcCollection.h"
@@ -861,10 +862,14 @@ Int_t StPicoDstMaker::MakeWrite() {
   Bool_t isFromDaq = kFALSE;
   if ( !mEmcCollection ) {
     isFromDaq = kTRUE;
-    static StMuEmcUtil emcUtil;
+//    static StMuEmcUtil emcUtil;
     // Recover StEmcCollection in case of broken/deleted pointer
     // This usually happens during daq->picoDst converstion
-    mEmcCollection = emcUtil.getEmc( mMuDst->muEmcCollection() );
+    StEvent *evt = (StEvent *)GetDataSet("StEvent");
+    if(evt) {
+      mEmcCollection = evt->emcCollection();
+    }
+//    mEmcCollection = emcUtil.getEmc( mMuDst->muEmcCollection() );
   }
 
   if (mEmcCollection) {

--- a/StRoot/StTriggerUtilities/StTriggerSimuMaker.cxx
+++ b/StRoot/StTriggerUtilities/StTriggerSimuMaker.cxx
@@ -153,6 +153,14 @@ Int_t StTriggerSimuMaker::Init() {
 
     }
 
+    if (GetMode() == 10) {
+      // Set parameters necessary for filling PicoDst in BFC
+      setMC(false);
+      useBemc();
+      useEemc();
+      useOfflineDB();
+      bemc->setConfig(StBemcTriggerSimu::kOffline);
+    }
 
     return StMaker::Init();
 }


### PR DESCRIPTION
- picoDstMaker change to extract the emcCollection from StEvent during daq production
- BFC option added for TriggerSimuMaker + options 