### PR TITLE
QA switch for FCS

### DIFF
--- a/StRoot/St_QA_Maker/StEventQAMaker.cxx
+++ b/StRoot/St_QA_Maker/StEventQAMaker.cxx
@@ -105,7 +105,7 @@ StQAMakerBase(name,title,"StE"), event(0), primVtx(0), mHitHist(0), mPmdGeom(0),
   multiplicity = 0;
   qaEvents = 0;
   evtTime = -1;
-  if (GetMaker("fcsDbMkr")) AddMaker(new StFcsPi0FinderForEcal());
+  if (GetMaker("fcsDbMkr") && GetMaker("StFcsClusterMaker")) AddMaker(new StFcsPi0FinderForEcal());
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Akio says: "Running StFcsPi0FinderForEcal does not make any sense when fcsCluster is off."