### PR TITLE
Add Toshihiro Nonaka to the StRefMultCorr codeowner list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,7 @@
 /StRoot/StPass0CalibMaker                          @genevb            @iraklic
 /StRoot/StPico*                                    @nigmatkulov       @marrbnl     @plexoos
 /StRoot/StPxl*                                     @starsdong         @GuannanXie
-/StRoot/StRefMultCorr                              @nigmatkulov
+/StRoot/StRefMultCorr                              @nigmatkulov	      @ToshihiroNonaka
 /StRoot/StRTSClient                                @jml985            @tonko-lj
 /StRoot/StShadowMaker                              @genevb
 /StRoot/StSpectraTagsMaker                         @ullrich-bnl


### PR DESCRIPTION
Add codeowner for centrality code.