### PR TITLE
TriggerSimu + picoDst for BEMC data in daq->picoDst production

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1960,7 +1960,9 @@ Bfc_st BFC[] = { // standard chains
 #endif /* __NoStrangeMuDst__ */
   {"RMuDST"    ,"","","CMuDST"   ,"","","reads Common MuDST, do not disactivate if no output files",kFALSE},
 
-  {"picoWrite" ,"","PicoChain","picoDst","StPicoDstMaker",""               ,"Writes picoDST format",kFALSE},
+  {"trgSimu"        ,"","",""       ,"StTriggerSimuMaker","StTriggerUtilities","trigger simu maker",kFALSE},
+
+  {"picoWrite" ,"","PicoChain","trgSimu,picoDst","StPicoDstMaker",""       ,"Writes picoDST format",kFALSE},
   {"picoRead"  ,"","PicoChain","picoDst","StPicoDstMaker",""           ,"WritesRead picoDST format",kFALSE},
   {"PicoVtxDefault" ,"","",""                                       ,"" ,"","pico Vtx default mode",kFALSE},
   {"PicoVtxVpd"     ,"","","-PicoVtxDefault"             ,"" ,"","pico Vtx cut on Tof and VPD mode",kFALSE},

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -654,6 +654,16 @@ Int_t StBFChain::Instantiate()
     // Use status tables for raw BEMC data (helpful for QA)
     if ( maker == "StEmcRawMaker" && GetOption("BEmcChkStat"))
       mk->SetAttr("BEmcCheckStatus",kTRUE);
+      
+    // 
+    if ( maker == "StEmcRawMaker" && GetOption("picoWrite")) {
+      mk->SetMode(1);  // saveAllStEvent for picoDst
+    }
+    
+    // trigger simu maker
+    if ( maker == "StTriggerSimuMaker" && GetOption("picoWrite") ) {
+      mk->SetMode(10);  // picoDst production
+    }
 
     // MuDST and ezTree. Combinations are
     //  ezTree         -> ezTree only

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1948,7 +1948,7 @@ void StPicoDstMaker::fillEmcTrigger() {
     mPicoDst->event()->setHighTowerThreshold(i, trigSimu->bemc->barrelHighTowerTh(i));
   }
 
-  if( bht0>=5 || bht1>=5 || bht2>=5 || bht3>=5 ) {  // avoid saving unuseful data in case all threshold values are zeros
+  if( bht0>0 || bht1>0 || bht2>0 || bht3>0 ) {  // avoid saving unuseful data in case all threshold values are zeros
   
   // Loop over all towers
   for(Int_t towerId=1; towerId<=4800; towerId++) {
@@ -2086,7 +2086,7 @@ void StPicoDstMaker::fillEmcTrigger() {
     mPicoDst->event()->setJetPatchThreshold(i, trigSimu->bemc->barrelJetPatchTh(i));
   }
 
-  if ( bjpth0 >= 10 || bjpth1 >= 10 || bjpth2 >= 10 ) {
+  if ( bjpth0 > 0 || bjpth1 > 0 || bjpth2 > 0 ) {
   
   // Loop over triggers
   for (int jp = 0; jp < 18; ++jp) {

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -29,6 +29,7 @@
 #include "StarClassLibrary/StPhysicalHelix.hh"
 #include "StarClassLibrary/PhysicalConstants.h"
 
+#include "StEvent/StEvent.h"
 #include "StEvent/StBTofHeader.h"
 #include "StEvent/StDcaGeometry.h"
 #include "StEvent/StEmcCollection.h"
@@ -861,10 +862,14 @@ Int_t StPicoDstMaker::MakeWrite() {
   Bool_t isFromDaq = kFALSE;
   if ( !mEmcCollection ) {
     isFromDaq = kTRUE;
-    static StMuEmcUtil emcUtil;
+//    static StMuEmcUtil emcUtil;
     // Recover StEmcCollection in case of broken/deleted pointer
     // This usually happens during daq->picoDst converstion
-    mEmcCollection = emcUtil.getEmc( mMuDst->muEmcCollection() );
+    StEvent *evt = (StEvent *)GetDataSet("StEvent");
+    if(evt) {
+      mEmcCollection = evt->emcCollection();
+    }
+//    mEmcCollection = emcUtil.getEmc( mMuDst->muEmcCollection() );
   }
 
   if (mEmcCollection) {
@@ -902,7 +907,7 @@ Int_t StPicoDstMaker::MakeWrite() {
 
   mTTree->Fill();
   if ( isFromDaq ) {
-    delete mEmcCollection;
+//    delete mEmcCollection;
     mEmcCollection = nullptr;
   }
 
@@ -1938,11 +1943,13 @@ void StPicoDstMaker::fillEmcTrigger() {
   int bht1 = trigSimu->bemc->barrelHighTowerTh(1);
   int bht2 = trigSimu->bemc->barrelHighTowerTh(2);
   int bht3 = trigSimu->bemc->barrelHighTowerTh(3);
-  LOG_DEBUG << " bht thresholds " << bht0 << " " << bht1 << " " << bht2 << " " << bht3 << endm;
+  LOG_INFO << " bht thresholds " << bht0 << " " << bht1 << " " << bht2 << " " << bht3 << endm;
   for (int i = 0; i < 4; ++i) {
     mPicoDst->event()->setHighTowerThreshold(i, trigSimu->bemc->barrelHighTowerTh(i));
   }
 
+  if( bht0>=5 || bht1>=5 || bht2>=5 || bht3>=5 ) {  // avoid saving unuseful data in case all threshold values are zeros
+  
   // Loop over all towers
   for(Int_t towerId=1; towerId<=4800; towerId++) {
     Int_t status;
@@ -2065,16 +2072,22 @@ void StPicoDstMaker::fillEmcTrigger() {
       new((*(mPicoArrays[StPicoArrays::EmcTrigger]))[counter]) StPicoEmcTrigger(flag, towerId, adc, smdEHits, smdPHits);
     }
   } //for(Int_t towerId=1; towerId<=4800; towerId++)
+  
+  } // end if (bht threshold check)
 
     // BEMC Jet Patch trigger threshold
   int const bjpth0 = trigSimu->bemc->barrelJetPatchTh(0);
   int const bjpth1 = trigSimu->bemc->barrelJetPatchTh(1);
   int const bjpth2 = trigSimu->bemc->barrelJetPatchTh(2);
 
+  LOG_INFO << " bjp thresholds " << bjpth0 << " " << bjpth0 << " " << bjpth1 << " " << bjpth2 << endm;
+  
   for (int i = 0; i < 3; ++i) {
     mPicoDst->event()->setJetPatchThreshold(i, trigSimu->bemc->barrelJetPatchTh(i));
   }
 
+  if ( bjpth0 >= 10 || bjpth1 >= 10 || bjpth2 >= 10 ) {
+  
   // Loop over triggers
   for (int jp = 0; jp < 18; ++jp) {
     // BEMC: 12 Jet Patch + 6 overlap Jet Patches. As no EEMC information
@@ -2099,6 +2112,8 @@ void StPicoDstMaker::fillEmcTrigger() {
       new((*(mPicoArrays[StPicoArrays::EmcTrigger]))[counter]) StPicoEmcTrigger(flag, jp, jpAdc);
     }
   } //for (int jp = 0; jp < 18; ++jp)
+  
+  }
 }
 
 //_________________

--- a/StRoot/StTriggerUtilities/Bemc/StBemcTriggerSimu.cxx
+++ b/StRoot/StTriggerUtilities/Bemc/StBemcTriggerSimu.cxx
@@ -79,12 +79,12 @@ void StBemcTriggerSimu::Init(){
   else {
     mAdc2e = static_cast<StEmcADCtoEMaker*> ( mHeadMaker->GetMakerInheritsFrom("StEmcADCtoEMaker") );
     StEmcRawMaker *emcRaw = static_cast<StEmcRawMaker*> ( mHeadMaker->GetMakerInheritsFrom("StEmcRawMaker") );
-    if(!mAdc2e && !emcRaw) {
+    if(mAdc2e) mTables = mAdc2e->getBemcData()->getTables();
+    else if(emcRaw) mTables = emcRaw->getBemcRaw()->getTables();
+    else {
       LOG_FATAL << "StBemcTriggerSimu couldn't find StEmcADCtoEMaker and StEmcRawMaker in chain" << endm;
       assert(0);
     }
-    if(mAdc2e) mTables = mAdc2e->getBemcData()->getTables();
-    else if(emcRaw) mTables = emcRaw->getBemcRaw()->getTables();
   }
 
   mDbThres->LoadTimeStamps();

--- a/StRoot/StTriggerUtilities/Bemc/StBemcTriggerSimu.cxx
+++ b/StRoot/StTriggerUtilities/Bemc/StBemcTriggerSimu.cxx
@@ -14,6 +14,7 @@
 #include "StEmcRawMaker/defines.h"
 #include "StEmcSimulatorMaker/StEmcSimulatorMaker.h"
 #include "StEmcADCtoEMaker/StEmcADCtoEMaker.h"
+#include "StEmcRawMaker/StEmcRawMaker.h"
 #include "StBemcTriggerDbThresholds.h"
 
 //StEvent
@@ -77,11 +78,13 @@ void StBemcTriggerSimu::Init(){
   }
   else {
     mAdc2e = static_cast<StEmcADCtoEMaker*> ( mHeadMaker->GetMakerInheritsFrom("StEmcADCtoEMaker") );
-    if(!mAdc2e) {
-      LOG_FATAL << "StBemcTriggerSimu couldn't find StEmcADCtoEMaker in chain" << endm;
+    StEmcRawMaker *emcRaw = static_cast<StEmcRawMaker*> ( mHeadMaker->GetMakerInheritsFrom("StEmcRawMaker") );
+    if(!mAdc2e && !emcRaw) {
+      LOG_FATAL << "StBemcTriggerSimu couldn't find StEmcADCtoEMaker and StEmcRawMaker in chain" << endm;
       assert(0);
     }
-    mTables = mAdc2e->getBemcData()->getTables();
+    if(mAdc2e) mTables = mAdc2e->getBemcData()->getTables();
+    else if(emcRaw) mTables = emcRaw->getBemcRaw()->getTables();
   }
 
   mDbThres->LoadTimeStamps();

--- a/StRoot/StTriggerUtilities/Eemc/StEemcTriggerSimu.cxx
+++ b/StRoot/StTriggerUtilities/Eemc/StEemcTriggerSimu.cxx
@@ -190,8 +190,10 @@ StEemcTriggerSimu::InitRun(int runnumber){
   fill(highTowerMask,highTowerMask+90,1); // all channels good
   fill(patchSumMask,patchSumMask+90,1); // all channels good
 
+#if 0  // loading local mask files - no actual effect for jobs running on clusters - working on DB solution
   EemcTrigUtil::getFeeOutMask(dbtime,highTowerMask,patchSumMask);
   EemcTrigUtil::getFeeBoardMask(dbtime,highTowerMask);
+#endif
 
   switch (mPedMode) {
   case kOnline:

--- a/StRoot/StTriggerUtilities/StTriggerSimuMaker.cxx
+++ b/StRoot/StTriggerUtilities/StTriggerSimuMaker.cxx
@@ -137,6 +137,16 @@ void StTriggerSimuMaker::useL2(StGenericL2Emulator2009* L2Mk){
 
 Int_t StTriggerSimuMaker::Init() {
     LOG_INFO <<Form("StTriggerSimuMaker::Init(), MCflag=%d",mMCflag)<<endm;
+
+    if (GetMode() == 10) {
+      // Set parameters necessary for filling PicoDst in BFC
+      setMC(false);
+      useBemc();
+      useEemc();
+      useOfflineDB();
+      bemc->setConfig(StBemcTriggerSimu::kOffline);
+    }
+
     if(eemc) {
         eemc->setHList(mHList);
     }
@@ -152,7 +162,6 @@ Int_t StTriggerSimuMaker::Init() {
       }
 
     }
-
 
     return StMaker::Init();
 }


### PR DESCRIPTION
- PicoDst EMC collection pointer taken from StEvent directly in case of daq production
- TriggerSimuMaker added to BFC chain
- EmcRawMaker used to obtain BEMC data in case of daq production