### PR TITLE
Tpc rdo mask fix

### DIFF
--- a/StDb/idl/tpcCorrection.idl
+++ b/StDb/idl/tpcCorrection.idl
@@ -17,6 +17,7 @@ struct tpcCorrection {
                 // type = 6 X = abs(x);
                 // type = 10 (== log(1. + OffSet/x) + poly(x,npar))                  -"-
                 // type = 11 (== log(1. + OffSet/x) + poly(x,npar) for log(ADC) and |Z|
+                // type = 20 has extra 2 parameters to add expo => a[npar]*exp(a[npar+1]*x) to polynomical fit 
                 // type = 200 cut on range [min,max]
                 // type = 300 don't correct out of range [min,max]
                 // type = 400 special for TpcZCorrectionB, to enable Gating Grid correction

--- a/StRoot/StDetectorDbMaker/StDetectorDbChairs.cxx
+++ b/StRoot/StDetectorDbMaker/StDetectorDbChairs.cxx
@@ -943,7 +943,33 @@ Float_t St_TpcAvgPowerSupplyC::AcChargeL(Int_t sector, Int_t channel) {
 
   return AcCharge(sector,channel)/Length[channel-1];
 }
-
+//________________________________________________________________________________
+void St_TpcAvgPowerSupplyC::PrintC() const {
+  const St_TpcAvgPowerSupply *TpcAvgPowerSupply = (St_TpcAvgPowerSupply *) GetThisTable();
+  const TpcAvgPowerSupply_st &avgC = *TpcAvgPowerSupply->GetTable();
+  Double_t AcCharge[2] = {0, 0};
+  for (Int_t sec = 1; sec <= 24; sec++) {
+    cout << "Voltage " << sec;
+    for (Int_t socket = 1; socket <= 8; socket++) cout << "\t" << Form("%10.3f",avgC.Voltage[8*(sec-1)+socket-1]);
+    cout << endl;
+  }
+  for (Int_t sec = 1; sec <= 24; sec++) {
+    cout << "Current " << sec;
+    for (Int_t socket = 1; socket <= 8; socket++) cout << "\t" << Form("%10.5f",avgC.Current[8*(sec-1)+socket-1]);
+    cout << endl;
+  }
+  for (Int_t sec = 1; sec <= 24; sec++) {
+    cout << "Charge " << sec;
+    for (Int_t socket = 1; socket <= 8; socket++) {
+      cout << "\t" << Form("%10.3f",avgC.Charge[8*(sec-1)+socket-1]);
+      Int_t io = 0;
+      if (socket > 4) io = 1;
+      AcCharge[io] += avgC.Charge[8*(sec-1)+socket-1];
+    }
+    cout << endl;
+  }
+  cout << "Run " << avgC.run << " Accumulated charge Inner = " << AcCharge[0] << " (C), Outer = " << AcCharge[1] << "(C)" << endl;
+}
 #include "St_tpcAnodeHVavgC.h"
 MakeChairInstance(tpcAnodeHVavg,Calibrations/tpc/tpcAnodeHVavg);
 //________________________________________________________________________________

--- a/StRoot/StDetectorDbMaker/St_TpcAvgPowerSupplyC.h
+++ b/StRoot/StDetectorDbMaker/St_TpcAvgPowerSupplyC.h
@@ -35,6 +35,7 @@ class St_TpcAvgPowerSupplyC : public TChair {
   Float_t       AcChargeL(Int_t sector = 1, Int_t channel = 1); // C/cm
   Float_t       AcChargeRowL(Int_t sector = 1, Int_t row = 1) {return AcChargeL(sector,ChannelFromRow(sector,row));}
   Bool_t        livePadrow(Int_t sec = 1, Int_t padrow = 1) const { return voltagePadrow(sec,padrow) >  500;}
+  void          PrintC() const;
  protected:
   St_TpcAvgPowerSupplyC(St_TpcAvgPowerSupply *table=0) : TChair(table) {}
   virtual ~St_TpcAvgPowerSupplyC() {fgInstance = 0;}

--- a/StRoot/StDetectorDbMaker/St_tpcRDOMasksC.h
+++ b/StRoot/StDetectorDbMaker/St_tpcRDOMasksC.h
@@ -33,13 +33,7 @@ class St_tpcRDOMasksC : public TChair {
     //Function returns the rdo board number for a given padrow index. Range of map used is 1-72
     return St_tpcRDOMapC::instance()->rdo(sector, row, pad);
   }
-  Bool_t        isOn(Int_t sector,Int_t rdo)  {    
-    if(sector < 1 || sector > 24 || rdo < 1 || rdo > 8)	return 0;
-    UInt_t MASK = getSectorMask(sector);
-    MASK = MASK >> (rdo - 1);
-    MASK &= 0x00000001;
-    return MASK;
-  }
+  Bool_t        isOn(Int_t sector,Int_t rdo);
   Bool_t       isRowOn(Int_t sector, Int_t row, Int_t pad = 1) {return isOn(sector, rdoForPadrow(sector, row, pad));}
  protected:
   St_tpcRDOMasksC(St_tpcRDOMasks *table=0) : TChair(table) {}


### PR DESCRIPTION
Two Updates:
1) An additional correction for dE/dx handled by a new table identified by StTpcdEdxCorrection::kzCorrectionC which is currently activated only for the Run 19 AuAu200 data. The authors claim that the change won't affect any other dataset. A slide illustrating the related problem is available at https://drupal.star.bnl.gov/STAR/event/2022/03/09/SC-Management-Meeting/Run19-AuAu200-Calibration-Status

The change in StRoot/StDetectorDbMaker looks pretty safe as it only adds a diagnostic routine St_TpcAvgPowerSupplyC::PrintC()

2) TPC RDO masking to deal with timestamp issue with full simulation for Run19 data (no impact on embedding).