### PR TITLE
Restore GetCVS() function in StTriggerSimuMaker

### DIFF
--- a/StRoot/StTriggerUtilities/StTriggerSimuMaker.h
+++ b/StRoot/StTriggerUtilities/StTriggerSimuMaker.h
@@ -128,8 +128,8 @@ public:
   void useOfflineDB() { mUseOfflineDB = 1; }
 
 
-  //virtual const char *GetCVS() const
-  //{static const char cvs[]="Tag $Name:  $ $Id: StTriggerSimuMaker.h,v 1.35 2020/04/12 03:56:25 zchang Exp $ built "__DATE__" "__TIME__ ; return cvs;}
+  virtual const char *GetCVS() const
+  {static const char cvs[]="Tag $Name:  $ $Id: StTriggerSimuMaker.h $ built " __DATE__ " " __TIME__ ; return cvs;}
 
   ClassDef(StTriggerSimuMaker,0)
 };


### PR DESCRIPTION
While the CVS tags don't work any longer with the code now sitting in git, the date and time of compilation are still useful pieces of information from this function that are displayed in the log files. Otherwise the date and time of StMaker's compilation are shown for this maker from the inherited function. Additionally, the log files are polluted by a warning message if GetCVS() is not overloaded from StMaker.