### PR TITLE
CODEOWNER update for StEvent/StETOF/EMC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /StRoot/StChain                                    @klendathu2k       @perevbnlgov @fisyak
 /StRoot/StDAQMaker                                 @perevbnlgov       @akioogawa
 /StRoot/StDaqLib                                   @jml985
-/StRoot/StDaqLib/EEMC                              @kkauder           @rkunnawa    @Navagyan
+/StRoot/StDaqLib/EEMC                              @kkauder           @rkunnawa    @zlchang
 /StRoot/StDaqLib/EMC                               @kkauder           @rkunnawa    @Navagyan
 /StRoot/StDaqLib/FPD                               @akioogawa
 /StRoot/StDaqLib/L3                                @jml985            @tonko-lj
@@ -39,12 +39,12 @@
 /StRoot/StDetectorDbMaker/St_tpcSCGLC*             @genevb
 /StRoot/StDetectorDbMaker/St_trigDetSums*          @genevb
 /StRoot/StDetectorDbMaker/St_vertexSeed*           @genevb
-/StRoot/StEEmc*                                    @kkauder           @rkunnawa    @Navagyan
-/StRoot/StEEmcSimulatorMaker                       @kkauder           @rkunnawa    @klendathu2k @Navagyan
-/StRoot/StEEmcUtil                                 @kkauder           @rkunnawa    @klendathu2k @tinglin-physics  @Navagyan
-/StRoot/StEEmcPool                                 @tinglin-physics
+/StRoot/StEEmc*                                    @kkauder           @rkunnawa    @zlchang
+/StRoot/StEEmcSimulatorMaker                       @kkauder           @rkunnawa    @klendathu2k @zlchang
+/StRoot/StEEmcUtil                                 @kkauder           @rkunnawa    @klendathu2k @tinglin-physics @zlchang
+/StRoot/StEEmcPool                                 @tinglin-physics   @zlchang
 /StRoot/StETof*                                    @PhilippWeidenkaff @ideppner    @YannickSoehngen
-/StRoot/StEmc*                                     @kkauder           @rkunnawa    @Navagyan
+/StRoot/StEmc*                                     @kkauder           @rkunnawa    @Navagyan    @zlchang
 /StRoot/StEmbeddingUtilities                       @zhux97
 /StRoot/StEvent*                                   @klendathu2k
 /StRoot/StEvent/StTpc*                             @fisyak

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /StRoot/StAnalysisMaker                            @ullrich-bnl       @fisyak
 /StRoot/StAnalysisUtilities/StHistUtil*            @genevb
 /StRoot/StAssociationMaker                         @ullrich-bnl
-/StRoot/StAssociationMaker/EMC                     @ullrich-bnl       @kkauder     @rkunnawa
+/StRoot/StAssociationMaker/EMC                     @ullrich-bnl       @kkauder     @rkunnawa    @Navagyan
 /StRoot/StBFChain                                  @genevb            @plexoos     @klendathu2k @fisyak
 /StRoot/StBichsel                                  @fisyak
 /StRoot/StBTof*                                    @ZaochenYe         @fgeurts     @starsdong   @jdbrice
@@ -14,8 +14,8 @@
 /StRoot/StChain                                    @klendathu2k       @perevbnlgov @fisyak
 /StRoot/StDAQMaker                                 @perevbnlgov       @akioogawa
 /StRoot/StDaqLib                                   @jml985
-/StRoot/StDaqLib/EEMC                              @kkauder           @rkunnawa
-/StRoot/StDaqLib/EMC                               @kkauder           @rkunnawa
+/StRoot/StDaqLib/EEMC                              @kkauder           @rkunnawa    @Navagyan
+/StRoot/StDaqLib/EMC                               @kkauder           @rkunnawa    @Navagyan
 /StRoot/StDaqLib/FPD                               @akioogawa
 /StRoot/StDaqLib/L3                                @jml985            @tonko-lj
 /StRoot/StDaqLib/SC                                @genevb
@@ -39,14 +39,14 @@
 /StRoot/StDetectorDbMaker/St_tpcSCGLC*             @genevb
 /StRoot/StDetectorDbMaker/St_trigDetSums*          @genevb
 /StRoot/StDetectorDbMaker/St_vertexSeed*           @genevb
-/StRoot/StEEmc*                                    @kkauder           @rkunnawa
-/StRoot/StEEmcSimulatorMaker                       @kkauder           @rkunnawa    @klendathu2k
-/StRoot/StEEmcUtil                                 @kkauder           @rkunnawa    @klendathu2k @tinglin-physics
+/StRoot/StEEmc*                                    @kkauder           @rkunnawa    @Navagyan
+/StRoot/StEEmcSimulatorMaker                       @kkauder           @rkunnawa    @klendathu2k @Navagyan
+/StRoot/StEEmcUtil                                 @kkauder           @rkunnawa    @klendathu2k @tinglin-physics  @Navagyan
 /StRoot/StEEmcPool                                 @tinglin-physics
-/StRoot/StETof*                                    @PhilippWeidenkaff @ideppner
-/StRoot/StEmc*                                     @kkauder           @rkunnawa
+/StRoot/StETof*                                    @PhilippWeidenkaff @ideppner    @YannickSoehngen
+/StRoot/StEmc*                                     @kkauder           @rkunnawa    @Navagyan
 /StRoot/StEmbeddingUtilities                       @zhux97
-/StRoot/StEvent*                                   @klendathu2k       @ullrich-bnl
+/StRoot/StEvent*                                   @klendathu2k
 /StRoot/StEvent/StTpc*                             @fisyak
 /StRoot/StEventUtilities/StEbyET0*                 @genevb
 /StRoot/StEventUtilities/StRedoTracks*             @genevb
@@ -74,7 +74,7 @@
 /StRoot/StMiniDstMaker                             @ullrich-bnl
 /StRoot/StMtd*                                     @marrbnl
 /StRoot/StMuDSTMaker                               @jdbrice
-/StRoot/StMuDSTMaker/EMC                           @kkauder           @rkunnawa
+/StRoot/StMuDSTMaker/EMC                           @kkauder           @rkunnawa    @Navagyan
 /StRoot/StMuDSTMaker/RICHTOF                       @fgeurts           @starsdong
 /StRoot/StPass0CalibMaker                          @genevb            @iraklic
 /StRoot/StPico*                                    @nigmatkulov       @marrbnl     @plexoos
@@ -127,14 +127,14 @@
 /StarDb/AgML*                                      @klendathu2k
 /StarDb/AgiGeometry                                @klendathu2k
 /StarDb/Calibrations                               @genevb
-/StarDb/Calibrations/emc                           @kkauder           @rkunnawa
+/StarDb/Calibrations/emc                           @kkauder           @rkunnawa    @Navagyan
 /StarDb/Calibrations/tof                           @ZaochenYe         @fgeurts
 /StarDb/Calibrations/tpc                           @fisyak           @iraklic
 /StarDb/Calibrations/tracker                       @klendathu2k
 /StarDb/Geometry                                   @genevb            @klendathu2k
 /StarDb/Geometry/tpc                               @fisyak           @iraklic
 /StarDb/VmcGeometry                                @klendathu2k
-/StarDb/emc                                        @kkauder           @rkunnawa
+/StarDb/emc                                        @kkauder           @rkunnawa    @Navagyan
 /StarVMC                                           @klendathu2k
 /StarVMC/geant3                                    @fisyak
 /StarVMC/Geometry                                  @klendathu2k


### PR DESCRIPTION
- Thomas Ullrich (@ullrich-bnl) removed from StEvent directory per request
- Yannick Soehngen (@YannickSoehngen) added for StETOF*
- Navagyan Ghimire (@Navagyan) added for EMC/EEMC related directories