### PR TITLE
Avoid onldb master usage when possible

### DIFF
--- a/StRoot/StFcsFastSimulatorMaker/macro/thresh.pl
+++ b/StRoot/StFcsFastSimulatorMaker/macro/thresh.pl
@@ -1,8 +1,8 @@
 #!/usr/bin/perl
 #
 #  Server and Port depend on run year:
-#   Year : ongoing  onldb:3501
-#          20xx     onlsun1:3400+x-1
+#   Year : ongoing  heston:3501
+#          20xx     db04:3400+year-1
 
 if (@ARGV != 1) {
     printf("thresh.pl run\n");
@@ -10,13 +10,13 @@ if (@ARGV != 1) {
 }
 
 $run = @ARGV[0];
-$year = $run/1000000;
+$year = int(($run - 273000)/1000000); # October 1 rollover date
 
-if($run > 22274000){
-    $server = "onldb.starp.bnl.gov";
+if($run > 22274000){ # This condition will change each year!
+    $server = "heston.star.bnl.gov";
     $port = 3501;
 }else{
-    $server = "onlsun1.starp.bnl.gov";
+    $server = "db04.star.bnl.gov";
     $port = 3400+$year-1;
 }
 

--- a/StRoot/StFgtPool/StFgtQAMaker/macros/runs
+++ b/StRoot/StFgtPool/StFgtQAMaker/macros/runs
@@ -4,7 +4,7 @@ set day=$1
 set startrun={$1}000
 set endrun={$1}999
 
-set dbserver=onldb.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov
 set dbport=3501
 
 if ( ! -e $day ) then

--- a/StRoot/StFgtPool/StFgtQAMaker/macros/runs
+++ b/StRoot/StFgtPool/StFgtQAMaker/macros/runs
@@ -4,7 +4,8 @@ set day=$1
 set startrun={$1}000
 set endrun={$1}999
 
-set dbserver=onldb2.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov # online
+#set dbserver=heston.star.bnl.gov # offline
 set dbport=3501
 
 if ( ! -e $day ) then

--- a/StRoot/StFgtPool/StFgtQAMaker/macros/runtime
+++ b/StRoot/StFgtPool/StFgtQAMaker/macros/runtime
@@ -2,7 +2,7 @@
 
 set run=$1
 
-set dbserver=onldb.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov
 set dbport=3501
 
 mysql --skip-column-names -h $dbserver --port=$dbport <<END

--- a/StRoot/StFgtPool/StFgtQAMaker/macros/runtime
+++ b/StRoot/StFgtPool/StFgtQAMaker/macros/runtime
@@ -2,7 +2,8 @@
 
 set run=$1
 
-set dbserver=onldb2.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov # online
+#set dbserver=heston.star.bnl.gov # offline
 set dbport=3501
 
 mysql --skip-column-names -h $dbserver --port=$dbport <<END

--- a/StRoot/StFmsDbMaker/macros/fmsBitShiftGainB_db.C
+++ b/StRoot/StFmsDbMaker/macros/fmsBitShiftGainB_db.C
@@ -23,7 +23,7 @@ void fmsBitShiftGainB_db(char* opt="", char* year="15ofl", char* filename="bitsh
     printf("%s idx=%d f2=%s run=%d\n",f1.Data(),idx,f2.Data(),run);
     
     if(run>0){
-	char *onlserver="onldb",*bakserver="db04",*server=0;
+	char *onlserver="heston",*bakserver="db04",*server=0;
 	int  port;
 	int y=run/1000000 -1;
 	if(y == 18){

--- a/StRoot/StFmsDbMaker/macros/fmsBitShiftGain_db.C
+++ b/StRoot/StFmsDbMaker/macros/fmsBitShiftGain_db.C
@@ -23,7 +23,7 @@ void fmsBitShiftGain_db(char* opt="", char* year="15ofl", char* filename="bitshi
     printf("%s idx=%d f2=%s run=%d\n",f1.Data(),idx,f2.Data(),run);
 
     if(run>0){
-	char *onlserver="onldb",*bakserver="dbbak",*server=0;
+	char *onlserver="onldb2",*bakserver="dbbak",*server=0;
 	int  port;
 	int y=run/1000000 -1;
 	if(y == 17){

--- a/StRoot/StFmsDbMaker/macros/fpostPedSV2017_db.C
+++ b/StRoot/StFmsDbMaker/macros/fpostPedSV2017_db.C
@@ -33,7 +33,7 @@ void fpostPedSV2017_db(char* opt="", char* year="", char* filename="fpost_good_p
 
   cout << f1.str() << " idx="<<idx  << " f2="<<f2.str() << " run="<<run << endl;
   
-  char *onlserver="onldb", *bakserver="dbbak", *server=0;
+  char *onlserver="onldb2", *bakserver="dbbak", *server=0;
   int  port = 0;
   int y=run/1000000 -1;
   if(y >= 18){

--- a/StRoot/StFmsDbMaker/macros/fpsGainSV_db.C
+++ b/StRoot/StFmsDbMaker/macros/fpsGainSV_db.C
@@ -24,7 +24,7 @@ void fpsGainSV_db(char* opt="", char* year="", char* filename="fpsgain/pAu200_16
     int run=f2.Atoi();
     printf("%s idx=%d f2=%s run=%d\n",f1.Data(),idx,f2.Data(),run);
     
-    char *onlserver="onldb",*bakserver="dbbak",*server=0;
+    char *onlserver="onldb2",*bakserver="dbbak",*server=0;
     int  port;
     int y=run/1000000 -1;
     if(y == 17){

--- a/StRoot/StFmsDbMaker/macros/fpsPedSV2017_db.C
+++ b/StRoot/StFmsDbMaker/macros/fpsPedSV2017_db.C
@@ -29,7 +29,7 @@ void fpsPedSV2017_db(char* opt="", char* year="", char* filename="fps_good_physi
 
   cout << f1.str() << " idx="<<idx  << " f2="<<f2.str() << " run="<<run << endl;
   
-  char *onlserver="onldb", *bakserver="dbbak", *server=0;
+  char *onlserver="onldb2", *bakserver="dbbak", *server=0;
   int  port = 0;
   int y=run/1000000 -1;
   if(y >= 18){

--- a/StRoot/StFtpcCalibMaker/macros/GetHV.pl
+++ b/StRoot/StFtpcCalibMaker/macros/GetHV.pl
@@ -4,7 +4,8 @@ use DBI;
 use Time::Local;
 use strict;
 # Connect up to RunLog
-my $conrun = join(":","DBI:mysql","RunLog","onldb.starp.bnl.gov:3501");
+my $conrun = join(":","DBI:mysql","RunLog","onldb2.starp.bnl.gov:3501"); # online
+#my $conrun = join(":","DBI:mysql","RunLog","heston.star.bnl.gov:3501"); # offline
 my $dbhrun = DBI->connect($conrun,"","");
 unless (defined($dbhrun)) {
   print STDERR "Bad: $DBI::errstr\n";

--- a/StRoot/StFtpcCalibMaker/macros/GetHV_60sec.pl
+++ b/StRoot/StFtpcCalibMaker/macros/GetHV_60sec.pl
@@ -4,7 +4,8 @@ use DBI;
 use Time::Local;
 use strict;
 # Connect up to RunLog
-my $conrun = join(":","DBI:mysql","RunLog","onldb.starp.bnl.gov:3501");
+my $conrun = join(":","DBI:mysql","RunLog","onldb2.starp.bnl.gov:3501"); # online
+#my $conrun = join(":","DBI:mysql","RunLog","heston.star.bnl.gov:3501"); # offline
 my $dbhrun = DBI->connect($conrun,"","");
 unless (defined($dbhrun)) {
   print STDERR "Bad: $DBI::errstr\n";

--- a/StRoot/StFtpcCalibMaker/macros/ftpc_sqldraw.C
+++ b/StRoot/StFtpcCalibMaker/macros/ftpc_sqldraw.C
@@ -41,7 +41,8 @@ void ftpc_sqldraw(std::string dbpath = "Conditions_ftpc/ftpcTemps/extra1East", s
 	std::getline(ss, mTable, '/');
 	std::getline(ss, mParam, '/');
 
-	std::string dsn = "mysql://onldb.starp.bnl.gov:3502/";
+	std::string dsn = "mysql://onldb2.starp.bnl.gov:3502/"; // online
+	//std::string dsn = "mysql://heston.star.bnl.gov:3502/"; // offline
 	dsn.append(mDatabase);
 	TSQLServer *db = 0;
 	db = TSQLServer::Connect(dsn.c_str(),"staruser", "");

--- a/StRoot/StFtpcCalibMaker/macros/getAvgExtraTemps.C
+++ b/StRoot/StFtpcCalibMaker/macros/getAvgExtraTemps.C
@@ -48,7 +48,9 @@ void getAvgExtraTemps(std::string dbpath = "Conditions_ftpc/ftpcTemps/extra1East
 	std::getline(ss, mTable, '/');
 	std::getline(ss, mParam, '/');
 
-	std::string dsn = "mysql://onldb.starp.bnl.gov:3502/";
+        std::string dsn = "mysql://onldb2.starp.bnl.gov:3502/"; // online
+        //std::string dsn = "mysql://heston.star.bnl.gov:3502/"; // offline
+
 	dsn.append(mDatabase);
 	TSQLServer *db = 0;
 	db = TSQLServer::Connect(dsn.c_str(),"staruser", "");

--- a/StRoot/StSpinPool/StFpsQaMaker/macro/runs
+++ b/StRoot/StSpinPool/StFpsQaMaker/macro/runs
@@ -4,7 +4,8 @@ set day=$1
 set startrun={$1}000
 set endrun={$1}999
 
-set dbserver=onldb2.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov # online
+#set dbserver=heston.star.bnl.gov # offline
 set dbport=3501
 
 if ( ! -e $day ) then
@@ -31,4 +32,5 @@ connect RunLog;
 select runNumber from detectorSet where runNumber>=$startrun and runNumber<=$endrun and detectorID=28;
 END2
 
-# mysql -h onldb2.starp.bnl.gov --port=3501
+# mysql -h onldb2.starp.bnl.gov --port=3501 # online
+# mysql -h heston.star.bnl.gov --port=3501 # offline

--- a/StRoot/StSpinPool/StFpsQaMaker/macro/runs
+++ b/StRoot/StSpinPool/StFpsQaMaker/macro/runs
@@ -31,4 +31,4 @@ connect RunLog;
 select runNumber from detectorSet where runNumber>=$startrun and runNumber<=$endrun and detectorID=28;
 END2
 
-# mysql -h onldb.starp.bnl.gov --port=3501
+# mysql -h onldb2.starp.bnl.gov --port=3501

--- a/StRoot/StSpinPool/StRccCounterMonitor/macro/runs
+++ b/StRoot/StSpinPool/StRccCounterMonitor/macro/runs
@@ -4,7 +4,7 @@ set day=$1
 set startrun={$1}000
 set endrun={$1}999
 
-set dbserver=onldb.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov
 set dbport=3501
 
 if ( ! -e $day ) then

--- a/StRoot/StSpinPool/StRccCounterMonitor/macro/runs
+++ b/StRoot/StSpinPool/StRccCounterMonitor/macro/runs
@@ -4,7 +4,8 @@ set day=$1
 set startrun={$1}000
 set endrun={$1}999
 
-set dbserver=onldb2.starp.bnl.gov
+set dbserver=onldb2.starp.bnl.gov # online
+#set dbserver=heston.star.bnl.gov # offline
 set dbport=3501
 
 if ( ! -e $day ) then

--- a/StRoot/StSvtPool/EventT/MakesvtRDOstripped.C
+++ b/StRoot/StSvtPool/EventT/MakesvtRDOstripped.C
@@ -97,7 +97,7 @@ void WritesvtRDOstripped(svtRDOstripped_st *rows, Int_t date, Int_t time) {
 //________________________________________________________________________________
 void MakesvtRDOstripped(Char_t *FileName="./svtRDOs.txt") {
   /* file svtRDOs.txt is created by
- mysql Conditions_svt -h onldb.starp.bnl.gov -P 3502 \
+ mysql Conditions_svt -h onldb2.starp.bnl.gov -P 3502 \
  -e 'select beginTime,flavor,deactive,barNum,ladNum,rdo,northTemp,southTemp,hvBoardTemp,hvVolt,hvCurr,lvFault from Conditions_svt.svtRDOs where deactive=0 and beginTime > "2007-01-01"' > svtRDOs.txt
   */  
   ///afs/rhic.bnl.gov/star/users/fisyak/.dev/DB/svtRDOs.txtdb01"

--- a/StRoot/macros/calib/TrimBeamLineFiles.C
+++ b/StRoot/macros/calib/TrimBeamLineFiles.C
@@ -51,7 +51,7 @@ having (@t4:=sum(dt.numberOfEvents*ts.numberOfEvents/ds.numberOfEvents))>60
 and (@t3:=mod(avg(dt.filesequence+(10*dt.fileStream)),(@t2:=floor(sum(ts.numberOfEvents)/10000.0)+1)))=0
 ;
 <<EOF
-    > cat query.txt | mysql -h onldb.starp.bnl.gov --port=3501 -C RunLog > output.txt
+    > cat query.txt | mysql -h heston.star.bnl.gov --port=3501 -C RunLog > output.txt
     > root -b -q 'TrimBeamLineFiles.C("output.txt","out.list",2000,0.75)'
 
 


### PR DESCRIPTION
This is a general sweep of code in the repository to avoid accessing the online master DB unless writing, and possibly use offline replicas if not using code from within the online enclave. People tend to copy existing code when they write new codes and it's best if everyone, old and new, makes a habit of reading from replicas (@dmarkh may wish to comment).

@akioogawa , I also updated some logic you use in StRoot/StFcsFastSimulatorMaker/macro/thresh.pl for determining which backup port to access, so please have a look. You were relying on a Jan. 1st rollover from one database to another, but Oct. 1st is more appropriate.

-Gene