### PR TITLE
Add FST hits in MuDst

### DIFF
--- a/StRoot/StMuDSTMaker/COMMON/StMuArrays.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuArrays.cxx
@@ -30,6 +30,7 @@ const char* StMuArrays::arrayNames [__NALLARRAYS__    ] = {"MuEvent","PrimaryVer
 /*fmsArrayNames    [__NFMSARRAYS__    ]*/                  "FmsHit","FmsCluster","FmsPoint","FmsInfo",
 /*fcsArrayNames    [__NFCSARRAYS__    ]*/                  "FcsHit","FcsCluster","FcsPoint", "FcsInfo",
 /*fttArrayNames    [__NFTTARRAYS__    ]*/                  "FttRawHit","FttCluster","FttPoint",
+/*fstArrayNames    [__NFSTARRAYS__    ]*/                  "FstHit",
 /*tofArrayNames    [__NTOFARRAYS__    ]*/                  "TofHit","TofData", "TofRawData",
 /*btofArrayNames   [__NBTOFARRAYS__   ]*/                  "BTofHit","BTofRawHit","BTofHeader", // dongx
 /*etofArrayNames   [__NETOFARRAYS__   ]*/                  "ETofDigi","ETofHit","ETofHeader",   // jdb
@@ -49,7 +50,8 @@ const char** StMuArrays::pmdArrayNames = StMuArrays::emcArrayNames    +__NEMCARR
 const char** StMuArrays::fmsArrayNames = StMuArrays::pmdArrayNames    +__NPMDARRAYS__;
 const char** StMuArrays::fcsArrayNames = StMuArrays::fmsArrayNames    +__NFMSARRAYS__;
 const char** StMuArrays::fttArrayNames = StMuArrays::fcsArrayNames    +__NFCSARRAYS__;
-const char** StMuArrays::tofArrayNames = StMuArrays::fttArrayNames    +__NFTTARRAYS__;
+const char** StMuArrays::fstArrayNames = StMuArrays::fttArrayNames    +__NFTTARRAYS__;
+const char** StMuArrays::tofArrayNames = StMuArrays::fstArrayNames    +__NFSTARRAYS__;
 const char** StMuArrays::btofArrayNames = StMuArrays::tofArrayNames   +__NTOFARRAYS__;  // dongx
 const char** StMuArrays::etofArrayNames = StMuArrays::btofArrayNames  +__NBTOFARRAYS__; // jdb
 const char** StMuArrays::epdArrayNames  = StMuArrays::etofArrayNames  +__NETOFARRAYS__; // MALisa
@@ -78,6 +80,7 @@ const char* StMuArrays::arrayTypes [__NALLARRAYS__    ] = {"StMuEvent","StMuPrim
 /*fmsArrayTypes   [__NFMSARRAYS__     ]*/                  "StMuFmsHit","StMuFmsCluster","StMuFmsPoint","StMuFmsInfo",
 /*fcsArrayTypes   [__NFCSARRAYS__     ]*/                  "StMuFcsHit","StMuFcsCluster","StMuFcsPoint","StMuFcsInfo",
 /*fttArrayTypes   [__NFTTARRAYS__     ]*/                  "StMuFttRawHit","StMuFttCluster","StMuFttPoint",
+/*fstArrayTypes   [__NFSTARRAYS__     ]*/                  "StMuFstHit",
 /*tofArrayTypes   [__NTOFARRAYS__     ]*/                  "StMuTofHit","StTofData","StTofRawData",
 /*btofArrayTypes  [__NBTOFARRAYS__    ]*/                  "StMuBTofHit","StBTofRawHit","StBTofHeader",  // dongx
 /*etofArrayTypes  [__NETOFARRAYS__    ]*/                  "StMuETofDigi","StMuETofHit","StMuETofHeader",  // jdb+fseck
@@ -96,7 +99,8 @@ const char** StMuArrays::pmdArrayTypes  = StMuArrays::emcArrayTypes    +__NEMCAR
 const char** StMuArrays::fmsArrayTypes  = StMuArrays::pmdArrayTypes    +__NPMDARRAYS__;
 const char** StMuArrays::fcsArrayTypes  = StMuArrays::fmsArrayTypes    +__NFMSARRAYS__;
 const char** StMuArrays::fttArrayTypes  = StMuArrays::fcsArrayTypes    +__NFCSARRAYS__;
-const char** StMuArrays::tofArrayTypes  = StMuArrays::fttArrayTypes    +__NFTTARRAYS__;
+const char** StMuArrays::fstArrayTypes  = StMuArrays::fttArrayTypes    +__NFTTARRAYS__;
+const char** StMuArrays::tofArrayTypes  = StMuArrays::fstArrayTypes    +__NFSTARRAYS__;
 const char** StMuArrays::btofArrayTypes = StMuArrays::tofArrayTypes    +__NTOFARRAYS__;  // dongx
 const char** StMuArrays::etofArrayTypes = StMuArrays::btofArrayTypes   +__NBTOFARRAYS__;  // jdb
 const char** StMuArrays::epdArrayTypes  = StMuArrays::etofArrayTypes   +__NETOFARRAYS__; // MALisa
@@ -119,6 +123,7 @@ int   StMuArrays::arraySizes       [__NALLARRAYS__    ] = {1,10,1000,1000,1000,1
 /*fmsArraySizes    [__NFMSARRAYS__    ]*/                  1,1,1,1,
 /*fcsArraySizes    [__NFCSARRAYS__    ]*/                  1,1,1,1,
 /*fttArraySizes    [__NFTTARRAYS__    ]*/                  1,1,1,
+/*fstArraySizes    [__NFSTARRAYS__    ]*/                  1,
 /*tofArraySizes    [__NTOFARRAYS__    ]*/                  100, 200, 1000,
 /*btofArraySizes   [__NBTOFARRAYS__   ]*/                  1000,1000,1,   // dongx
 /*etofArraySizes   [__NETOFARRAYS__   ]*/                  1000,1000,1,   // jdb
@@ -137,7 +142,8 @@ int* StMuArrays::pmdArraySizes = StMuArrays::emcArraySizes     +__NEMCARRAYS__;
 int* StMuArrays::fmsArraySizes = StMuArrays::pmdArraySizes     +__NPMDARRAYS__;
 int* StMuArrays::fcsArraySizes = StMuArrays::fmsArraySizes     +__NFMSARRAYS__;
 int* StMuArrays::fttArraySizes = StMuArrays::fcsArraySizes     +__NFCSARRAYS__;
-int* StMuArrays::tofArraySizes = StMuArrays::fttArraySizes     +__NFTTARRAYS__;
+int* StMuArrays::fstArraySizes = StMuArrays::fttArraySizes     +__NFTTARRAYS__;
+int* StMuArrays::tofArraySizes = StMuArrays::fstArraySizes     +__NFSTARRAYS__;
 int* StMuArrays::btofArraySizes = StMuArrays::tofArraySizes    +__NTOFARRAYS__;  // dongx
 int* StMuArrays::etofArraySizes = StMuArrays::btofArraySizes   +__NBTOFARRAYS__;  // jdb
 int* StMuArrays::epdArraySizes  = StMuArrays::etofArraySizes   +__NETOFARRAYS__;  // MALisa
@@ -157,6 +163,7 @@ int   StMuArrays::arrayCounters       [__NALLARRAYS__ ] = {0,0,0,0,0,0,0,0,0,0,0
 /*fmsArrayCounters    [__NFMSARRAYS__    ]*/               0,0,0,0,
 /*fcsArrayCounters    [__NFCSARRAYS__    ]*/               0,0,0,0,
 /*fttArrayCounters    [__NFTTARRAYS__    ]*/               0,0,0,
+/*fstArrayCounters    [__NFSTARRAYS__    ]*/               0,
 /*tofArrayCounters    [__NTOFARRAYS__    ]*/               0, 0, 0,
 /*btofArrayCounters   [__NBTOFARRAYS__   ]*/               0, 0, 0,      // dongx
 /*etofArrayCounters   [__NETOFARRAYS__   ]*/               0, 0, 0,      // jdb
@@ -177,7 +184,8 @@ int* StMuArrays::pmdArrayCounters = StMuArrays::emcArrayCounters     +__NEMCARRA
 int* StMuArrays::fmsArrayCounters = StMuArrays::pmdArrayCounters     +__NPMDARRAYS__;
 int* StMuArrays::fcsArrayCounters = StMuArrays::fmsArrayCounters     +__NFMSARRAYS__;
 int* StMuArrays::fttArrayCounters = StMuArrays::fcsArrayCounters     +__NFCSARRAYS__;
-int* StMuArrays::tofArrayCounters = StMuArrays::fttArrayCounters     +__NFTTARRAYS__;
+int* StMuArrays::fstArrayCounters = StMuArrays::fttArrayCounters     +__NFTTARRAYS__;
+int* StMuArrays::tofArrayCounters = StMuArrays::fstArrayCounters     +__NFSTARRAYS__;
 int* StMuArrays::btofArrayCounters = StMuArrays::tofArrayCounters    +__NTOFARRAYS__;  // dongx
 int* StMuArrays::etofArrayCounters = StMuArrays::btofArrayCounters   +__NBTOFARRAYS__;  // jdb
 int* StMuArrays::epdArrayCounters = StMuArrays::etofArrayCounters    +__NETOFARRAYS__;  // MALisa

--- a/StRoot/StMuDSTMaker/COMMON/StMuArrays.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuArrays.h
@@ -25,6 +25,8 @@ enum fmsTypes {muFmsHit=0, muFmsCluster, muFmsPoint, muFmsInfo};
 enum fcsTypes {muFcsHit=0, muFcsCluster, muFcsPoint, muFcsInfo}; 
 
 enum fttTypes {muFttRawHit=0, muFttCluster, muFttPoint}; 
+
+enum fstTypes {muFstHit=0}; 
 #ifndef __NO_STRANGE_MUDST__
 /// @enum strangeTypes enumeration to to index the strangeArrays
 enum strangeTypes {smuEv=0, smuEvMc, smuV0, smuV0Mc, smuV0Assoc, smuXi, smuXiMc, smuXiAssoc, smuKink, smuKinkMc, smuKinkAssoc, smuCut};
@@ -65,6 +67,7 @@ __NPMDARRAYS__     =4 ,	///< size of the pmd arrays, i.e. number of TClonesArray
 __NFMSARRAYS__     =4 ,	///< size of the fms arrays, i.e. number of TClonesArrays  
 __NFCSARRAYS__     =4 ,  ///< size of the fcs arrays, i.e. number of TClonesArrays  
 __NFTTARRAYS__     =3 ,  ///< size of the ftt arrays, i.e. number of TClonesArrays  
+__NFSTARRAYS__     =1 ,  ///< size of the fst arrays, i.e. number of TClonesArrays  
 // run 5 - dongx
 __NTOFARRAYS__     =3 ,  ///< size of the tof arrays >
 __NBTOFARRAYS__    =3 ,  /// dongx
@@ -76,9 +79,9 @@ __NEZTARRAYS__     =5 ,  ///< size of the ez arrays >
      
 /// dongx
 #ifndef __NO_STRANGE_MUDST__
-__NALLARRAYS__     =  __NARRAYS__+__NSTRANGEARRAYS__+__NMCARRAYS__+__NEMCARRAYS__+__NFMSARRAYS__+__NFCSARRAYS__+__NFTTARRAYS__+__NPMDARRAYS__+__NTOFARRAYS__+__NBTOFARRAYS__+__NETOFARRAYS__+__NEPDARRAYS__+__NMTDARRAYS__+__NFGTARRAYS__+__NEZTARRAYS__
+__NALLARRAYS__     =  __NARRAYS__+__NSTRANGEARRAYS__+__NMCARRAYS__+__NEMCARRAYS__+__NFMSARRAYS__+__NFCSARRAYS__+__NFTTARRAYS__+__NFSTARRAYS__+__NPMDARRAYS__+__NTOFARRAYS__+__NBTOFARRAYS__+__NETOFARRAYS__+__NEPDARRAYS__+__NMTDARRAYS__+__NFGTARRAYS__+__NEZTARRAYS__
 #else
-__NALLARRAYS__     =  __NARRAYS__+__NMCARRAYS__+__NEMCARRAYS__+__NFMSARRAYS__+__NFCSARRAYS__+__NFTTARRAYS__+__NPMDARRAYS__+__NTOFARRAYS__+__NBTOFARRAYS__+__NETOFARRAYS__+__NEPDARRAYS__+__NMTDARRAYS__+__NFGTARRAYS__+__NEZTARRAYS__
+__NALLARRAYS__     =  __NARRAYS__+__NMCARRAYS__+__NEMCARRAYS__+__NFMSARRAYS__+__NFCSARRAYS__+__NFTTARRAYS__+__NFSTARRAYS__+__NPMDARRAYS__+__NTOFARRAYS__+__NBTOFARRAYS__+__NETOFARRAYS__+__NEPDARRAYS__+__NMTDARRAYS__+__NFGTARRAYS__+__NEZTARRAYS__
 #endif
 };
 class StMuArrays {
@@ -96,6 +99,7 @@ class StMuArrays {
     static const char**      fmsArrayNames;//[__NFMSARRAYS__    ]
     static const char**      fcsArrayNames;//[__NFCSARRAYS__    ]
     static const char**      fttArrayNames;//[__NFTTARRAYS__    ]
+    static const char**      fstArrayNames;//[__NFSTARRAYS__    ]
     static const char**      tofArrayNames;//[__NTOFARRAYS__    ]
     static const char**     btofArrayNames;//[__NBTOFARRAYS__   ] // dongx
     static const char**     etofArrayNames;//[__NETOFARRAYS__   ] // jdb
@@ -115,6 +119,7 @@ class StMuArrays {
     static const char**  fmsArrayTypes;//    [__NFMSARRAYS__    ]
     static const char**  fcsArrayTypes;//    [__NFCSARRAYS__    ]
     static const char**  fttArrayTypes;//    [__NFTTARRAYS__    ]
+    static const char**  fstArrayTypes;//    [__NFSTARRAYS__    ]
     static const char**  tofArrayTypes;//    [__NTOFARRAYS__    ]
     static const char**  btofArrayTypes;//   [__NBTOFARRAYS__   ]  // dongx
     static const char**  etofArrayTypes;//   [__NETOFARRAYS__   ]  // jdb
@@ -134,6 +139,7 @@ class StMuArrays {
     static int*       fmsArraySizes;// [__NFMSARRAYS__    ]
     static int*       fcsArraySizes;// [__NFCSARRAYS__    ]
     static int*       fttArraySizes;// [__NFTTARRAYS__    ]
+    static int*       fstArraySizes;// [__NFSTARRAYS__    ]
     static int*       tofArraySizes;// [__NTOFARRAYS__    ]
     static int*       btofArraySizes;// [__NBTOFARRAYS__   ]  // dongx
     static int*       etofArraySizes;// [__NETOFARRAYS__   ]  // jdb
@@ -153,6 +159,7 @@ class StMuArrays {
     static int*    fmsArrayCounters;// [__NFMSARRAYS__    ]
     static int*    fcsArrayCounters;// [__NFCSARRAYS__    ]
     static int*    fttArrayCounters;// [__NFTTARRAYS__    ]
+    static int*    fstArrayCounters;// [__NFSTARRAYS__    ]
     static int*    tofArrayCounters;// [__NTOFARRAYS__    ]
     static int*   btofArrayCounters;// [__NBTOFARRAYS__   ]  // dongx
     static int*   etofArrayCounters;// [__NETOFARRAYS__   ]  // jdb

--- a/StRoot/StMuDSTMaker/COMMON/StMuDst.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDst.cxx
@@ -31,6 +31,7 @@
 #include "StMuFmsUtil.h"
 #include "StMuFcsUtil.h"
 #include "StMuFttUtil.h"
+#include "StMuFstUtil.h"
 #include "StMuPmdUtil.h"
 ///dongx
 #include "StBTofCollection.h"
@@ -65,6 +66,7 @@ TClonesArray** StMuDst::emcArrays            = 0;
 TClonesArray** StMuDst::fmsArrays            = 0;
 TClonesArray** StMuDst::fcsArrays            = 0;
 TClonesArray** StMuDst::fttArrays            = 0;
+TClonesArray** StMuDst::fstArrays            = 0;
 TClonesArray** StMuDst::pmdArrays            = 0;
 TClonesArray** StMuDst::tofArrays            = 0;
 TClonesArray** StMuDst::btofArrays           = 0;   /// dongx
@@ -77,6 +79,7 @@ StMuEmcCollection *StMuDst::mMuEmcCollection = 0;
 StMuFmsCollection *StMuDst::mMuFmsCollection = 0;
 StMuFcsCollection *StMuDst::mMuFcsCollection = 0;
 StMuFttCollection *StMuDst::mMuFttCollection = 0;
+StMuFstCollection *StMuDst::mMuFstCollection = 0;
 TClonesArray *StMuDst::mMuPmdCollectionArray = 0;
 StMuPmdCollection *StMuDst::mMuPmdCollection = 0;
 StEmcCollection *StMuDst::mEmcCollection     = 0;
@@ -104,6 +107,7 @@ void StMuDst::unset() {
     fmsArrays     = 0;
     fcsArrays     = 0;
     fttArrays     = 0;
+    fstArrays     = 0;
     pmdArrays     = 0;
     tofArrays     = 0;
     btofArrays    = 0;   // dongx
@@ -116,6 +120,7 @@ void StMuDst::unset() {
 	mMuFmsCollection = 0;
     mMuFcsCollection = 0;
     mMuFttCollection = 0;
+    mMuFstCollection = 0;
     mMuPmdCollectionArray = 0;
     mMuPmdCollection = 0;
     mEmcCollection = 0;
@@ -138,6 +143,7 @@ void StMuDst::set(StMuDstMaker* maker) {
   fmsArrays     = maker->mFmsArrays;
   fcsArrays     = maker->mFcsArrays;
   fttArrays     = maker->mFttArrays;
+  fstArrays     = maker->mFstArrays;
   pmdArrays     = maker->mPmdArrays;
   tofArrays     = maker->mTofArrays;
   btofArrays    = maker->mBTofArrays;    // dongx
@@ -152,6 +158,7 @@ void StMuDst::set(StMuDstMaker* maker) {
   mMuFmsCollection      = maker->mFmsCollection;
   mMuFcsCollection      = maker->mFcsCollection;
   mMuFttCollection      = maker->mFttCollection;
+  mMuFstCollection      = maker->mFstCollection;
    mMuPmdCollectionArray = maker->mPmdCollectionArray;
   mMuPmdCollection = maker->mPmdCollection;
   eztArrays     = maker->mEztArrays;
@@ -175,6 +182,7 @@ void StMuDst::set(TClonesArray** theArrays,
 		  TClonesArray** theFmsArrays,
           TClonesArray** theFcsArrays,
           TClonesArray** theFttArrays,
+          TClonesArray** theFstArrays,
 		  TClonesArray** thePmdArrays,
 		  TClonesArray** theTofArrays,
 		  TClonesArray** theBTofArrays,    // dongx
@@ -188,6 +196,7 @@ void StMuDst::set(TClonesArray** theArrays,
  		  StMuFmsCollection *fms,
           StMuFcsCollection *fcs,		  
           StMuFttCollection *ftt,
+          StMuFstCollection *fst,
           TClonesArray* pmd_arr,
 		  StMuPmdCollection *pmd)
 {
@@ -203,6 +212,7 @@ void StMuDst::set(TClonesArray** theArrays,
   fmsArrays     = theFmsArrays;
   fcsArrays     = theFcsArrays;
   fttArrays     = theFttArrays;
+  fstArrays     = theFstArrays;
   fgtArrays     = theFgtArrays;
   pmdArrays     = thePmdArrays;
   tofArrays     = theTofArrays;
@@ -214,6 +224,7 @@ void StMuDst::set(TClonesArray** theArrays,
   mMuFmsCollection = fms;  
   mMuFcsCollection = fcs;
   mMuFttCollection = ftt;
+  mMuFstCollection = fst;
   mMuPmdCollectionArray = pmd_arr;
   mMuPmdCollection = pmd;
   eztArrays     = theEztArrays;
@@ -783,6 +794,13 @@ StEvent* StMuDst::createStEvent() {
   if(ftt) { // transform to StEvent format and fill it
      StFttCollection *FTT = mFttUtil->getFtt(ftt);
      if(FTT) ev->setFttCollection(FTT);
+  }
+  // now get the FST stuff and put it in the StEvent
+  static StMuFstUtil* mFstUtil = new StMuFstUtil();
+  StMuFstCollection *fst = muFstCollection();
+  if(fst) { // transform to StEvent format and fill it
+     StFstHitCollection *FST = mFstUtil->getFst(fst);
+     if(FST) ev->setFstHitCollection(FST);
   }
   // now get the PMD stuff and put it in the StEvent
   static StMuPmdUtil* mPmdUtil = new StMuPmdUtil();

--- a/StRoot/StMuDSTMaker/COMMON/StMuDst.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDst.h
@@ -33,6 +33,7 @@ class StMuEmcCollection;
 class StMuFmsCollection;
 class StMuFcsCollection;
 class StMuFttCollection;
+class StMuFstCollection;
 class StMuPmdCollection;
 
 class StEvent;
@@ -116,6 +117,7 @@ public:
 		    TClonesArray** fms_ptca=0, 
             TClonesArray** fcs_ptca=0, 
             TClonesArray** ftt_ptca=0, 
+            TClonesArray** fst_ptca=0, 
 		    TClonesArray** pmd_ptca=0, 
 		    TClonesArray** tof_ptca=0, 
 		    TClonesArray** btof_ptca=0,
@@ -129,6 +131,7 @@ public:
 		    StMuFmsCollection *fms_col=0, 
             StMuFcsCollection *fcs_col=0, 
             StMuFttCollection *ftt_col=0, 
+            StMuFstCollection *fst_col=0, 
 		    TClonesArray *pmd_tca=0, 
 		    StMuPmdCollection *pmd_col=0
 );
@@ -184,6 +187,8 @@ public:
   static TClonesArray** fcsArrays;
   /// array of TClonesArrays for the stuff inherited from the Ftt
   static TClonesArray** fttArrays;
+  /// array of TClonesArrays for the stuff inherited from the Fst
+  static TClonesArray** fstArrays;
   /// array of TClonesArrays for the stuff inherited from the Pmd 
   static TClonesArray** pmdArrays;
   /// array of TClonesArrays for the stuff inherited from the TOF
@@ -210,6 +215,8 @@ public:
   static StMuFcsCollection *mMuFcsCollection; 
   /// pointer to FttCollection (manages the FttArrays)
   static StMuFttCollection *mMuFttCollection; 
+  /// pointer to FstCollection (manages the FstArrays)
+  static StMuFstCollection *mMuFstCollection; 
   /// pointer to PmdCollection (manages the PmdArrays)
   static StMuPmdCollection *mMuPmdCollection;
   /// pointer to EmcCollecion (for Emc clusterfinding etc)
@@ -247,6 +254,8 @@ public:
   static TClonesArray* fcsArray(int type) { return fcsArrays[type]; }
   /// returns pointer to the n-th TClonesArray from the ftt arrays
   static TClonesArray* fttArray(int type) { return fttArrays[type]; }
+  /// returns pointer to the n-th TClonesArray from the fst arrays
+  static TClonesArray* fstArray(int type) { return fstArrays[type]; }
     /// returns pointer to the n-th TClonesArray from the pmd arrays
   static TClonesArray* pmdArray(int type) { return pmdArrays[type]; }
   /// returns pointer to the n-th TClonesArray from the tof arrays
@@ -361,6 +370,8 @@ public:
   static StMuFcsCollection* muFcsCollection() { return mMuFcsCollection; }
   /// returns pointer to current StMuFttCollection
   static StMuFttCollection* muFttCollection() { return mMuFttCollection; }
+  /// returns pointer to current StMuFstCollection
+  static StMuFstCollection* muFstCollection() { return mMuFstCollection; }
   /// returns pointer to current StMuPmdCollection
   static StMuPmdCollection* pmdCollection() { if (mMuPmdCollectionArray)  return (StMuPmdCollection*) mMuPmdCollectionArray->UncheckedAt(0); else return mMuPmdCollection; }
   /// returns pointer to current StEmcCollection

--- a/StRoot/StMuDSTMaker/COMMON/StMuDst.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDst.h
@@ -517,7 +517,7 @@ public:
   friend class StMuIOMaker;
 
   // Increment this by 1 every time the class structure is changed
-  ClassDef(StMuDst,5)
+  ClassDef(StMuDst,6)
 };
 
 #endif

--- a/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.h
@@ -399,7 +399,7 @@ virtual   void closeRead();
   //  StMuEpdHitCollection *mMuEpdHitCollection;   // MALisa
 
   // Increment this by 1 every time the class structure is changed
-  ClassDef(StMuDstMaker, 8)
+  ClassDef(StMuDstMaker, 9)
 };
 
 inline StMuDst* StMuDstMaker::muDst() { return mStMuDst;}

--- a/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.h
@@ -68,6 +68,10 @@ class StMuFcsUtil;
 #include "StMuFttCollection.h"
 class StMuFttUtil;
 
+/// fst stuff
+#include "StMuFstCollection.h"
+class StMuFstUtil;
+
 #include "StMuEpdHitCollection.h" // MALisa
 class StMuEpdUtil;
 /// PMD by Supriya Das
@@ -182,6 +186,7 @@ class StMuDstMaker : public StIOInterFace {
   StMuFmsUtil* muFmsUtil() { return mFmsUtil; } ///< return pointer to StMuFmsUtil;
   StMuFcsUtil* muFcsUtil() { return mFcsUtil; } ///< return pointer to StMuFcsUtil;
   StMuFttUtil* muFttUtil() { return mFttUtil; } ///< return pointer to StMuFttUtil;
+  StMuFstUtil* muFstUtil() { return mFstUtil; } ///< return pointer to StMuFstUtil;
   StMuPmdUtil* muPmdUtil() { return mPmdUtil; } ///< return pointer to StMuPmdUtil;
 
   virtual const char *GetCVS() const {  ///< Returns version tag.
@@ -198,6 +203,7 @@ protected:
   void connectFmsCollection();
   void connectFcsCollection();
   void connectFttCollection();
+  void connectFstCollection();
   void connectPmdCollection();
   enum ioMode {ioRead, ioWrite};
   /** Specifies the way the output file name is contructed when creating muDsts.
@@ -221,6 +227,7 @@ protected:
   StMuFmsUtil* mFmsUtil;
   StMuFcsUtil* mFcsUtil;
   StMuFttUtil* mFttUtil;
+  StMuFstUtil* mFstUtil;
   StMuPmdUtil* mPmdUtil;
   StMuTofUtil* mTofUtil;
   /// dongx
@@ -299,6 +306,7 @@ virtual   void closeRead();
   void fillFms(StEvent* ev);
   void fillFcs(StEvent* ev);
   void fillFtt(StEvent* ev);
+  void fillFst(StEvent* ev);
 #ifndef __NO_STRANGE_MUDST__
   void fillStrange(StStrangeMuDstMaker*);
 #endif
@@ -368,6 +376,7 @@ virtual   void closeRead();
   TClonesArray** mFmsArrays;    //[__NFMSARRAYS__    ];
   TClonesArray** mFcsArrays;    //[__NFCSARRAYS__    ];
   TClonesArray** mFttArrays;    //[__NFTTARRAYS__    ];
+  TClonesArray** mFstArrays;    //[__NFSTARRAYS__    ];
   TClonesArray** mPmdArrays;    //[__NPMDARRAYS__    ];
   TClonesArray** mTofArrays;    //[__NTOFARRAYS__    ];
   /// dongx
@@ -384,6 +393,7 @@ virtual   void closeRead();
   StMuFmsCollection *mFmsCollection;
   StMuFcsCollection *mFcsCollection;
   StMuFttCollection *mFttCollection;
+  StMuFstCollection *mFstCollection;
   TClonesArray*  mPmdCollectionArray; // Needed to hold old format
   StMuPmdCollection *mPmdCollection;
   //  StMuEpdHitCollection *mMuEpdHitCollection;   // MALisa

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstCollection.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstCollection.cxx
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *
+ * $Id: StMuFstCollection.cxx
+ *
+ * Author: tchuang, 2022
+ ***************************************************************************
+ *
+ * Description: Fst data interface to StMuFstHit
+ *
+ ***************************************************************************/
+
+#include "StMuDSTMaker/COMMON/StMuFstCollection.h"
+#include "StMuDSTMaker/COMMON/StMuFstHit.h"
+
+#include "St_base/StMessMgr.h"
+
+ClassImp(StMuFstCollection)
+
+StMuFstCollection::StMuFstCollection() { mHits = 0;  }
+
+StMuFstCollection::~StMuFstCollection() {
+    delete mHits;
+    mHits = nullptr;
+}
+
+void StMuFstCollection::init() {
+    mHits   = new TClonesArray("StMuFstHit", 0);
+}
+
+StMuFstHit* StMuFstCollection::addHit() {
+    if (!mHits) init();
+    int counter = mHits->GetEntriesFast();
+    return new ((*mHits)[counter]) StMuFstHit;
+}
+
+unsigned int StMuFstCollection::numberOfHits() const {
+    if (!mHits) return 0;
+    return mHits->GetEntriesFast();
+}
+
+StMuFstHit* StMuFstCollection::getHit(int index) {
+    if (!mHits) return NULL;
+    return static_cast<StMuFstHit*>(mHits->At(index));
+}

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstCollection.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstCollection.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *
+ * $Id: StMuFstCollection.h
+ *
+ * Author: tchuang, 2022
+ ***************************************************************************
+ *
+ * Description: Fst data interface to StMuFstHit
+ *
+ ***************************************************************************
+ *
+ *
+ **************************************************************************/
+#ifndef StMuFstCollection_hh
+#define StMuFstCollection_hh
+
+#include <TObject.h>
+#include "TClonesArray.h"
+
+class StMuFstHit;
+
+class StMuFstCollection : public TObject {
+public:
+    StMuFstCollection();
+    ~StMuFstCollection();
+    
+    void            init();
+    StMuFstHit*   addHit();
+
+    unsigned int    numberOfHits() const;
+
+    void            setFstHitArray(TClonesArray* array) {mHits=array;}
+
+    StMuFstHit*   getHit(int index);
+
+    TClonesArray*   getHitArray() { return mHits; }
+
+private:
+    TClonesArray* mHits=0;
+
+    ClassDef(StMuFstCollection,1)
+};
+#endif

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstHit.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstHit.cxx
@@ -1,0 +1,60 @@
+/***************************************************************************
+ *
+ * StMuFstHit.cxx
+ *
+ * Author: tchuang 2022
+ ***************************************************************************
+ *
+ * Description: Implementation of StMuFstHit, the StEvent hit structure
+ *
+ ***************************************************************************/
+#include "StMuFstHit.h"
+#include "St_base/StMessMgr.h"
+#include "StEvent/StFstHit.h"
+#include "StThreeVector.hh"
+
+ClassImp(StMuFstHit)
+
+StMuFstHit::StMuFstHit() :  TObject() { /* no op */ }
+
+StMuFstHit::~StMuFstHit() { /* no op */ }
+
+void StMuFstHit::print(int opt) {
+}
+
+void StMuFstHit::setLocalPosition(float vR, float vPhi, float vZ)
+{
+   mLocalPosition[0] = vR;
+   mLocalPosition[1] = vPhi;
+   mLocalPosition[2] = vZ;
+}
+
+float StMuFstHit::localPosition(unsigned int i) const
+{
+   if (i < 3)
+      return mLocalPosition[i];
+   else
+      return 0;
+}
+
+void StMuFstHit::set( StFstHit *hit ){
+    mId = hit->id();
+    mIdTruth = hit->idTruth();
+    mApv = hit->getApv();
+    mMaxTimeBin = hit->getMaxTimeBin();
+    mMeanRStrip = hit->getMeanRStrip();
+    mMeanPhiStrip = hit->getMeanPhiStrip();
+    mCharge = hit->charge();
+    mChargeErr = hit->getChargeErr();
+    mNRawHits = hit->getNRawHits();
+    mNRawHitsR = hit->getNRawHitsR();
+    mNRawHitsPhi = hit->getNRawHitsPhi();
+    mLocalPosition[0] = hit->localPosition(0);
+    mLocalPosition[1] = hit->localPosition(1);
+    mLocalPosition[2] = hit->localPosition(2);
+
+    const StThreeVectorF &pos = hit->position();
+    mXYZ = TVector3( pos.x(), pos.y(), pos.z() );
+
+    mHardwarePosition = hit->hardwarePosition();
+} // set from StEvent

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstHit.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstHit.h
@@ -1,0 +1,125 @@
+/**************************************************************************
+ *
+ * StMuFstHit.h
+ *
+ * Author: tchuang 2022
+ **************************************************************************
+ *
+ * Description: Data class for FST hit in StMuDst
+ *
+ **************************************************************************/
+#ifndef StMuFstHit_h
+#define StMuFstHit_h
+
+#include <TVector3.h>
+#include <TObject.h>
+#include <TRefArray.h>
+#include "StEnumerations.h"
+#include "StEvent/StFstConsts.h"
+
+class StFstHit;
+
+class StMuFstHit : public TObject {
+public:
+    StMuFstHit();
+    ~StMuFstHit();
+
+    int           getId() const;
+    int           getIdTruth() const;
+    unsigned char getDisk() const;
+    unsigned char getWedge() const;
+    unsigned char getSensor() const;
+    unsigned char getApv() const;
+    unsigned char getMaxTimeBin() const;
+    float         getMeanRStrip() const;
+    float         getMeanPhiStrip() const;
+    float         getCharge() const;
+    float         getChargeErr() const;
+    unsigned char getNRawHits() const;
+    unsigned char getNRawHitsR() const;
+    unsigned char getNRawHitsPhi() const;
+    float         localPosition(unsigned int ) const;
+ 
+    void setId(int id);
+    void setIdTruth(int idtruth);
+    void setDisk(unsigned char disk);
+    void setWedge(unsigned char wedge);
+    void setSensor(unsigned char sensor);
+    void setApv(unsigned char apv);
+    void setMaxTimeBin(unsigned char tb);
+    void setCharge(float charge);
+    void setChargeErr(float chargeErr);
+    void setMeanRStrip(float meanRStrip);
+    void setMeanPhiStrip(float meanPhiStrip);
+    void setNRawHits(unsigned char nRawHits);
+    void setNRawHitsR(unsigned char nRawHitsR);
+    void setNRawHitsPhi(unsigned char nRawHitsPhi);
+    void setLocalPosition(float, float, float);
+
+    const TVector3& xyz()   const; // position in global STAR coordinate
+    void setXYZ(const TVector3& p3);
+
+    void setHardwarePosition(int HardwarePosition);
+    
+    void print(int option=0);
+
+    void set( StFstHit *hit );
+
+private:
+
+    Int_t 	mId;
+    Int_t 	mIdTruth;
+    UChar_t mApv;
+    UChar_t mMaxTimeBin;
+    Float_t mMeanRStrip;
+    Float_t mMeanPhiStrip;
+    Float_t mCharge;
+    Float_t mChargeErr;
+    UChar_t mNRawHits;
+    UChar_t mNRawHitsR;
+    UChar_t mNRawHitsPhi;
+    Float_t mLocalPosition[3];
+
+    UInt_t  mHardwarePosition;
+    TVector3  mXYZ;    // position in STAR coordinate
+
+    ClassDef(StMuFstHit, 1)
+};
+
+
+
+inline int           StMuFstHit::getId() const              { return mId;                 };
+inline int           StMuFstHit::getIdTruth() const         { return mIdTruth;            };
+inline unsigned char StMuFstHit::getDisk() const            { return 1 + (mHardwarePosition - 1) / kFstNumSensorsPerWedge / kFstNumWedgePerDisk;};
+inline unsigned char StMuFstHit::getWedge() const           { return 1 + (mHardwarePosition - 1) / kFstNumSensorsPerWedge;};
+inline unsigned char StMuFstHit::getSensor() const          { return (mHardwarePosition - 1) % kFstNumSensorsPerWedge;};
+inline unsigned char StMuFstHit::getApv() const             { return mApv;                };
+inline unsigned char StMuFstHit::getMaxTimeBin() const      { return mMaxTimeBin;         };
+inline float StMuFstHit::getMeanRStrip() const              { return mMeanRStrip;         };
+inline float StMuFstHit::getMeanPhiStrip() const            { return mMeanPhiStrip;       };
+inline float StMuFstHit::getCharge()    const               { return mCharge;             };
+inline float StMuFstHit::getChargeErr()    const            { return mChargeErr;          };
+inline unsigned char StMuFstHit::getNRawHits() const        { return mNRawHits;           };
+inline unsigned char StMuFstHit::getNRawHitsR() const       { return mNRawHitsR;          };
+inline unsigned char StMuFstHit::getNRawHitsPhi() const     { return mNRawHitsPhi;        };
+
+inline const TVector3& StMuFstHit::xyz() const              { return mXYZ;                };
+
+inline void StMuFstHit::setId(int id)                               { mId = id;                     };
+inline void StMuFstHit::setIdTruth(int idtruth)                     { mIdTruth = idtruth;           };
+inline void StMuFstHit::setApv(unsigned char apv)                   { mApv = apv;                   };
+inline void StMuFstHit::setMaxTimeBin(unsigned char tb)             { mMaxTimeBin = tb;             };
+inline void StMuFstHit::setMeanRStrip(float meanRStrip)             { mMeanRStrip = meanRStrip;     };
+inline void StMuFstHit::setMeanPhiStrip(float meanPhiStrip)         { mMeanPhiStrip = meanPhiStrip; };
+inline void StMuFstHit::setCharge(float charge)                     { mCharge = charge;             };
+inline void StMuFstHit::setChargeErr(float chargeErr)               { mChargeErr = chargeErr;       };
+inline void StMuFstHit::setNRawHits(unsigned char nRawHits)         { mNRawHits = nRawHits;         };
+inline void StMuFstHit::setNRawHitsR(unsigned char nRawHitsR)       { mNRawHitsR = nRawHitsR;       };
+inline void StMuFstHit::setNRawHitsPhi(unsigned char nRawHitsPhi)   { mNRawHitsPhi = nRawHitsPhi;   };
+
+inline void StMuFstHit::setXYZ(const TVector3& p3) { mXYZ = p3; }
+
+inline void StMuFstHit::setHardwarePosition(int hardwarePosition)   { mHardwarePosition = hardwarePosition;   };
+
+#endif  // StMuFstHit_h
+

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstUtil.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstUtil.cxx
@@ -1,0 +1,105 @@
+#include "StEvent/StFstHitCollection.h"
+#include "StEvent/StFstHit.h"
+
+#include "StMuDSTMaker/COMMON/StMuFstHit.h"
+#include "StMuDSTMaker/COMMON/StMuFstUtil.h"
+#include "StMuDSTMaker/COMMON/StMuFstCollection.h"
+#include "StMuDSTMaker/COMMON/StMuDst.h"
+#include "StMuDSTMaker/COMMON/StMuEvent.h"
+#include "StEvent/StEvent.h"
+#include "St_base/StMessMgr.h"
+#include "StEvent/StEventTypes.h"
+#include "StEvent/StTriggerData.h"
+#include "StEvent/StContainers.h"
+
+#include <algorithm>  // For std::find
+#include <iterator>  // For std::distance
+
+#include "TCollection.h"  // For TIter
+#include "TRefArray.h"
+#include "TVector3.h"
+
+ClassImp(StMuFstUtil)
+
+StMuFstUtil::StMuFstUtil()
+{
+}
+StMuFstUtil::~StMuFstUtil()
+{
+}
+
+StMuFstCollection* StMuFstUtil::getMuFst(StFstHitCollection *fstcol)
+{
+    LOG_DEBUG << "StMuFstUtil::getMuFst" << endm;
+    if(!fstcol) return NULL;
+    StMuFstCollection* muFst=new StMuFstCollection();
+    fillMuFst(muFst,fstcol);
+    return muFst;
+} // getMuFst
+
+StFstHitCollection* StMuFstUtil::getFst(StMuFstCollection* muFst)
+{
+    if(!muFst) return NULL;
+
+    StFstHitCollection *fst=new StFstHitCollection();
+    fillFst(fst,muFst);
+    return fst;
+} //getFst
+
+void StMuFstUtil::fillMuFst(StMuFstCollection *muFst,StFstHitCollection *fstcol)
+{
+    LOG_INFO << "fillMuFst" << endm;
+    if(!fstcol) return;
+    if(!muFst) return;
+
+    fillMuFstHits(muFst, fstcol);
+
+} // fillMuFst
+
+void StMuFstUtil::fillFst(StFstHitCollection* fstcol,StMuFstCollection* muFst)
+{
+    if(!muFst) return;
+    if(!fstcol) return;
+    fillFstHits(fstcol, muFst);
+} // fillFst
+
+void StMuFstUtil::fillMuFstHits(StMuFstCollection* muFst,
+        StFstHitCollection* fstcol)
+{
+    LOG_INFO << "fillMuFstHits" << endm;
+
+    for(int wedgeIdx=0; wedgeIdx<kFstNumWedges; wedgeIdx++ )
+    {
+        StFstWedgeHitCollection* wedgeHitCollection = fstcol->wedge(wedgeIdx);
+        for(int sensorIdx=0; sensorIdx<kFstNumSensorsPerWedge; sensorIdx++)
+        {
+            StFstSensorHitCollection* sensorHitCollection = wedgeHitCollection->sensor(sensorIdx);
+
+            StSPtrVecFstHit &vecHit = sensorHitCollection->hits();
+            for(unsigned int i=0; i<sensorHitCollection->numberOfHits(); i++)
+            {
+                StMuFstHit* muFstHit = muFst->addHit();
+                muFstHit->set( vecHit[i] );
+            }  // for i hit
+        }  // for sensorIdx
+    }  // for wedgeIdx
+
+} // fillMuFstHits
+
+void StMuFstUtil::fillFstHits(StFstHitCollection* fstcol,
+        StMuFstCollection* muFst)
+{
+    // Using TIter to iterate is safe in the case of hits being NULL
+    TIter next(muFst->getHitArray());
+    StMuFstHit* muHit(NULL);
+    while ((muHit = static_cast<StMuFstHit*>(next())))
+    {
+        StFstHit *newHit = new StFstHit(muHit->getDisk(), muHit->getWedge(), muHit->getSensor(), muHit->getApv(), muHit->getCharge(), muHit->getChargeErr(), muHit->getMaxTimeBin(), muHit->getMeanRStrip(), muHit->getMeanPhiStrip(), muHit->getNRawHits(), muHit->getNRawHitsR(), muHit->getNRawHitsPhi());
+        newHit->setId(muHit->getId());
+        newHit->setIdTruth(muHit->getIdTruth());
+
+        newHit->setLocalPosition(muHit->localPosition(0), muHit->localPosition(1), muHit->localPosition(2)); //set local position on sensor
+
+        fstcol->addHit(newHit);
+    }  // while
+} // fillFstHits

--- a/StRoot/StMuDSTMaker/COMMON/StMuFstUtil.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFstUtil.h
@@ -1,0 +1,35 @@
+#ifndef StMuFstUtil_h
+#define StMuFstUtil_h
+
+#include <TObject.h>
+#include <map>
+
+class StMuFstCollection;
+class StFstHitCollection;
+class StMuDst;
+class StFstHit;
+
+
+class StMuFstUtil : public TObject
+{
+public:
+    StMuFstUtil();
+    ~StMuFstUtil();
+    StMuFstCollection* getMuFst(StFstHitCollection*);
+    StFstHitCollection*   getFst(StMuFstCollection*);
+    void               fillMuFst(StMuFstCollection*,StFstHitCollection*);
+    void               fillFst(StFstHitCollection*,StMuFstCollection*);
+
+
+private:
+
+    /** Create StMuFstHits from StFstHits and fill StMuFstCollection */
+    void fillMuFstHits(StMuFstCollection*, StFstHitCollection*);
+
+    /** fill the StFstHits from MuDst */
+    void fillFstHits(StFstHitCollection*, StMuFstCollection*);
+
+    ClassDef(StMuFstUtil,1)
+};
+
+#endif

--- a/StRoot/StMuDSTMaker/COMMON/StMuTypes.hh
+++ b/StRoot/StMuDSTMaker/COMMON/StMuTypes.hh
@@ -44,3 +44,6 @@
 #include "StMuFttCollection.h"
 #include "StMuFttRawHit.h"
 #include "StMuFttUtil.h"
+#include "StMuFstCollection.h"
+#include "StMuFstHit.h"
+#include "StMuFstUtil.h"


### PR DESCRIPTION
The purpose of this PR is to set up FST hits in MuDst events. 

There are 3 additional classes (6 files) for FST was added (StMuFstCollection, StMuFstHit, and StMuFstUtil).
7 files are modified for adding the FST hits (StMuArrays, StMuDst, StMuDstMaker, and StMuTypes).