### PR TITLE
Fix memory issue in destruction of StBTofGeometry

### DIFF
--- a/StRoot/StBTofUtil/StBTofGeometry.h
+++ b/StRoot/StBTofUtil/StBTofGeometry.h
@@ -33,7 +33,6 @@
 #include "StThreeVectorD.hh"
 #include "StHelixD.hh"
 #include "TVolume.h"
-#include "TVolumePosition.h"
 #include "TVolumeView.h"
 #include "TVolumeViewIter.h"
 #include "StMaker.h"
@@ -49,7 +48,6 @@ class StBTofGeomTray;
 class StBTofGeomSensor;
 class StBTofGeometry;
 
-class TVolumeView;
 class TGeoPhysicalNode;
 class TGeoManager;
 
@@ -92,8 +90,8 @@ class StBTofNode : public TObject {
     StBTofNode() {}
    ~StBTofNode() {
      if ( TestBit(kIsOwner) ) {
+       if (pView != fView->GetPosition()) delete pView;
        delete fView;
-       delete pView;
        delete mMasterNode;
        delete mTVolume;
        delete mTShape;


### PR DESCRIPTION
@PhilippWeidenkaff reported that MuDst->PicoDst conversion jobs were seg faulting at the end. I investigated in gdb and identified the fault as happening in the destructor of StBTofNode of StBTofGeometry. Looking further with valgrind showed that the issue was that the memory at the location of pView had already been deallocated at the deletion of fView in these two lines:

       delete fView;
       delete pView;

...under the circumstance where these two had been allocated through these lines in StBTofGeometry.cxx:

    pView = new TVolumePosition(mTVolume, trans[0], trans[1], trans[2], rotMatrix);
    pView->SetMatrixOwner(true);
    
    fView = new TVolumeView( static_cast<TVolume*>(nullptr), pView);

The problem is resolved by not deleting pView if pView points to the same memory as fView->GetPosition(). There may be better ways to do this, but this solution appears to me to be working.

-Gene