### PR TITLE
ci: don't push containers for :SLYYx, only :SLYYx_z

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'SL*'
     tags:
       - '*'
 


### PR DESCRIPTION
This is a follow up to discussion in https://github.com/star-bnl/star-sw/pull/362#discussion_r892492034.

The SLYYx branches may be modified without a notice. Users should use SLYYx_z tags to get reproducible results. The :main label is left for those folks who like to use stardev.