### PR TITLE
ci: avoid a duplicate step in build-containers.yml

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -32,20 +32,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build latest container for the branch
+      - name: Build a release container
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/star-sw:cache-${{ env.STARENV }}
-          cache-to:   type=registry,ref=ghcr.io/${{ github.repository_owner }}/star-sw:cache-${{ env.STARENV }},mode=max
           build-args: starenv=${{ matrix.starenv }}
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
-
-      - name: Build release container
-        if: steps.branch-name.outputs.is_tag == 'true'
-        uses: docker/build-push-action@v3
-        with:
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/star-sw:cache-${{ env.STARENV }}
-          build-args: starenv=${{ matrix.starenv }}
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.tag }}-${{ env.STARENV }}


### PR DESCRIPTION
Originally, the "latest" containers for a branch were supposed to
provide a cache for the build environment for the PRs and new
tags. Since the switch to the new star-spack infrastructure the
environment is now built elsewhere, the only target left in the local
dockerfile is to build the star-sw itself.