### PR TITLE
[SL22b] Backport #372: Fix misconfigured alignment correction in #358, ...

### DIFF
--- a/StRoot/StETofMatchMaker/StETofMatchMaker.cxx
+++ b/StRoot/StETofMatchMaker/StETofMatchMaker.cxx
@@ -166,7 +166,7 @@ StETofMatchMaker::StETofMatchMaker( const char* name )
   mIsMuDstIn( false ),
   mOuterTrackGeometry( true ),
   mUseHelixSwimmer( false ),
-  mUseOnlyBTofHeaderStartTime( false ),
+  mUseOnlyBTofHeaderStartTime( true ),
   mIsSim( false ),
   mDoQA( false ),
   mDebug( false ),
@@ -306,12 +306,17 @@ StETofMatchMaker::InitRun( Int_t runnumber )
 
         if( !gGeoManager ) {
             LOG_ERROR << "Cannot get GeoManager" << endm;
-            return kStErr;
+            return kStFatal;
         }
 
         LOG_DEBUG << " gGeoManager: " << gGeoManager << endm;
 
         mETofGeom->init( gGeoManager, etofProjection::safetyMargins, mUseHelixSwimmer ); //provide backline to initiating maker to load DB tables
+    }
+
+    if ( mETofGeom && !mETofGeom->isInitDone() ) { //if initialization attempt above failed.
+        LOG_ERROR << "Initialization of StEtofGeometry failed" << endm;
+        return kStFatal;
     }
 
     if( mDoQA ) {


### PR DESCRIPTION
- Changing default start time modus in StEtofMatchMaker to use bTOF only start time instead of eTOF hybrid start time. 
- Added error hand-down from eTOF geometry to matchmaker if no alignment database table is found.

Additional notes:

This patch (PR #372) fixes a bug missed while introducing misalignment parameters for ETOF counters in PR #156
The code was reading a wrong number of entries from the database thus disabling the correction effect for all channels