### PR TITLE
cons: Help agetof to find definition file

### DIFF
--- a/asps/Simulation/starsim/Conscript
+++ b/asps/Simulation/starsim/Conscript
@@ -127,7 +127,6 @@ $env2 = $env->clone('FC'           => $FC,
 		    'CPPFLAGS'     => $CPPFLAGS,
 		    'CPPPATH'      => $CPPPATH,
 		    'DEBUG'        => $DEBUG,
-		    'AGETOFLAGS'   => "",
 		    'LIBS'         => $LIBS,
 		    'ObjDir'       => $obj_dir,
 		    'Libraries'    => $Libraries

--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -210,7 +210,7 @@
     $STIC          = "stic";
     $STICFLAGS     = "";
     $AGETOF        = "agetof";
-    $AGETOFLAGS    = "-V 1";
+    $AGETOFLAGS    = "-V 1 -d $STAR_BIN/agetof.def";
     $LIBSTDC       = `$CC $CFLAGS -print-file-name=libstdc++.a | awk '{ if (\$1 != "libstdc++.a") print \$1}'`;
     chomp($LIBSTDC);
 


### PR DESCRIPTION
When upgrading Spack (used to build the STAR environment in containers) from v0.17.2 to v0.18.1, building with `cons` fails due to an issue with the `agetof` utility. It seems to have trouble finding the definition file `asps/Simulation/agetof/agetof.def` normally installed in `$STAR_BIN` along with the `agetof` executable.

The fix appears to be backward compatible and should work for all versions of `agetof` accepting the argument.