### PR TITLE
cons: Pass PYTHONPATH to build environment

### DIFF
--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -1216,6 +1216,7 @@
 		  'ENV'    => {
 		      'CPATH'           => $CPATH,
 		      'PATH'            => $PATH,
+		      'PYTHONPATH'      => $PYTHONPATH,
 		      'LM_LICENSE_FILE' => $LM_LICENSE_FILE,
 		      'INCLUDE'         => $INCLUDE_PATH,
 		      'ROOT'            => $ROOT,


### PR DESCRIPTION
This variable is not utilized at the moment but is handy when python and
python modules are not installed in the standard location, e.g. when
installed via Spack.