### PR TITLE
Add issue template for bug reports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 *                                                  @plexoos           @nigmatkulov
+.github/                                           @plexoos           @veprbl
 /OnlTools                                          @plexoos           @jml985
 /StDb                                              @dmarkh
 /StDb/idl                                          @akioogawa         @dmarkh      @fgeurts     @iraklic     @fisyak

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+
+**To Reproduce**
+
+Steps to reproduce the behavior.
+
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.


### PR DESCRIPTION
Templates for issues and pull requests can be created as described in the documentation:

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates