### PR TITLE
Addition of StFwdTrack and StFwdTrackCollection to StEvent

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1587,6 +1587,7 @@ Bfc_st BFC[] = { // standard chains
                                                                                                     kFALSE},
   {"fstHit",     "", "fstChain", "event,fstCluster", "StFstHitMaker",       "StFstHitMaker","FST Hit Maker",
                                                                                                     kFALSE},
+  {"fstQA",      "", "fstChain", "fstUtil,StEvent", "StFstQAMaker","StFstQAMaker","Fst QA maker",   kFALSE},
 
   {"ssddat"      ,"","","ssd_daq"                             ,"","","SSD full chain for Real Data",kFALSE},
   {"sstdat"      ,"","","sst_daq"                             ,"","","SST full chain for Real Data",kFALSE},
@@ -1723,7 +1724,9 @@ Bfc_st BFC[] = { // standard chains
   {"fcsPoint"   ,"","fcsChain", "StEvent,fcsDb",
    "StFcsPointMaker","StFcsPointMaker,libMinuit","Fill FCS points",                                 kFALSE},
   // FTT
-  {"ftt","fttChain","","FttDat,FttHitCalib,FttClu,FttPoint", "StMaker","StChain","FST chain"        ,kFALSE}, 
+  {"Ftt","fttChain","","FttDat,FttHitCalib,FttClu,FttPoint", "StMaker","StChain","FST chain"        ,kFALSE}, 
+  {"FttFastSim","","fttChain","StMcEvent,StEvent","StFttFastSimMaker","StFttSimMaker","FTT fast simulator", 
+                                                                                                    kFALSE},
   {"FttDat","","fttChain","StEvent","StFttRawHitMaker","StFttRawHitMaker,StEvent",
                                                             "sTGC Raw hit maker",                   kFALSE},
   {"FttHitCalib","","fttChain","StEvent,MuDST","StFttHitCalibMaker","StFttHitCalibMaker,StFttRawHitMaker,StEvent",
@@ -1734,6 +1737,10 @@ Bfc_st BFC[] = { // standard chains
                                                                              "sTGC Point maker",    kFALSE},
   {"FttQA","","fttChain","","StFttQAMaker","StFttQAMaker", "sTGC Raw hit QA maker",                 kFALSE},
 
+  // forward track maker
+  {"FwdTrack","","","","StFwdTrackMaker",
+  "XMLIO.so,genfit2.so,KiTrack.so,StarGeneratorUtil.so,libMathMore.so,StEventUtilities.so,StEpdUtil,StFwdTrackMaker", 
+                                                            "Forward Track Maker",                  kFALSE},
 
 #if 0
   {"fpd"         ,"fpd","","",                  "StFpdMaker","StFpdMaker","FPD/BBC Data base chain",kFALSE},

--- a/StRoot/StEvent/StContainers.cxx
+++ b/StRoot/StEvent/StContainers.cxx
@@ -193,6 +193,7 @@
 #include "StTrackPidTraits.h"
 #include "StV0Vertex.h"
 #include "StXiVertex.h"
+#include "StFwdTrack.h"
 
 StCollectionImp(BTofHit)
 StCollectionImp(BTofRawHit)
@@ -267,3 +268,4 @@ StCollectionImp(TrackNode)
 StCollectionImp(TrackPidTraits)
 StCollectionImp(V0Vertex)
 StCollectionImp(XiVertex)
+StCollectionImp(FwdTrack)

--- a/StRoot/StEvent/StContainers.h
+++ b/StRoot/StEvent/StContainers.h
@@ -209,6 +209,7 @@ class StTrackNode;
 class StTrackPidTraits;
 class StV0Vertex;
 class StXiVertex;
+class StFwdTrack;
 
 StCollectionDef(BTofHit)
 StCollectionDef(BTofRawHit)
@@ -283,5 +284,6 @@ StCollectionDef(TrackNode)
 StCollectionDef(TrackPidTraits)
 StCollectionDef(V0Vertex)
 StCollectionDef(XiVertex)
+StCollectionDef(FwdTrack)
 
 #endif

--- a/StRoot/StEvent/StEvent.cxx
+++ b/StRoot/StEvent/StEvent.cxx
@@ -254,6 +254,7 @@
 #include "StFstHitCollection.h"
 #include "StTrackNode.h"
 #include "StTrack.h"
+#include "StFwdTrackCollection.h"
 
 #ifndef ST_NO_NAMESPACES
 using std::swap;
@@ -986,6 +987,22 @@ StEvent::trackNodes() const
     return *nodes;
 }
 
+StFwdTrackCollection*
+StEvent::fwdTrackCollection()
+{
+    StFwdTrackCollection *fwdTracks = 0;
+    _lookup(fwdTracks, mContent);
+    return fwdTracks;
+}
+
+const StFwdTrackCollection*
+StEvent::fwdTrackCollection() const
+{
+    StFwdTrackCollection *fwdTrack = 0;
+    _lookup(fwdTrack, mContent);
+    return fwdTrack;
+}
+
 unsigned int
 StEvent::numberOfPrimaryVertices() const
 {
@@ -1436,6 +1453,12 @@ StEvent::setFstHitCollection(StFstHitCollection* val)
 
 void
 StEvent::setPxlHitCollection(StPxlHitCollection* val)
+{
+    _lookupAndSet(val, mContent);
+}
+
+void
+StEvent::setFwdTrackCollection(StFwdTrackCollection* val)
 {
     _lookupAndSet(val, mContent);
 }

--- a/StRoot/StEvent/StEvent.h
+++ b/StRoot/StEvent/StEvent.h
@@ -226,6 +226,7 @@ class StFgtCollection;
 class StPxlHitCollection;
 class StIstHitCollection;
 class StFstHitCollection;
+class StFwdTrackCollection;
 
 class StEvent : public StXRefMain {
 public:
@@ -336,6 +337,9 @@ public:
     StSPtrVecKinkVertex&                kinkVertices();
     const StSPtrVecKinkVertex&          kinkVertices() const;
 
+    StFwdTrackCollection*               fwdTrackCollection();
+    const StFwdTrackCollection*         fwdTrackCollection() const;
+
     StDetectorState*                    detectorState(StDetectorId);
     const StDetectorState*              detectorState(StDetectorId) const;
     
@@ -396,6 +400,7 @@ public:
     void setL3Trigger(StL3Trigger*);
     void setHltEvent(StHltEvent*);
     void setFgtCollection(StFgtCollection*);
+    void setFwdTrackCollection(StFwdTrackCollection*);
     void addPrimaryVertex(StPrimaryVertex*, StPrimaryVertexOrder = orderByNumberOfDaughters);
     void addCalibrationVertex(StCalibrationVertex*);
     void addDetectorState(StDetectorState*);

--- a/StRoot/StEvent/StEventClusteringHints.cxx
+++ b/StRoot/StEvent/StEventClusteringHints.cxx
@@ -182,6 +182,7 @@ StEventClusteringHints::StEventClusteringHints()
     setBranch("StSPtrVecTrackDetectorInfo",  "evt_tracks",   4);
     setBranch("StSPtrVecPrimaryVertex",      "evt_tracks",   4);
     setBranch("StSPtrVecTrackNode",          "evt_tracks",   4);
+    setBranch("StFwdTrackCollection",        "evt_tracks",   4);
     setBranch("StSPtrVecKinkVertex",         "evt_vertices", 5);
     setBranch("StSPtrVecV0Vertex",           "evt_vertices", 5);
     setBranch("StSPtrVecXiVertex",           "evt_vertices", 5);
@@ -269,6 +270,7 @@ StEventClusteringHints::StEventClusteringHints()
     setBranch("StRnDHitCollection",          "event", 1);
     setBranch("StHltEvent",                  "event", 1);
     setBranch("StFgtCollection",             "event", 1);
+    setBranch("StFwdTrackCollection",        "event", 1);
 } 
 
 void

--- a/StRoot/StEvent/StEventTypes.h
+++ b/StRoot/StEvent/StEventTypes.h
@@ -331,4 +331,6 @@
 #include "StIstSensorHitCollection.h" 
 #include "StIstLadderHitCollection.h"
 #include "StIstHitCollection.h"
+#include "StFwdTrackCollection.h"
+#include "StFwdTrack.h"
 #endif

--- a/StRoot/StEvent/StFcsCluster.cxx
+++ b/StRoot/StEvent/StFcsCluster.cxx
@@ -19,6 +19,7 @@
 #include "StMessMgr.h"
 #include "StFcsHit.h"
 #include "StFcsPoint.h"
+#include "StFwdTrack.h"
 
 static const char rcsid[] = "$Id: StFcsCluster.cxx,v 2.1 2021/01/11 20:25:37 ullrich Exp $";
 
@@ -39,6 +40,16 @@ void StFcsCluster::addPoint(StFcsPoint* p) {
 void StFcsCluster::addPoint(StFcsPoint* p1, StFcsPoint* p2) {
     mPoints.push_back(p1);
     mPoints.push_back(p2);
+}
+
+void StFcsCluster::addTrack(StFwdTrack* p){
+    mTracks.push_back(p);
+}
+
+void StFcsCluster::sortTrackByPT() {
+    std::sort(mTracks.begin(), mTracks.end(), [](StFwdTrack* a, StFwdTrack* b) {
+        return b->momentum().perp() < a->momentum().perp();
+    });
 }
 
 void StFcsCluster::print(Option_t *option) const {

--- a/StRoot/StEvent/StFcsCluster.h
+++ b/StRoot/StEvent/StFcsCluster.h
@@ -26,6 +26,7 @@
 #include "StEnumerations.h"
 
 class StFcsPoint;
+class StFwdTrack;
 
 class StFcsCluster : public StObject {
 public:
@@ -61,15 +62,26 @@ public:
     void setChi2Ndf1Photon(float chi2ndfph1);
     void setChi2Ndf2Photon(float chi2ndfph2);
     void setFourMomentum(StLorentzVectorD p4);
+    //Hits
     StPtrVecFcsHit& hits();
     const StPtrVecFcsHit& hits() const;
+    //Neighbors
     void addNeighbor(StFcsCluster* neighbor);
     StPtrVecFcsCluster& neighbor();
     const StPtrVecFcsCluster& neighbor() const;    
+    //Points
     StPtrVecFcsPoint& points();
     const StPtrVecFcsPoint& points() const;
     void addPoint(StFcsPoint* p);
     void addPoint(StFcsPoint* p1, StFcsPoint* p2);
+
+    //Tracks
+    StPtrVecFwdTrack& tracks();
+    const StPtrVecFwdTrack& tracks() const;
+    void addTrack(StFwdTrack* p);
+    void sortTrackByPT();
+
+
     void print(Option_t *option="") const;
 
 private:
@@ -89,8 +101,9 @@ private:
     StPtrVecFcsHit mHits;            // Tower hits of the current cluster
     StPtrVecFcsCluster mNeighbor;    // Neighbor clusters
     StPtrVecFcsPoint mPoints;        // Fitted points (photons) in the cluster
+    StPtrVecFwdTrack mTracks;        // Associated Tracks
 
-    ClassDef(StFcsCluster, 2)
+    ClassDef(StFcsCluster, 3)
 };
 
 
@@ -122,11 +135,16 @@ inline void StFcsCluster::setChi2Ndf1Photon(float chi2ndfph1) { mChi2Ndf1Photon 
 inline void StFcsCluster::setChi2Ndf2Photon(float chi2ndfph2) { mChi2Ndf2Photon = chi2ndfph2; }
 inline void StFcsCluster::setId(int cluid) { mId = cluid; }
 inline void StFcsCluster::setFourMomentum(StLorentzVectorD p4) { mFourMomentum = p4; }
+// Hits
 inline StPtrVecFcsHit& StFcsCluster::hits() { return mHits; }
 inline const StPtrVecFcsHit& StFcsCluster::hits() const { return mHits; }
+// Neighbors
 inline StPtrVecFcsCluster& StFcsCluster::neighbor() { return mNeighbor; }
 inline const StPtrVecFcsCluster& StFcsCluster::neighbor() const { return mNeighbor; }
+//Points
 inline StPtrVecFcsPoint& StFcsCluster::points() { return mPoints; }
 inline const StPtrVecFcsPoint& StFcsCluster::points() const { return mPoints; }
+inline StPtrVecFwdTrack& StFcsCluster::tracks() { return mTracks; }
+inline const StPtrVecFwdTrack& StFcsCluster::tracks() const { return mTracks; }
 
 #endif  // STFCSCLUSTER_H

--- a/StRoot/StEvent/StFwdTrack.cxx
+++ b/StRoot/StEvent/StFwdTrack.cxx
@@ -20,7 +20,7 @@ StFwdTrack::StFwdTrack( genfit::Track *t ) : mGenfitTrack(t), mProjections(0) {
 
 }
 
-const bool StFwdTrack::didFitConverge() const {
+bool StFwdTrack::didFitConverge() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -30,7 +30,7 @@ const bool StFwdTrack::didFitConverge() const {
     return fitStatus->isFitConverged();
 }
 
-const bool StFwdTrack::didFitConvergeFully() const {
+bool StFwdTrack::didFitConvergeFully() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -40,7 +40,7 @@ const bool StFwdTrack::didFitConvergeFully() const {
     return fitStatus->isFitConvergedFully();
 }
 
-const int StFwdTrack::numberOfFailedPoints() const {
+int StFwdTrack::numberOfFailedPoints() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -50,7 +50,7 @@ const int StFwdTrack::numberOfFailedPoints() const {
     return fitStatus->getNFailedPoints();
 }
 
-const double StFwdTrack::chi2() const {
+double StFwdTrack::chi2() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -60,7 +60,7 @@ const double StFwdTrack::chi2() const {
     return fitStatus->getChi2();
 }
 
-const double StFwdTrack::ndf() const {
+double StFwdTrack::ndf() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -70,7 +70,7 @@ const double StFwdTrack::ndf() const {
     return fitStatus->getNdf();
 }
 
-const double StFwdTrack::pval() const {
+double StFwdTrack::pval() const {
     if (!mGenfitTrack)
         return false;
     // uses the default track rep
@@ -83,7 +83,7 @@ const double StFwdTrack::pval() const {
 /* momentum
  * get the track momentum at the first point (PV if included)
  */
-const StThreeVectorD StFwdTrack::momentum() const{
+StThreeVectorD StFwdTrack::momentum() const{
     if (!mGenfitTrack)
         return StThreeVectorD( 0, 0, 0 );
     auto cr = mGenfitTrack->getCardinalRep();
@@ -94,7 +94,7 @@ const StThreeVectorD StFwdTrack::momentum() const{
 /* momentumAt
  * get the track momentum at the nthh point (if available)
  */
-const StThreeVectorD StFwdTrack::momentumAt(int _id) const{
+StThreeVectorD StFwdTrack::momentumAt(int _id) const{
     if (!mGenfitTrack)
         return StThreeVectorD( 0, 0, 0 );
     
@@ -116,12 +116,13 @@ const StThreeVectorD StFwdTrack::momentumAt(int _id) const{
     LOG_INFO << "Momentum at point: " << id << endm;
     return StThreeVectorD( p.X(), p.Y(), p.Z() );
 }
-const char StFwdTrack::charge() const{
+
+char StFwdTrack::charge() const{
     auto cr = mGenfitTrack->getCardinalRep();
     return cr->getCharge(mGenfitTrack->getFittedState(0, cr)); // at the first fit point
 }
 
-const unsigned int StFwdTrack::numberOfFitPoints() const {
+unsigned int StFwdTrack::numberOfFitPoints() const {
     if ( !mGenfitTrack )
         return 0;
     return mGenfitTrack->getNumPoints();

--- a/StRoot/StEvent/StFwdTrack.cxx
+++ b/StRoot/StEvent/StFwdTrack.cxx
@@ -1,0 +1,147 @@
+/***************************************************************************
+ *
+ * $Id: StFwdTrack.cxx
+ *
+ * Author: jdb, Feb 2022
+ ***************************************************************************
+ *
+ * Description: StFwdTrack stores the Forward tracks built from Fst and Ftt
+ *
+ ***************************************************************************/
+
+#include "StEvent/StFwdTrack.h"
+#include "StEvent/StFcsCluster.h"
+#include "GenFit/Track.h"
+#include "StMessMgr.h"
+
+ClassImp( StFwdTrack )
+
+StFwdTrack::StFwdTrack( genfit::Track *t ) : mGenfitTrack(t), mProjections(0) {
+
+}
+
+const bool StFwdTrack::didFitConverge() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->isFitConverged();
+}
+
+const bool StFwdTrack::didFitConvergeFully() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->isFitConvergedFully();
+}
+
+const int StFwdTrack::numberOfFailedPoints() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->getNFailedPoints();
+}
+
+const double StFwdTrack::chi2() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->getChi2();
+}
+
+const double StFwdTrack::ndf() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->getNdf();
+}
+
+const double StFwdTrack::pval() const {
+    if (!mGenfitTrack)
+        return false;
+    // uses the default track rep
+    auto fitStatus = mGenfitTrack->getFitStatus();
+    if ( !fitStatus ) 
+        return false;
+    return fitStatus->getPVal();
+}
+
+/* momentum
+ * get the track momentum at the first point (PV if included)
+ */
+const StThreeVectorD StFwdTrack::momentum() const{
+    if (!mGenfitTrack)
+        return StThreeVectorD( 0, 0, 0 );
+    auto cr = mGenfitTrack->getCardinalRep();
+    TVector3 p = cr->getMom(mGenfitTrack->getFittedState(0, cr));
+    return StThreeVectorD( p.X(), p.Y(), p.Z() );
+}
+
+/* momentumAt
+ * get the track momentum at the nthh point (if available)
+ */
+const StThreeVectorD StFwdTrack::momentumAt(int _id) const{
+    if (!mGenfitTrack)
+        return StThreeVectorD( 0, 0, 0 );
+    
+    int id = _id;
+    if (id >= mGenfitTrack->getNumPoints()){
+        id = mGenfitTrack->getNumPoints() - 1;
+    }
+
+    while ( !mGenfitTrack->getPoint( id ) || !mGenfitTrack->getPoint( id )->getFitterInfo() ){
+        id = id -1;
+        if ( id < 0 ){
+            LOG_WARN << " Cannot get momentum at point: " << _id << endm;
+            return StThreeVectorD( 0, 0, 0 );
+        }
+    } // while valid point
+
+    auto cr = mGenfitTrack->getCardinalRep();
+    TVector3 p = cr->getMom(mGenfitTrack->getFittedState(id, cr));
+    LOG_INFO << "Momentum at point: " << id << endm;
+    return StThreeVectorD( p.X(), p.Y(), p.Z() );
+}
+const char StFwdTrack::charge() const{
+    auto cr = mGenfitTrack->getCardinalRep();
+    return cr->getCharge(mGenfitTrack->getFittedState(0, cr)); // at the first fit point
+}
+
+const unsigned int StFwdTrack::numberOfFitPoints() const {
+    if ( !mGenfitTrack )
+        return 0;
+    return mGenfitTrack->getNumPoints();
+}
+
+StPtrVecFcsCluster& StFwdTrack::ecalClusters() { return mEcalClusters; }
+const StPtrVecFcsCluster& StFwdTrack::ecalClusters() const { return mEcalClusters; }
+void StFwdTrack::addEcalCluster(StFcsCluster* p){mEcalClusters.push_back(p);}
+void StFwdTrack::sortEcalClusterByET() {
+    std::sort(mEcalClusters.begin(), mEcalClusters.end(), [](StFcsCluster* a, StFcsCluster* b) {
+            return b->fourMomentum().perp() < a->fourMomentum().perp();
+        });
+}
+
+StPtrVecFcsCluster& StFwdTrack::hcalClusters() { return mHcalClusters; }
+const StPtrVecFcsCluster& StFwdTrack::hcalClusters() const { return mHcalClusters; }
+void StFwdTrack::addHcalCluster(StFcsCluster* p){mHcalClusters.push_back(p);}
+void StFwdTrack::sortHcalClusterByET() {
+    std::sort(mHcalClusters.begin(), mHcalClusters.end(), [](StFcsCluster* a, StFcsCluster* b) {
+            return b->fourMomentum().perp() < a->fourMomentum().perp();
+        });
+}
+

--- a/StRoot/StEvent/StFwdTrack.h
+++ b/StRoot/StEvent/StFwdTrack.h
@@ -57,27 +57,27 @@ public:
     genfit::Track *mGenfitTrack;
 
     // Quality of the fit
-    const bool   didFitConverge() const;
-    const bool   didFitConvergeFully() const;
-    const int    numberOfFailedPoints() const;
-    const double chi2() const;
-    const double ndf() const;
-    const double pval() const;
+    bool   didFitConverge() const;
+    bool   didFitConvergeFully() const;
+    int    numberOfFailedPoints() const;
+    double chi2() const;
+    double ndf() const;
+    double pval() const;
 
     // error on pT upper and lower 1-sigma values
     // add access to cov matrix
 
     // Number of fit points used by GenFit
-    const unsigned int   numberOfFitPoints() const;
-    // const unsigned int   numberOfPossibleFitPoints() const;
+    unsigned int   numberOfFitPoints() const;
+    // unsigned int   numberOfPossibleFitPoints() const;
 
     // Number of points used in the track seed step
-    // const unsigned int   numberOfSeedPoints() const;
+    // unsigned int   numberOfSeedPoints() const;
 
     // momentum at the primary vertex
-    const StThreeVectorD momentum() const;
-    const StThreeVectorD momentumAt(int _id = 1) const;
-    const char charge() const;
+    StThreeVectorD momentum() const;
+    StThreeVectorD momentumAt(int _id = 1) const;
+    char charge() const;
 
     StPtrVecFcsCluster& ecalClusters();
     const StPtrVecFcsCluster& ecalClusters() const;

--- a/StRoot/StEvent/StFwdTrack.h
+++ b/StRoot/StEvent/StFwdTrack.h
@@ -1,0 +1,101 @@
+/***************************************************************************
+ *
+ * $Id: StFwdTrack.h,v 2.1 2021/01/11 20:25:37 ullrich Exp $
+ *
+ * Author: jdb, Feb 2022
+ ***************************************************************************
+ *
+ * Description: StFwdTrack stores the Forward tracks built from Fst and Ftt
+ *
+ ***************************************************************************
+ *
+ * $Log: StFwdTrack.h,v $
+ * Revision 2.1  2021/01/11 20:25:37  ullrich
+ * Initial Revision
+ *
+ **************************************************************************/
+#ifndef StFwdTrack_hh
+#define StFwdTrack_hh
+
+#include "Stiostream.h"
+#include "StObject.h"
+#include <vector>
+#include "StThreeVectorD.hh"
+#include "StContainers.h"
+
+namespace genfit {
+    class Track;
+}
+
+class StFcsCluster;
+
+struct StFwdTrackProjection {
+    StFwdTrackProjection() {}
+    StFwdTrackProjection( StThreeVectorD xyz, float c[9] ) {
+        XYZ = xyz;
+        memcpy( cov, c, sizeof(cov) );
+    }
+    StThreeVectorD XYZ;
+    float cov[9];
+
+    float dx(){
+        return sqrt( cov[0] );
+    }
+    float dy(){
+        return sqrt( cov[4] );
+    }
+    float dz(){
+        return sqrt( cov[8] );
+    }
+};
+
+class StFwdTrack : public StObject {
+
+public:
+    StFwdTrack( genfit::Track * );
+    vector<StFwdTrackProjection> mProjections;
+    genfit::Track *mGenfitTrack;
+
+    // Quality of the fit
+    const bool   didFitConverge() const;
+    const bool   didFitConvergeFully() const;
+    const int    numberOfFailedPoints() const;
+    const double chi2() const;
+    const double ndf() const;
+    const double pval() const;
+
+    // error on pT upper and lower 1-sigma values
+    // add access to cov matrix
+
+    // Number of fit points used by GenFit
+    const unsigned int   numberOfFitPoints() const;
+    // const unsigned int   numberOfPossibleFitPoints() const;
+
+    // Number of points used in the track seed step
+    // const unsigned int   numberOfSeedPoints() const;
+
+    // momentum at the primary vertex
+    const StThreeVectorD momentum() const;
+    const StThreeVectorD momentumAt(int _id = 1) const;
+    const char charge() const;
+
+    StPtrVecFcsCluster& ecalClusters();
+    const StPtrVecFcsCluster& ecalClusters() const;
+    void addEcalCluster(StFcsCluster* p);
+    void sortEcalClusterByET();
+
+    StPtrVecFcsCluster& hcalClusters();
+    const StPtrVecFcsCluster& hcalClusters() const;
+    void addHcalCluster(StFcsCluster* p);
+    void sortHcalClusterByET();
+
+protected:
+    StPtrVecFcsCluster mEcalClusters;
+    StPtrVecFcsCluster mHcalClusters;
+
+    ClassDef(StFwdTrack,1)
+
+};
+
+#endif
+

--- a/StRoot/StEvent/StFwdTrackCollection.cxx
+++ b/StRoot/StEvent/StFwdTrackCollection.cxx
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *
+ * $Id: StFwdTrackCollection.cxx
+ *
+ * Author: jdb, Feb 2022
+ ***************************************************************************
+ *
+ * Description: Forward Tracks
+ *
+ *
+ **************************************************************************/
+
+#include "StEvent/StFwdTrackCollection.h"
+#include "StEvent/StFwdTrack.h"
+
+ClassImp(StFwdTrackCollection)
+
+void StFwdTrackCollection::addTrack( StFwdTrack *track ) {
+	mTracks.push_back( track );
+}
+
+StSPtrVecFwdTrack& StFwdTrackCollection::tracks() {
+	return mTracks;
+}
+
+const StSPtrVecFwdTrack& StFwdTrackCollection::tracks() const {
+	return mTracks;
+}
+
+unsigned int StFwdTrackCollection::numberOfTracks() const {
+	return mTracks.size();
+}
+

--- a/StRoot/StEvent/StFwdTrackCollection.h
+++ b/StRoot/StEvent/StFwdTrackCollection.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *
+ * $Id: StFwdTrackCollection.h,v 2.1 2021/01/11 20:25:37 ullrich Exp $
+ *
+ * Author: jdb, Feb 2022
+ ***************************************************************************
+ *
+ * Description:
+ *
+ **************************************************************************/
+#ifndef StFwdTrackCollection_hh
+#define StFwdTrackCollection_hh
+
+#include "StObject.h"
+#include "StContainers.h"
+
+class StFwdTrack;
+
+class StFwdTrackCollection : public StObject {
+public:
+    // StFwdTrackCollection();
+    // ~StFwdTrackCollection();
+
+    void addTrack(StFwdTrack*);              // Add a track
+    StSPtrVecFwdTrack& tracks();             // Return the track list
+    const StSPtrVecFwdTrack& tracks() const; // Return the track list
+    unsigned int numberOfTracks() const;     // Return the number of tracks
+
+    // void print(int option=1);
+
+private:
+    StSPtrVecFwdTrack   mTracks;   //tracks
+
+    ClassDef(StFwdTrackCollection,1)
+
+};
+
+#endif


### PR DESCRIPTION
Builds on FWD upgrade PR 396 (BFC additions)

cons +StRoot/StEvent succeeds but just cons fails with inability to find the StPtrVecFwdTrack based on new StFwdTrack class