### PR TITLE
ci: Bump starenv to v0.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG starenv=root5
 # Pick one from [gcc485, gcc11]
 ARG compiler=gcc485
 
-FROM ghcr.io/star-bnl/star-spack:v0.1.7-${starenv}-${compiler}
+FROM ghcr.io/star-bnl/star-spack:v0.2.3-${starenv}-${compiler}
 
 ENV NODEBUG=yes
 ENV STAR=/star-sw


### PR DESCRIPTION
The new starenv release is based on spack v0.18.1

See https://github.com/star-bnl/star-spack/releases for details