### PR TITLE
cons: Use xml2-config to set up external dependency

### DIFF
--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -1049,6 +1049,7 @@
 	    "LIBDIR = $LoggerLIBDIR \tLoggerINCDIR = $LoggerINCDIR \tLoggerLIBS = $LoggerLIBS\n"
 	    if $LoggerLIBDIR && ! $param::quiet;
     }
+
     # xml2
     my  ($XMLINCDIR,$XMLLIBDIR,$XMLLIBS) = ("","","");
     my ($xml) =  script::find_lib($MYSTAR . "/bin /usr/bin " . $LIBXML2_DIR . "/bin " . dirname(`which xml2-config`),
@@ -1071,15 +1072,6 @@
 	    # and fix -L / should work for both 32 and 64
 	    $XMLLIBDIR = "/usr/$LLIB";
 	}
-
-
-	# ($XMLLIBDIR,$XMLLIBS) = split(' ', $XML);
-	# if ($XMLLIBDIR =~ /-L/){
-	#    $XMLLIBDIR =~ s/-L//;
-	# } else {
-	#    # may not have any -L
-	#    if ($XMLLIBS
-	# }
 
 	my $XMLVersion = `$xml --version`;            # print "XMLVersion = $XMLVersion\n";
 	my ($major,$minor) = split '\.', $XMLVersion; # print "major = $major,minor = $minor\n";

--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -1084,7 +1084,7 @@
     }
     if ( ! $param::quiet ){
         if ( $XMLLIBDIR ){
-            print "Use xml $xml XMLLIBDIR = $XMLLIBDIR \tXMLINCDIR = $XMLINCDIR \tXMLLIBS = $XMLLIBS XMLCPPFlag =$XMLCPPFlag\n";
+            print "Using $xml\n\tXMLLIBDIR = $XMLLIBDIR\n\tXMLINCDIR = $XMLINCDIR\n\tXMLLIBS = $XMLLIBS\n\tXMLCPPFlag = $XMLCPPFlag\n" if !$param::quiet;
         } else {
             print "Use xml -> WARNING ** Could not define XMLLIBDIR, XMLINCDIR, XMLLIBS\n";
         }

--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -1051,43 +1051,43 @@
     }
 
     # xml2
+    chomp(my $xml = `which xml2-config`);
+
+    if ($?) {
+        die "No xml2-config found\n";
+    }
+
     my  ($XMLINCDIR,$XMLLIBDIR,$XMLLIBS) = ("","","");
-    my ($xml) =  script::find_lib($MYSTAR . "/bin /usr/bin " . $LIBXML2_DIR . "/bin " . dirname(`which xml2-config`),
-				  "xml2-config");
-    if ($xml) {
-	$xml .= "/xml2-config";
-	$XMLINCDIR = `$xml --cflags`;
-	chomp($XMLINCDIR);
-	$XMLINCDIR =~ s/-I//;
-	my $XML  = `$xml --libs`; # die "$XML\n";
-	my(@libs)= split(" ", $XML);
 
-	$XMLLIBDIR = shift(@libs);
-	if ($XMLLIBDIR =~ /-L/){
-	    $XMLLIBDIR =~ s/-L//;
-	    $XMLLIBS   = join(" ",@libs);
-	} else {
-	    # no -L, assume all were LIBS
-	    $XMLLIBS   = $XMLLIBDIR ." ".join(" ",@libs);
-	    # and fix -L / should work for both 32 and 64
-	    $XMLLIBDIR = "/usr/$LLIB";
-	}
+    $XMLINCDIR = `$xml --cflags`;
+    chomp($XMLINCDIR);
+    $XMLINCDIR =~ s/-I//;
+    my $XML  = `$xml --libs`; # die "$XML\n";
+    my(@libs)= split(" ", $XML);
 
-	my $XMLVersion = `$xml --version`;            # print "XMLVersion = $XMLVersion\n";
-	my ($major,$minor) = split '\.', $XMLVersion; # print "major = $major,minor = $minor\n";
-	$XMLCPPFlag = "";#-DXmlTreeReader";
-	if ($major < 2 or $major == 2 and $minor < 5) {
-	    $XMLCPPFlag = "-DNoXmlTreeReader";
-	}
-	if ( ! $param::quiet ){
-	    if ( $XMLLIBDIR ){
-		print "Use xml $xml XMLLIBDIR = $XMLLIBDIR \tXMLINCDIR = $XMLINCDIR \tXMLLIBS = $XMLLIBS XMLCPPFlag =$XMLCPPFlag\n";
-	    } else {
-		print "Use xml -> WARNING ** Could not define XMLLIBDIR, XMLINCDIR, XMLLIBS\n";
-	    }
-	}
+    $XMLLIBDIR = shift(@libs);
+    if ($XMLLIBDIR =~ /-L/){
+        $XMLLIBDIR =~ s/-L//;
+        $XMLLIBS   = join(" ",@libs);
     } else {
-	print "Could not find xml libs\n" if (! $param::quiet);
+        # no -L, assume all were LIBS
+        $XMLLIBS   = $XMLLIBDIR ." ".join(" ",@libs);
+        # and fix -L / should work for both 32 and 64
+        $XMLLIBDIR = "/usr/$LLIB";
+    }
+
+    my $XMLVersion = `$xml --version`;            # print "XMLVersion = $XMLVersion\n";
+    my ($major,$minor) = split '\.', $XMLVersion; # print "major = $major,minor = $minor\n";
+    $XMLCPPFlag = "";#-DXmlTreeReader";
+    if ($major < 2 or $major == 2 and $minor < 5) {
+        $XMLCPPFlag = "-DNoXmlTreeReader";
+    }
+    if ( ! $param::quiet ){
+        if ( $XMLLIBDIR ){
+            print "Use xml $xml XMLLIBDIR = $XMLLIBDIR \tXMLINCDIR = $XMLINCDIR \tXMLLIBS = $XMLLIBS XMLCPPFlag =$XMLCPPFlag\n";
+        } else {
+            print "Use xml -> WARNING ** Could not define XMLLIBDIR, XMLINCDIR, XMLLIBS\n";
+        }
     }
 
     chomp($FASTJET_PREFIX = `fastjet-config --prefix`);


### PR DESCRIPTION
When we configure the build with xml2 as external dependency we can rely on xml2-config found in PATH

This is similar to https://github.com/star-bnl/star-sw/pull/357 where we also use config utilities to set up fastjet and gsl packages and #402 for mysql