### PR TITLE
SpinPool Fcs pi0 finder fixing a crash

### DIFF
--- a/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
+++ b/StRoot/StSpinPool/StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx
@@ -247,8 +247,10 @@ Int_t StFcsPi0FinderForEcal::Make() {
       if(tpcvtx) {
 	zTPC=tpcvtx->position().z();
       }else{
-	StMuPrimaryVertex* mutpcvtx=StMuDst::primaryVertex();
-	if(mutpcvtx) zTPC=mutpcvtx->position().z();
+	if (StMuDst::numberOfPrimaryVertices() > 0){
+	  StMuPrimaryVertex* mutpcvtx=StMuDst::primaryVertex();
+	  if(mutpcvtx) zTPC=mutpcvtx->position().z();
+	}
       }
 
       //BBC ZVERTEX


### PR DESCRIPTION
Fix crash on StSpinPool/StFcsPi0FinderForEcal when Mudst has no primary vertex.