### PR TITLE
Encode Geometry Tag w/in DB macros

### DIFF
--- a/StarDb/AgMLGeometry/Geometry.dev13.C
+++ b/StarDb/AgMLGeometry/Geometry.dev13.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev13"); }

--- a/StarDb/AgMLGeometry/Geometry.dev14.C
+++ b/StarDb/AgMLGeometry/Geometry.dev14.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev14"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2016.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2016.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2016"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2020.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2020.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2020"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2021.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2021.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2021"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2022.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2022.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2022"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2022m.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2022m.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2022m"); }

--- a/StarDb/AgMLGeometry/Geometry.dev2022sm.C
+++ b/StarDb/AgMLGeometry/Geometry.dev2022sm.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("dev2022sm"); }

--- a/StarDb/AgMLGeometry/Geometry.devE.C
+++ b/StarDb/AgMLGeometry/Geometry.devE.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("devE"); }

--- a/StarDb/AgMLGeometry/Geometry.eStar2.C
+++ b/StarDb/AgMLGeometry/Geometry.eStar2.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("eStar2"); }

--- a/StarDb/AgMLGeometry/Geometry.y2004.C
+++ b/StarDb/AgMLGeometry/Geometry.y2004.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2004"); }

--- a/StarDb/AgMLGeometry/Geometry.y2004c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2004c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2004c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2004d.C
+++ b/StarDb/AgMLGeometry/Geometry.y2004d.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2004d"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005d.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005d.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005d"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005e.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005e.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005e"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005f.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005f.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005f"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005g.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005g.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005g"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005h.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005h.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005h"); }

--- a/StarDb/AgMLGeometry/Geometry.y2005i.C
+++ b/StarDb/AgMLGeometry/Geometry.y2005i.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2005i"); }

--- a/StarDb/AgMLGeometry/Geometry.y2006.C
+++ b/StarDb/AgMLGeometry/Geometry.y2006.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2006"); }

--- a/StarDb/AgMLGeometry/Geometry.y2006a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2006a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2006a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2006b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2006b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2006b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2006g.C
+++ b/StarDb/AgMLGeometry/Geometry.y2006g.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2006g"); }

--- a/StarDb/AgMLGeometry/Geometry.y2006h.C
+++ b/StarDb/AgMLGeometry/Geometry.y2006h.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2006h"); }

--- a/StarDb/AgMLGeometry/Geometry.y2007.C
+++ b/StarDb/AgMLGeometry/Geometry.y2007.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2007"); }

--- a/StarDb/AgMLGeometry/Geometry.y2007a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2007a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2007a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2007g.C
+++ b/StarDb/AgMLGeometry/Geometry.y2007g.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2007g"); }

--- a/StarDb/AgMLGeometry/Geometry.y2007h.C
+++ b/StarDb/AgMLGeometry/Geometry.y2007h.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2007h"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008d.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008d.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008d"); }

--- a/StarDb/AgMLGeometry/Geometry.y2008e.C
+++ b/StarDb/AgMLGeometry/Geometry.y2008e.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2008e"); }

--- a/StarDb/AgMLGeometry/Geometry.y2009.C
+++ b/StarDb/AgMLGeometry/Geometry.y2009.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2009"); }

--- a/StarDb/AgMLGeometry/Geometry.y2009a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2009a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2009a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2009b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2009b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2009b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2009c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2009c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2009c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2010.C
+++ b/StarDb/AgMLGeometry/Geometry.y2010.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2010"); }

--- a/StarDb/AgMLGeometry/Geometry.y2010a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2010a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2010a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2010b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2010b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2010b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2010c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2010c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2010c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2010x.C
+++ b/StarDb/AgMLGeometry/Geometry.y2010x.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2010x"); }

--- a/StarDb/AgMLGeometry/Geometry.y2011.C
+++ b/StarDb/AgMLGeometry/Geometry.y2011.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2011"); }

--- a/StarDb/AgMLGeometry/Geometry.y2011a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2011a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2011a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2011b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2011b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2011b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2012.C
+++ b/StarDb/AgMLGeometry/Geometry.y2012.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2012"); }

--- a/StarDb/AgMLGeometry/Geometry.y2012a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2012a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2012a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2012b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2012b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2012b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_1.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_1.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_1"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_1a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_1a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_1a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_1b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_1b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_1b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_1c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_1c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_1c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_1x.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_1x.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_1x"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_2.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_2.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_2"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_2a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_2a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_2a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_2b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_2b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_2b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_2c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_2c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_2c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2013_2x.C
+++ b/StarDb/AgMLGeometry/Geometry.y2013_2x.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2013_2x"); }

--- a/StarDb/AgMLGeometry/Geometry.y2014.C
+++ b/StarDb/AgMLGeometry/Geometry.y2014.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2014"); }

--- a/StarDb/AgMLGeometry/Geometry.y2014a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2014a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2014a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2014c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2014c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2014c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2015.C
+++ b/StarDb/AgMLGeometry/Geometry.y2015.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2015"); }

--- a/StarDb/AgMLGeometry/Geometry.y2015a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2015a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2015a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2015b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2015b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2015b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2015c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2015c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2015c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2015d.C
+++ b/StarDb/AgMLGeometry/Geometry.y2015d.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2015d"); }

--- a/StarDb/AgMLGeometry/Geometry.y2016.C
+++ b/StarDb/AgMLGeometry/Geometry.y2016.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2016"); }

--- a/StarDb/AgMLGeometry/Geometry.y2016a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2016a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2016a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2017.C
+++ b/StarDb/AgMLGeometry/Geometry.y2017.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2017"); }

--- a/StarDb/AgMLGeometry/Geometry.y2017a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2017a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2017a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2018.C
+++ b/StarDb/AgMLGeometry/Geometry.y2018.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2018"); }

--- a/StarDb/AgMLGeometry/Geometry.y2018a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2018a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2018a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2018b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2018b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2018b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2018c.C
+++ b/StarDb/AgMLGeometry/Geometry.y2018c.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2018c"); }

--- a/StarDb/AgMLGeometry/Geometry.y2018x.C
+++ b/StarDb/AgMLGeometry/Geometry.y2018x.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2018x"); }

--- a/StarDb/AgMLGeometry/Geometry.y2019.C
+++ b/StarDb/AgMLGeometry/Geometry.y2019.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2019"); }

--- a/StarDb/AgMLGeometry/Geometry.y2019a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2019a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2019a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2019b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2019b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2019b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2020.C
+++ b/StarDb/AgMLGeometry/Geometry.y2020.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2020"); }

--- a/StarDb/AgMLGeometry/Geometry.y2020a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2020a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2020a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2020b.C
+++ b/StarDb/AgMLGeometry/Geometry.y2020b.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2020b"); }

--- a/StarDb/AgMLGeometry/Geometry.y2021.C
+++ b/StarDb/AgMLGeometry/Geometry.y2021.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2021"); }

--- a/StarDb/AgMLGeometry/Geometry.y2021a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2021a.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2021a"); }

--- a/StarDb/AgMLGeometry/Geometry.y2022.C
+++ b/StarDb/AgMLGeometry/Geometry.y2022.C
@@ -1,32 +1,3 @@
+class TDataSet;
 #include "CreateGeometry.h"
-TDataSet *CreateTable() 
-{
-  // Name of the macro including the full path
-  TString myname = gInterpreter->GetCurrentMacroName();
-  
-  // Get an array of TString separated by "/"
-  TObjArray *array = myname.Tokenize("/");
-
-  // Get the name of the macro itself
-  TString name = ((TObjString *)array->Last())->GetString();
-
-  // Isolate the geometry tag
-  array = name.Tokenize(".");
-
-  // Get the geometry tag
-  TString tag = ((TObjString *)array->At(1))->GetString();
-
-  // Ensure that we are not looking at the template
-  if ( tag=="C" )
-    {
-      std::cout << "Please use one of the Geometry.[TAG].C macros" << std::endl;
-      std::cout << "to instantiate the geometry specified by the " << std::endl;
-      std::cout << "given [TAG]." << std::endl;
-      return NULL;
-    }
-
-  // Return the requested geometry
-  return CreateGeometry(tag);
-
-}
-
+TDataSet* CreateTable() { return CreateGeometry("y2022"); }


### PR DESCRIPTION
The Geometry.{tag}.C "database" macros establish the connection between the geometry tag (defined by the BFC chain options and/or timestamp) and the code which instantiates the geometry model.  The macro is loaded / executed by St_db_Maker whenever GetDataBase("VmcGeometry") is called.

This PR encodes the geometry tag inside of each database macro, rather than using the ROOT interpreter's introspection capabilities to read the tag from the filename of the currently executing macro. This works well under ROOT 5 / CINT.  But I think the way that we load macros in St_db_Maker confuses ROOT 6 / CINT.

The simplest solution is to encode the geometry tag within each database macro.