### PR TITLE
[root6] Modify StRoot/StBFChain/BFC.C for ROOT6/cling

### DIFF
--- a/StRoot/StBFChain/BFC.C
+++ b/StRoot/StBFChain/BFC.C
@@ -2,7 +2,7 @@
 #include "TROOT.h"
 #endif
 #include "Bfc.h"
-#if !defined(__CINT__)
+#if !defined(__CINT__) && !defined(__CLING__)
 TableImpl(Bfc);
 #endif
 #include "BigFullChain.h"


### PR DESCRIPTION
StRoot/StBFChain/BFC.C is loaded and executed through the ROOT interpreter in StBFChain::Setup.

ROOT 6 / cling complains about redefinitions when we run the bfc macro.

Minimal solution is to protect the table implementation for "Bfc" from being compiled by the cling interpreter (just like it is protected from compilation by the CINT interpreter).

Likely solves the same problem which Victor was addressing on the Star6 branch.
https://github.com/star-bnl/star-sw/blame/Star6/StRoot/StBFChain/BFC.C#L6