### PR TITLE
docker: Add latest tag to default build configuration

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -42,6 +42,14 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
 
+      - name: Create latest tag for default branch
+        if: ${{ steps.branch-name.outputs.is_default == 'true' && env.STARENV == 'root5-gcc485' }}
+        run: docker buildx imagetools create ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-root5-gcc485 --tag ghcr.io/${{ github.repository_owner }}/star-sw:latest
+
+      - name: Create latest tag for SL* branches
+        if: ${{ steps.branch-name.outputs.is_default == 'false' && env.STARENV == 'root5-gcc485' }}
+        run: docker buildx imagetools create ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-root5-gcc485 --tag ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}
+
   build-cleanup:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -46,6 +46,18 @@ jobs:
         run: |
           docker push ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
 
+      - name: Create latest tag for default branch
+        if: ${{ steps.branch-name.outputs.is_default == 'true' && env.STARENV == 'root5-gcc485' }}
+        run: |
+          docker tag  ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }} ghcr.io/${{ github.repository_owner }}/star-sw:latest
+          docker push ghcr.io/${{ github.repository_owner }}/star-sw:latest
+
+      - name: Create latest tag for SL* branches
+        if: ${{ steps.branch-name.outputs.is_default == 'false' && env.STARENV == 'root5-gcc485' }}
+        run: |
+          docker tag  ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }} ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}
+          docker push ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}
+
   build-cleanup:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -42,14 +42,6 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
 
-      - name: Create latest tag for default branch
-        if: ${{ steps.branch-name.outputs.is_default == 'true' && env.STARENV == 'root5-gcc485' }}
-        run: docker buildx imagetools create ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-root5-gcc485 --tag ghcr.io/${{ github.repository_owner }}/star-sw:latest
-
-      - name: Create latest tag for SL* branches
-        if: ${{ steps.branch-name.outputs.is_default == 'false' && env.STARENV == 'root5-gcc485' }}
-        run: docker buildx imagetools create ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-root5-gcc485 --tag ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}
-
   build-cleanup:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -39,8 +39,12 @@ jobs:
           build-args: |
             starenv=${{ matrix.starenv }}
             compiler=${{ matrix.compiler }}
-          push: true
+          load: true
           tags: ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
+
+      - name: Push container image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/star-sw:${{ steps.branch-name.outputs.current_branch }}-${{ env.STARENV }}
 
   build-cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add customary tags:

```
ghcr.io/star-bnl/star-sw:latest
ghcr.io/star-bnl/star-sw:SL##
```

to the respective branch images:

```
ghcr.io/star-bnl/star-sw:main-root5-gcc485
ghcr.io/star-bnl/star-sw:SL##-root5-gcc485
```

root5-gc485 is currently the default build configuration.