### PR TITLE
Set search paths for included files for ROOT C++ interpreter

### DIFF
--- a/StRoot/macros/rootlogon.C
+++ b/StRoot/macros/rootlogon.C
@@ -30,5 +30,10 @@
 
   std::cout << " *** Start at Date : " << TDatime().AsString() << std::endl;
 
-  gSystem->AddIncludePath(" -I. -I./.$STAR_HOST_SYS/include -I./StRoot -I$STAR/.$STAR_HOST_SYS/include -I$STAR/StRoot -I/usr/include/mysql");
+  gInterpreter->AddIncludePath(".");
+  gInterpreter->AddIncludePath("./.$STAR_HOST_SYS/include");
+  gInterpreter->AddIncludePath("./StRoot");
+  gInterpreter->AddIncludePath("$STAR/.$STAR_HOST_SYS/include");
+  gInterpreter->AddIncludePath("$STAR/StRoot");
+  gInterpreter->AddIncludePath("/usr/include/mysql");
 }


### PR DESCRIPTION
It is my understanding that `TSystem::AddIncludePath()` sets search paths to look for header files only when ACLiC is used. On the other hand, `TInterpreter::AddIncludePath()` sets search paths used by the both interpreter and ACLiC (see the documentation at https://root.cern/root/html534/TCint.html#TCint:AddIncludePath)