### PR TITLE
[root6] Eliminate crash when creating the MuDst

### DIFF
--- a/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
@@ -479,9 +479,7 @@ void  StMuDstMaker::streamerOff() {
   StMuL3EventSummary::Class()->IgnoreTObjectStreamer();
 #ifndef __NO_STRANGE_MUDST__
   StStrangeMuDst::Class()->IgnoreTObjectStreamer();
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0) 
   StStrangeAssoc::Class()->IgnoreTObjectStreamer(); 
-#endif
   StV0MuDst::Class()->IgnoreTObjectStreamer();
   StXiMuDst::Class()->IgnoreTObjectStreamer();
   StKinkMuDst::Class()->IgnoreTObjectStreamer();

--- a/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuDstMaker.cxx
@@ -479,6 +479,9 @@ void  StMuDstMaker::streamerOff() {
   StMuL3EventSummary::Class()->IgnoreTObjectStreamer();
 #ifndef __NO_STRANGE_MUDST__
   StStrangeMuDst::Class()->IgnoreTObjectStreamer();
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0) 
+  StStrangeAssoc::Class()->IgnoreTObjectStreamer(); 
+#endif
   StV0MuDst::Class()->IgnoreTObjectStreamer();
   StXiMuDst::Class()->IgnoreTObjectStreamer();
   StKinkMuDst::Class()->IgnoreTObjectStreamer();

--- a/StRoot/StStrangeMuDstMaker/StStrangeMuDst.cc
+++ b/StRoot/StStrangeMuDstMaker/StStrangeMuDst.cc
@@ -43,4 +43,7 @@ int initializeForWriting() {
   StObject::Class()->GetStreamerInfo()->Build();
   return 1;
 }
+
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 int initialized = initializeForWriting();
+#endif

--- a/StRoot/StStrangeMuDstMaker/StStrangeMuDst.cc
+++ b/StRoot/StStrangeMuDstMaker/StStrangeMuDst.cc
@@ -30,20 +30,3 @@ StStrangeAssoc::StStrangeAssoc(Int_t indexRecoArray, Int_t indexMcArray)
   mIndexRecoArray = indexRecoArray;
   mIndexMcArray   = indexMcArray;
 }
-
-// The following code is necessary as of Root version 3 in order to prevent
-// the fBits and fUniqueID data members of TObject from being saved. It is
-// called upon loading of the library into Root.
-// StObject needs special attention because the StreamerInfo may be read
-// in from an input file, overriding the setting.
-int initializeForWriting() {
-  StStrangeMuDst::Class()->IgnoreTObjectStreamer();
-  StStrangeAssoc::Class()->IgnoreTObjectStreamer();
-  StObject::Class()->IgnoreTObjectStreamer();
-  StObject::Class()->GetStreamerInfo()->Build();
-  return 1;
-}
-
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
-int initialized = initializeForWriting();
-#endif


### PR DESCRIPTION
When creating the MuDst, ROOT6 has a problem with creating the TClonesArray
of StStrangeAssoc objects.   Running under GDB shows that TClass::GetClass enters
an infinite recursion...   almost as if the system is confused, and believes the class is it's
own base class.  

Disabling the call to initializeForWriting() on loading the share library resolves the issue.  
Though I don't know what side effects this may cause.