### PR TITLE
[root6] Set attributes on StrangeMuDstMaker in StBFChain, rather than using interpreter to configure

### DIFF
--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -638,12 +638,12 @@ Int_t StBFChain::Instantiate()
     }
 
     if (maker == "StStrangeMuDstMaker" && GetOption("CMuDST")&& GetOption("StrngMuDST") ) {
-      TString cmd(Form("StStrangeMuDstMaker *pSMMk = (StStrangeMuDstMaker*) %p;",mk));
-      cmd += "pSMMk->DoV0();";                                 // Set StrangeMuDstMaker parameters
-      cmd += "pSMMk->DoXi();";
-      cmd += "pSMMk->DoKink();";
-      cmd += "pSMMk->SetNoKeep();";                            // Set flag for output OFF
-      ProcessLine(cmd);
+
+      mk -> SetAttr( "DoV0", 1 );
+      mk -> SetAttr( "DoXi", 1 );
+      mk -> SetAttr( "DoKink", 1 );
+      mk -> SetAttr( "SetNoKeep", 1 );
+
     }
 
     // Alex requested an option (not turned by default) to disable all

--- a/StRoot/StStrangeMuDstMaker/StStrangeMuDstMaker.cxx
+++ b/StRoot/StStrangeMuDstMaker/StStrangeMuDstMaker.cxx
@@ -90,6 +90,11 @@ StStrangeMuDstMaker::~StStrangeMuDstMaker() {
 //_____________________________________________________________________________
 Int_t StStrangeMuDstMaker::Init() {
 
+  if ( 1 == IAttr( "DoV0" ) ) DoV0();
+  if ( 1 == IAttr( "DoXi" ) ) DoXi();
+  if ( 1 == IAttr( "DoKink" ) ) DoKink();
+  if ( 1 == IAttr( "SetNoKeep" ) ) SetNoKeep(); 
+
   abortEvent = kFALSE;
   firstEvent = kTRUE;
   if (Debug()) gMessMgr->Debug() << "In StStrangeMuDstMaker::Init() ... "


### PR DESCRIPTION
Cling appears to have problems with using ProcessLine to get a pointer to a maker... at least in this context and/or at least in the default environment.  So... 

Refactor to use maker attributes, and set configuration options at initialization time.  (This is also  cleaner and more inline with the StMaker philosophy).