### PR TITLE
[root6] Fix undeclared identifier 'chain' in StarDb/AgMLGeometry/Geometry...C macro

### DIFF
--- a/StarDb/AgMLGeometry/CreateGeometry.h
+++ b/StarDb/AgMLGeometry/CreateGeometry.h
@@ -1,3 +1,7 @@
+#include "StBFChain/StBFChain.h"
+
+extern StBFChain* chain;
+
 /**
  * Adapted from StarDb/VmcGeometry/CreateGeometry.h
  */


### PR DESCRIPTION
See errors reported in ROOT6_test_ignore_fail (120):

```
In file included from input_line_656:1:
In file included from /star-sw/StarDb/AgMLGeometry/Geometry.y2021a.C:2:
/star-sw/StarDb/AgMLGeometry/CreateGeometry.h:15:8: error: use of undeclared identifier 'chain'
  if  (chain)  { filename = chain->GetFileOut(); if ( filename=="" ) filename = chain->GetFileIn();  }
       ^
/star-sw/StarDb/AgMLGeometry/CreateGeometry.h:15:29: error: use of undeclared identifier 'chain'
  if  (chain)  { filename = chain->GetFileOut(); if ( filename=="" ) filename = chain->GetFileIn();  }
                            ^
/star-sw/StarDb/AgMLGeometry/CreateGeometry.h:15:81: error: use of undeclared identifier 'chain'
  if  (chain)  { filename = chain->GetFileOut(); if ( filename=="" ) filename = chain->GetFileIn();  }
```