### PR TITLE
[root6] Address issues in TTable when interpreted by Cling

### DIFF
--- a/StRoot/Table/TTable.cxx
+++ b/StRoot/Table/TTable.cxx
@@ -2465,3 +2465,17 @@ TTable::piterator::piterator(const TTable *t,EColumnType type): fCurrentRowIndex
    }
 } // piterator(TTable *)
 
+void TTable::iterator::operator++()    { ++fCurrentRow;   }
+void TTable::iterator::operator++(int) {   fCurrentRow++; }
+void TTable::iterator::operator--()    { --fCurrentRow;   }
+void TTable::iterator::operator--(int) {   fCurrentRow--; }
+TTable::iterator TTable::iterator::operator+(Int_t idx)   { std::vector<Long_t>::iterator addition   = fCurrentRow+idx; return TTable::iterator(*fThisTable,addition); }
+TTable::iterator TTable::iterator::operator-(Int_t idx)   { std::vector<Long_t>::iterator subtraction = fCurrentRow-idx; return TTable::iterator(*fThisTable,subtraction); }
+void TTable::iterator::operator+=(Int_t idx)  {  fCurrentRow+=idx; }
+void TTable::iterator::operator-=(Int_t idx)  {  fCurrentRow-=idx; }
+void *TTable::iterator::rowPtr() const { return  (void *)(((const char *)fThisTable->GetArray()) + (*fCurrentRow)*fRowSize ); }
+TTable::iterator::operator void *() const { return rowPtr(); }
+Int_t TTable::iterator::operator-(const iterator &it) const { return (*fCurrentRow)-(*(it.fCurrentRow)); }
+Long_t TTable::iterator::operator *() const { return  *fCurrentRow; }
+Bool_t TTable::iterator::operator==(const iterator &t) const { return  ( (fCurrentRow == t.fCurrentRow) && (fThisTable == t.fThisTable) ); }
+Bool_t TTable::iterator::operator!=(const iterator &t) const { return !operator==(t); }

--- a/StRoot/Table/TTable.h
+++ b/StRoot/Table/TTable.h
@@ -185,7 +185,6 @@ public:
          const TTable *fThisTable;
          vec_iterator  fCurrentRow;
       public:
-         iterator(): fRowSize(0), fThisTable(0) {;}
          iterator(const TTable &table, vec_iterator &arowPtr) :
             fRowSize(table.GetRowSize()), fThisTable(&table), fCurrentRow(arowPtr) {;}
          iterator(const TTable &table, vec_const_iterator &arowPtr) :

--- a/StRoot/Table/TTable.h
+++ b/StRoot/Table/TTable.h
@@ -194,20 +194,20 @@ public:
             //fCurrentRow(* const_cast<std::vector<Long_t>::iterator *>(&arowPtr) ) {;}
          iterator(const iterator& iter) : fRowSize (iter.fRowSize), fThisTable(iter.fThisTable),fCurrentRow(iter.fCurrentRow){}
          iterator &operator=(const iterator& iter)   { fRowSize = iter.fRowSize; fThisTable = iter.fThisTable; fCurrentRow=iter.fCurrentRow; return *this; }
-         void operator++()    { ++fCurrentRow;   }
-         void operator++(int) {   fCurrentRow++; }
-         void operator--()    { --fCurrentRow;   }
-         void operator--(int) {   fCurrentRow--; }
-         iterator operator+(Int_t idx)   { std::vector<Long_t>::iterator addition   = fCurrentRow+idx; return  iterator(*fThisTable,addition); }
-         iterator operator-(Int_t idx)   { std::vector<Long_t>::iterator subtraction = fCurrentRow-idx; return  iterator(*fThisTable,subtraction); }
-         void operator+=(Int_t idx)  {  fCurrentRow+=idx; }
-         void operator-=(Int_t idx)  {  fCurrentRow-=idx; }
-         void *rowPtr() const { return  (void *)(((const char *)fThisTable->GetArray()) + (*fCurrentRow)*fRowSize ); }
-         operator void *() const { return rowPtr(); }
-         Int_t operator-(const iterator &it) const { return (*fCurrentRow)-(*(it.fCurrentRow)); }
-         Long_t operator *() const { return  *fCurrentRow; }
-         Bool_t operator==(const iterator &t) const { return  ( (fCurrentRow == t.fCurrentRow) && (fThisTable == t.fThisTable) ); }
-         Bool_t operator!=(const iterator &t) const { return !operator==(t); }
+         void operator++();
+         void operator++(int);
+         void operator--();
+         void operator--(int);
+         iterator operator+(Int_t idx);
+         iterator operator-(Int_t idx);
+         void operator+=(Int_t idx);
+         void operator-=(Int_t idx);
+         void *rowPtr() const;
+         operator void *() const;
+         Int_t operator-(const iterator &it) const;
+         Long_t operator *() const;
+         Bool_t operator==(const iterator &t) const;
+         Bool_t operator!=(const iterator &t) const;
 
          const TTable &Table()   const { return *fThisTable;}
          const Long_t &RowSize() const { return fRowSize;}

--- a/mgr/Conscript-standard
+++ b/mgr/Conscript-standard
@@ -11,11 +11,7 @@ my $STAR_SYS     = $env->{ENV}->{STAR_SYS};
 my $STAR_VERSION = $env->{ENV}->{STAR_VERSION};         # print "#####  $STAR_VER\n";
 my $AFS_RHIC     = $env->{ENV}->{AFS_RHIC};
 
-my $ROOT_FEATURES = `root-config --features`;
-
 @Repo   = Repository_List unless $param::noRepository;#   print "Repositories = |@Repo|\n";
-
-
 
 print "+-+-+- STAR=".$env->{ENV}->{STAR}."\n"  if $param::debug;
 print "+-+-+- cwd=".$CWD."\n"                  if $param::debug;
@@ -254,14 +250,6 @@ if ($FC =~ m/g77/ || $FC =~ m/gfortran/ ){
 #-
 if ( $pkg !~ /^sim$/ && $pkg !~ /^gen$/ ) {
     print "\t--- Regular case treatment (not gen not sim) ---\n" if $param::debug;
-
-
-
-    if ( $Dir =~ m/Table$/ ) { 
-	if ( $ROOT_FEATURES =~ m/table/ ){ print "[ROOT has table support]\n";@srcL=();@h_filesL = (); }
-	else                             { print "[ROOT has no table support, compile Table] \n"; }
-    }
-
 
     # if user requested debug, print some info on what was found
     if ($param::debug) {

--- a/mgr/Construct
+++ b/mgr/Construct
@@ -4,8 +4,6 @@ use Env;
 use lib qw(./mgr $STAR/mgr);#$ENV{ConstructLocation};           # Modify perl include path
 use ConsDefs;
 
-my $ROOT_FEATURES = `root-config --features`;
-
 #my $xx=$ENV{ConstructLocation};
 #print "Path used for ConsDefs is $xx\n" unless ($param::quiet);
 
@@ -166,9 +164,6 @@ print "DirsWithIncludes = @DirsWithIncludes @DirsIdlInc\n" if ($param::debug);
 foreach my $dir (@DirsWithIncludes, @DirsIdlInc) {
   print "---> looking for include in $dir\n" if ($param::debug);
   next if ! -r $dir;
-
-  next if ( ($ROOT_FEATURES=~/table/) && ($dir =~ /Table$/) );   # Do not export Table headers if ROOT provides table support
-
   opendir( DIR, $dir ) or die "Can't open $dir\n";
   my @incs = readdir DIR; print "incs = @incs\n" if ($param::debug);
   closedir DIR;

--- a/mgr/Construct
+++ b/mgr/Construct
@@ -164,6 +164,10 @@ print "DirsWithIncludes = @DirsWithIncludes @DirsIdlInc\n" if ($param::debug);
 foreach my $dir (@DirsWithIncludes, @DirsIdlInc) {
   print "---> looking for include in $dir\n" if ($param::debug);
   next if ! -r $dir;
+
+  # Do not export StRoot/Table headers if ROOT_VERSION < 6
+  next if ($dir =~ /StRoot\/Table$/ and $def->{ENV}->{ROOT_VERSION_MAJOR} < 6);
+
   opendir( DIR, $dir ) or die "Can't open $dir\n";
   my @incs = readdir DIR; print "incs = @incs\n" if ($param::debug);
   closedir DIR;
@@ -281,6 +285,10 @@ foreach my $dir( "pams", "StRoot", "StPiD", "StarVMC" ) {
     next if ( $sub_dir =~ $excludeDirList);
     my $sub_Dir = $dir . "/" . $sub_dir; 
     next if !-d $sub_Dir and !-l $sub_Dir;
+
+    # Do not build StRoot/Table if ROOT_VERSION < 6
+    next if ($sub_Dir =~ m/StRoot\/Table$/ and $def->{ENV}->{ROOT_VERSION_MAJOR} < 6);
+
     print "dir = $dir \t sub_dir = $sub_dir sub_Dir = $sub_Dir\n" if ($param::debug);
 #    print "$sub_dir => $items\n";
 #      if ($items and $sub_dir =~ /$items/) {print "skip dir: $sub_dir \t=> $items\n"; next;}


### PR DESCRIPTION
Our ROOT6 tests indicated a problem with the ROOT's TTable class when it is interpreted by the bfc.C macro. A few fixes seem to take care of that but now we need to build and use the local code from StRoot/Table instead of the external `libTable` provided by ROOT. This is achieved by building StRoot/Table conditionally only when external dependency on ROOT >= 6 is detected.