### PR TITLE
Hide include directive from ROOT5 interpreter

### DIFF
--- a/StarDb/AgMLGeometry/CreateGeometry.h
+++ b/StarDb/AgMLGeometry/CreateGeometry.h
@@ -1,4 +1,4 @@
-#ifdef __CLING__
+#ifndef __CINT__
 #include "StBFChain/StBFChain.h"
 #endif
 

--- a/StarDb/AgMLGeometry/CreateGeometry.h
+++ b/StarDb/AgMLGeometry/CreateGeometry.h
@@ -1,4 +1,6 @@
+#ifdef __CLING__
 #include "StBFChain/StBFChain.h"
+#endif
 
 extern StBFChain* chain;
 


### PR DESCRIPTION
Proposed fix for Issue #455

It is not clear to me from the tests I've done on issue #455 why StBFChain/StBFChain.h is not located in the include path by root5 / cint.  Simplest fix is to hide the include directive from CINT.  