### PR TITLE
Remove StBFChain dependence in StarDb/AgMLGeometry/CreateGeometry.h

### DIFF
--- a/StarDb/AgMLGeometry/CreateGeometry.h
+++ b/StarDb/AgMLGeometry/CreateGeometry.h
@@ -1,7 +1,3 @@
-#include "StBFChain/StBFChain.h"
-
-extern StBFChain* chain;
-
 /**
  * Adapted from StarDb/VmcGeometry/CreateGeometry.h
  */
@@ -15,29 +11,24 @@ TDataSet *CreateGeometry(const Char_t *name="y2011") {
   }
 
   // Cache geometry to a TFile.  Geometry will be restored from TFile on subsequent calls.
-  TString filename = "";  
-  if  (chain)  { filename = chain->GetFileOut(); if ( filename=="" ) filename = chain->GetFileIn();  }
-  else { filename = name;  }
+  TString filename = "agmlcache.root";  
 
-  // Strip out @ symbol
-  filename = filename.ReplaceAll("@",""); 
-  // Strip off the last extention in the filename
-  filename = filename( 0, filename.Last('.') );
-  // Append geom.root to the extentionless filename
-  filename+=".geom.root";
+  static int count = 0;
 
-  // Detect second call to the system
+  // Detect second call to the system (I believe this never gets called?)
   if ( AgModule::Find("HALL") ) {
-    if ( chain->GetOption("Sti")    ||
-	 chain->GetOption("StiCA")  ||
-	 chain->GetOption("StiVMC") ){
-      cout << "AgML geometry:  HALL exists.  Restore from cache file " 
-	   << filename.Data() << endl;
-      gGeoManager = 0;
-      assert(0);
-      TGeoManager::Import( filename );
-      assert(gGeoManager);
-    }
+
+    count++;
+    // Warn that we have reloaded the geometry from cache
+    std::cout << "Info: [AgML geometry] HALL exists.  Restore from cache file [x" << count << "] " << filename.Data() << std::endl;
+
+    assert(count<100); // should never be done in ::Make
+  
+    gGeoManager = 0;
+    TGeoManager::Import( filename );
+    assert(gGeoManager);
+    
+      
     return geom;
   }
 
@@ -69,126 +60,3 @@ TDataSet *CreateGeometry(const Char_t *name="y2011") {
   return (TDataSet *)geom;  
 }
 
-
-
-#if 0 
-
-void loadStarGeometry( const Char_t *mytag="y2009a" )
-{
-
-  TString tag = mytag;
-  gSystem->AddIncludePath(" -IStRoot -Igeom -IStarVMC -IStarVMC/Geometry/macros ");
-  gErrorIgnoreLevel=9999;                        // Silence ROOT warnings for now
-
-  if ( gGeoManager==NULL ) 
-    {
-      gGeoManager = new TGeoManager(mytag,Form("%s/AgML",mytag));
-    }
-
-  AgBlock::SetStacker( new StarTGeoStacker() );  // Creates TGeo geometry
-
-  ///////////////////////////////////////////////////////////
-  //
-  // This is the name of the file in which we cache the AgML
-  // geometry
-  //
-#if 0  
-  TString filename = ((StBFChain*)StMaker::GetTopChain())->GetFileOut();
-#else /* NOTE: this assumes that "chain" is in scope in CINT */
-  TString filename = "";  
-  if ( chain ) {
-      filename = chain -> GetFileOut();
-      filename.ReplaceAll(".root","");
-  }
-#endif
-  if ( filename == "" ) 
-    {
-      filename = chain -> GetFileIn();
-      filename.ReplaceAll("@","");      // special case for filelist
-      filename.ReplaceAll(".list","");
-    }
-  if ( filename == "" )
-    {
-      filename = mytag;
-    }
-
-  filename += ".geom.root";
-
-  ///////////////////////////////////////////////////////////
-  //
-  // If there is an existing AgML geometry, load from a cached file
-  //
-  if ( AgModule::Find("HALL") )
-    {
-      std::cout << Form(">>> AgML geometry detected.  Loading from %s <<<",filename.Data()) << std::endl;      
-      gGeoManager = 0;// Prevent ROOT deleting existing geometry
-      TGeoManager::Import( filename );
-      assert(gGeoManager);
-      return;
-    }
-
-  Geometry *build = new Geometry();                        // Instantiate the geometry
-  build -> ConstructGeometry ( tag );            
-  gGeoManager->CloseGeometry();
-
-
-  TFile *file = new TFile( filename, "recreate" );
-  file->cd();
-  gGeoManager->Write();
-  file->Close();
-  delete file;
-
-  gErrorIgnoreLevel=0;                           // Enable ROOT warnings
-
-  return;
-
-}
-
-
-
-TDataSet *CreateGeometry(const Char_t *name="y2011") {
-
-  std::cout << "=====================================>>> CreateGeometry " << name << " <<<=====================================" << std::endl;
-
-  TObjectSet *geom = NULL;
-
-  // Check for existing geometries and return (NULL) 
-  // if we find one.
-  if (gGeoManager) {
-    cout << "-- Geometry " << gGeoManager->GetName() << " -- " 
-	 << " has beed created.  Ignoring request for AgML geometry " 
-	 << name << "." << endl;
-    return geom;
-  }
-
-  const Char_t *path  = ".:./StarDb/AgMLGeometry/:$STAR/StarDb/AgMLGeometry/";
-  Char_t *file = gSystem->Which(path,"loadStarGeometry.Cxx",kReadPermission);
-
-  // Load the geometry macro
-  //  gROOT -> ProcessLine( Form(".L %s",file ) );
-
-  // Instantiate the geometry
-  loadStarGeometry( name );
-
-  // Unload the macro
-  //  gROOT -> ProcessLine( Form(".U %s",file ) );
-
-
-  // Make damn sure we have a navigator... 
-  assert(gGeoManager);
-  //  if ( !gGeoManager->GetCurrentNavigator() )
-  //    {
-  //      gGeoManager->AddNavigator( new TGeoNavigator() );
-  //    }
-
-  // Wrap TGeoManager in a TDataSet and return it
-  if ( gGeoManager ) 
-    {
-      geom = new TObjectSet("Geometry",gGeoManager, false );
-      geom -> SetTitle( Form("AgML Geometry: %s",name) );
-    }
-
-  return (TDataSet *)geom;
-
-}
-#endif


### PR DESCRIPTION
This PR Should resolve #455.

The StBFChain dependence supported two features in this macro. 

1) It allowed us to name the geometry cache file based on the output filename for the chain.
2) It allowed us to detect when Sti (CA or V) was present in the chain options.

Item 1 is nice to have but not required.

Given the "assert(0)" in the block of code which detects Sti... we don't actually use item 2.  (I suspect it was deprecated at some point).

Therefore we remove the dependency on StBFChain.