### PR TITLE
StETofHitMaker: Fix unused variable warnings

### DIFF
--- a/StRoot/StETofHitMaker/StETofHitMaker.cxx
+++ b/StRoot/StETofHitMaker/StETofHitMaker.cxx
@@ -412,13 +412,7 @@ StETofHitMaker::processStEvent()
     }
 
     if( etofCollection->hitsPresent() ) {
-        StSPtrVecETofHit& etofHits = etofCollection->etofHits();
-        //LOG_INFO << "processStEvent() - etof hit collection: " << etofHits.size() << " entries" << endm;
-
         fillHitQA( isMuDst, tstart );
-    }
-    else {
-       // LOG_INFO << "processStEvent() - no hits" << endm;
     }
 }
 
@@ -482,13 +476,7 @@ StETofHitMaker::processMuDst()
 
 
     if( mMuDst->numberOfETofHit() ) {
-        size_t nHits = mMuDst->numberOfETofHit();
-        //LOG_INFO << "processMuDst() - etof hits: " << nHits << " entries" << endm;
-
         fillHitQA( isMuDst, tstart );
-    }
-    else {
-        //LOG_INFO << "processMuDst() - no hits" << endm;
     }
 }
 //_____________________________________________________________
@@ -1200,9 +1188,6 @@ StETofHitMaker::fillUnclusteredHitQA( const double& tstart, const bool isMuDst )
 
     int nHitsPrinted = 0;
 
-    int eventTime = ( this->GetTime() / 10000 ) * 3600 + ( ( this->GetTime() % 10000 ) / 100 ) * 60 + ( this->GetTime() % 100 );
-    //LOG_INFO << "fillUnclusteredHitQA(): -- event time: " << eventTime << endm;
-
     for( const auto& kv : mStoreHit ) {
         unsigned int detIndex  = kv.first;
 
@@ -1284,9 +1269,6 @@ StETofHitMaker::fillUnclusteredHitQA( const double& tstart, const bool isMuDst )
 
             std::string histNamePosJump = "unclusteredHit_jump_pos_s" + std::to_string( sector ) + "m" + std::to_string( plane ) + "c" + std::to_string( counter );
             if( hit->clusterSize() > 100 ) mHistograms.at( histNamePosJump )->Fill( hit->localX(), hit->localY() );
-
-            //std::string histNamePosTime = "unclusteredHit_pos_time_s" + std::to_string( sector ) + "m" + std::to_string( plane ) + "c" + std::to_string( counter );
-            //mHistograms.at( histNamePosTime )->Fill( eventTime, hit->localY() );
 
             // ---------------------------------------
             if( fabs( tstart + 9999. ) < 1.e-5 ) continue;

--- a/mgr/warnoff_dirs.txt
+++ b/mgr/warnoff_dirs.txt
@@ -13,7 +13,6 @@ StRoot/StEEmcPool.*
 StRoot/StEEmcSimulatorMaker
 StRoot/StEEmcUtil
 StRoot/StEStructPool.*
-StRoot/StETofHitMaker
 StRoot/StEmbeddingUtilities
 StRoot/StEmcADCtoEMaker
 StRoot/StEmcCalibrationMaker


### PR DESCRIPTION
```
g++ -m64 -fPIC -pipe -Wall -Woverloaded-virtual -std=c++0x -Wno-long-long -pthread -Wno-deprecated-declarations -O2 -g -falign-loops -falign-jumps -falign-functions -Dsl79_gcc485 -D__ROOT__ -DNEW_DAQ_READER -I. -IStRoot -I.sl79_gcc485/include -I/opt/software/linux-scientific7-x86_64/gcc-4.8.5/root-5.34.38-l3v6vso6qgojm4l2ctwjojs6trbt4hpn/include -c .sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx -o .sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.o
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx: In member function 'void StETofHitMaker::processStEvent()':
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx:415:27: warning: unused variable 'etofHits' [-Wunused-variable]
         StSPtrVecETofHit& etofHits = etofCollection->etofHits();
                           ^
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx: In member function 'void StETofHitMaker::processMuDst()':
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx:485:16: warning: unused variable 'nHits' [-Wunused-variable]
         size_t nHits = mMuDst->numberOfETofHit();
                ^
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx: In member function 'void StETofHitMaker::fillUnclusteredHitQA(const double&, bool)':
.sl79_gcc485/OBJ/StRoot/StETofHitMaker/StETofHitMaker.cxx:1203:9: warning: unused variable 'eventTime' [-Wunused-variable]
     int eventTime = ( this->GetTime() / 10000 ) * 3600 + ( ( this->GetTime() % 10000 ) / 100 ) * 60 + ( this->GetTime() % 100 );
         ^
```
