### PR TITLE
Fix GCC 11 warning in StETofMatchMaker

### DIFF
--- a/StRoot/StETofMatchMaker/StETofMatchMaker.cxx
+++ b/StRoot/StETofMatchMaker/StETofMatchMaker.cxx
@@ -765,7 +765,7 @@ StETofMatchMaker::readETofDetectorHits( eTofHitVec& detectorHitVec )
                 continue;
             }
 
-            StructETofHit detectorHit;
+            StructETofHit detectorHit{};
 
             detectorHit.sector         = aHit->sector();
             /*
@@ -795,7 +795,7 @@ StETofMatchMaker::readETofDetectorHits( eTofHitVec& detectorHitVec )
                 continue;
             }
 
-            StructETofHit detectorHit;
+            StructETofHit detectorHit{};
 
             detectorHit.sector         = aHit->sector();
             /*
@@ -1176,7 +1176,7 @@ StETofMatchMaker::extrapolateTrackToETof( eTofHitVec& intersectionVec, const StP
             LOG_INFO << "local coordinates: "  << localVec.at( i ).x() << ", " << localVec.at( i ).y() << ", " << localVec.at( i ).z() << endm;
         }
 
-        StructETofHit intersect;
+        StructETofHit intersect{};
 
         mETofGeom->decodeVolumeIndex( idVec.at( i ), intersect.sector, intersect.plane, intersect.counter, intersect.strip );
 
@@ -1267,7 +1267,7 @@ StETofMatchMaker::matchETofHits( eTofHitVec& detectorHitVec, eTofHitVec& interse
             }
 
             if( isMatch ) {
-                StructETofHit matchCand;
+                StructETofHit matchCand{};
 
                 matchCand.sector        = detHitIter->sector;
                 matchCand.plane         = detHitIter->plane;


### PR DESCRIPTION
```
In file included from .sl79_gcc11/OBJ/StRoot/StETofMatchMaker/StETofMatchMaker.cxx:90:
In copy constructor 'constexpr StETofMatchMaker::StructETofHit::StructETofHit(const StETofMatchMaker::StructETofHit&)',
    inlined from 'void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = StETofMatchMaker::StructETofHit; _Args = {const StETofMatchMaker::StructETofHit&}; _Tp = StETofMatchMaker::StructETofHit]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/ext/new_allocator.h:162:4,
    inlined from 'static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = StETofMatchMaker::StructETofHit; _Args = {const StETofMatchMaker::StructETofHit&}; _Tp = StETofMatchMaker::StructETofHit]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/alloc_traits.h:516:17,
    inlined from 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = StETofMatchMaker::StructETofHit; _Alloc = std::allocator<StETofMatchMaker::StructETofHit>]' at /opt/rh/devtoolset-11/root/usr/include/c++/11/bits/stl_vector.h:1192:30,
    inlined from 'void StETofMatchMaker::readETofDetectorHits(StETofMatchMaker::eTofHitVec&)' at .sl79_gcc11/OBJ/StRoot/StETofMatchMaker/StETofMatchMaker.cxx:810:37:
.sl79_gcc11/OBJ/StRoot/StETofMatchMaker/StETofMatchMaker.h:81:12: warning: 'detectorHit.StETofMatchMaker::StructETofHit::strip' may be used uninitialized [-Wmaybe-uninitialized]
   81 |     struct StructETofHit{
      |            ^~~~~~~~~~~~~
.sl79_gcc11/OBJ/StRoot/StETofMatchMaker/StETofMatchMaker.cxx: In member function 'void StETofMatchMaker::readETofDetectorHits(StETofMatchMaker::eTofHitVec&)':
.sl79_gcc11/OBJ/StRoot/StETofMatchMaker/StETofMatchMaker.cxx:791:27: note: 'detectorHit' declared here
  791 |             StructETofHit detectorHit;
      |                           ^~~~~~~~~~~
```
