### PR TITLE
[root6] Avoid using unnecessary typedefs for TDataSet

### DIFF
--- a/StarDb/ctf/ctg/ctb.C
+++ b/StarDb/ctf/ctg/ctb.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/ctb Allocated rows: 1  Used rows: 1  Row size: 68 bytes
 //  Table: ctg_geo_st[0]--> ctg_geo_st[0]
@@ -28,5 +28,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.tray_phi_zero	 =          0; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/ctb_slat.C
+++ b/StarDb/ctf/ctg/ctb_slat.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // params/ctf/ctg/ctb_slat Allocated rows: 240  Used rows: 240  Row size: 32 bytes
 //  Table: ctg_slat_st[0]--> ctg_slat_st[239]
@@ -23,5 +23,5 @@ St_ctg_slat *tableSet = new St_ctg_slat("ctb_slat",240);
    }
  }
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/ctb_slat_eta.C
+++ b/StarDb/ctf/ctg/ctb_slat_eta.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/ctb_slat_eta Allocated rows: 4  Used rows: 4  Row size: 36 bytes
 //  Table: ctg_slat_eta_st[0]--> ctg_slat_eta_st[3]
@@ -53,5 +53,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_min	 =     241.49; // ;
 tableSet->AddAt(&row,3);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/ctb_slat_phi.C
+++ b/StarDb/ctf/ctg/ctb_slat_phi.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/ctb_slat_phi Allocated rows: 60  Used rows: 60  Row size: 16 bytes
 //  Table: ctg_slat_phi_st[0]--> ctg_slat_phi_st[59]
@@ -369,5 +369,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.phi_min	 =    351.092; // ;
 tableSet->AddAt(&row,59);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/tof.C
+++ b/StarDb/ctf/ctg/tof.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/tof Allocated rows: 1  Used rows: 1  Row size: 68 bytes
 //  Table: ctg_geo_st[0]--> ctg_geo_st[0]
@@ -28,5 +28,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.tray_phi_zero	 =          0; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/tof_slat.C
+++ b/StarDb/ctf/ctg/tof_slat.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // params/ctf/ctg/tof_slat Allocated rows: 5400  Used rows: 5400  Row size: 32 bytes
 //  Table: ctg_slat_st[0]--> ctg_slat_st[5399]
@@ -23,5 +23,5 @@ St_ctg_slat *tableSet = new St_ctg_slat("tof_slat",5400);
    }
  }
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/tof_slat_eta.C
+++ b/StarDb/ctf/ctg/tof_slat_eta.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/tof_slat_eta Allocated rows: 18  Used rows: 18  Row size: 36 bytes
 //  Table: ctg_slat_eta_st[0]--> ctg_slat_eta_st[17]
@@ -207,5 +207,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_min	 =     205.56; // ;
 tableSet->AddAt(&row,17);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/ctg/tof_slat_phi.C
+++ b/StarDb/ctf/ctg/tof_slat_phi.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ctg/tof_slat_phi Allocated rows: 300  Used rows: 300  Row size: 16 bytes
 //  Table: ctg_slat_phi_st[0]--> ctg_slat_phi_st[299]
@@ -1809,5 +1809,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.phi_min	 =    355.732; // ;
 tableSet->AddAt(&row,299);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/cts/cts_ctb.C
+++ b/StarDb/ctf/cts/cts_ctb.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cts/cts_ctb Allocated rows: 1  Used rows: 1  Row size: 1076 bytes
 //  Table: cts_mpara_st[0]--> cts_mpara_st[0]
@@ -280,5 +280,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.zero_suppression	 =          1; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ctf/cts/cts_tof.C
+++ b/StarDb/ctf/cts/cts_tof.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cts/cts_tof Allocated rows: 1  Used rows: 1  Row size: 1076 bytes
 //  Table: cts_mpara_st[0]--> cts_mpara_st[0]
@@ -280,5 +280,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.zero_suppression	 =          1; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ebye/sca/sca_const.C
+++ b/StarDb/ebye/sca/sca_const.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/sca/sca_const Allocated rows: 1  Used rows: 1  Row size: 112 bytes
 //  Table: sca_const_st[0]--> sca_const_st[0]
@@ -39,5 +39,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.perfectdither	 =          0; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ebye/sca/sca_filter_const.C
+++ b/StarDb/ebye/sca/sca_filter_const.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/sca/sca_filter_const Allocated rows: 1  Used rows: 1  Row size: 28 bytes
 //  Table: sca_filter_const_st[0]--> sca_filter_const_st[0]
@@ -18,5 +18,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nGoodTraks	 =         50; // total no. of good tracks    ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ebye/sca/sca_switch.C
+++ b/StarDb/ebye/sca/sca_switch.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/sca/sca_switch Allocated rows: 1  Used rows: 1  Row size: 16 bytes
 //  Table: sca_switch_st[0]--> sca_switch_st[0]
@@ -15,5 +15,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nEvents	 =          0; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/ems_cal_control.C
+++ b/StarDb/emc/cal/ems_cal_control.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/ems_cal_control Allocated rows: 1  Used rows: 1  Row size: 52 bytes
 //  Table: ems_cal_control_st[0]--> ems_cal_control_st[0]
@@ -25,5 +25,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.occupancy	 =        0.5; // hit occupancy toy_simulator mode=1 ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bemc.C
+++ b/StarDb/emc/cal/org_ped_bemc.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bemc Allocated rows: 4800  Used rows: 4800  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[4799]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.ped	 =          0; // pedestal for ADC channel ;
   for (Int_t i=0;i<4800;i++) tableSet->AddAt(&row,i);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bemc_h.C
+++ b/StarDb/emc/cal/org_ped_bemc_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bemc_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          2; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bprs.C
+++ b/StarDb/emc/cal/org_ped_bprs.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bprs Allocated rows: 4800  Used rows: 4800  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[4799]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.ped	 =          0; // pedestal for ADC channel ;
   for (Int_t i=0;i<4800;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bprs_h.C
+++ b/StarDb/emc/cal/org_ped_bprs_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bprs_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          2; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bsmde.C
+++ b/StarDb/emc/cal/org_ped_bsmde.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bsmde Allocated rows: 18000  Used rows: 18000  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[17999]
@@ -10,5 +10,5 @@ St_DataSet *CreateTable() {
   row.ped	 =          0; // pedestal for ADC channel ;
   for (Int_t i=0;i<18000;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bsmde_h.C
+++ b/StarDb/emc/cal/org_ped_bsmde_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bsmde_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          1; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bsmdp.C
+++ b/StarDb/emc/cal/org_ped_bsmdp.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bsmdp Allocated rows: 18000  Used rows: 18000  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[17999]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   for (Int_t i=0;i<18000;i++) tableSet->AddAt(&row,i);
 //
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_bsmdp_h.C
+++ b/StarDb/emc/cal/org_ped_bsmdp_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_bsmdp_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =         15; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_eemc.C
+++ b/StarDb/emc/cal/org_ped_eemc.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_eemc Allocated rows: 1440  Used rows: 1440  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[1439]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.ped	 =          0; // pedestal for ADC channel ;
    for (Int_t i=0;i<1440;i++) tableSet->AddAt(&row,i); 
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_eemc_h.C
+++ b/StarDb/emc/cal/org_ped_eemc_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_eemc_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          5; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_eprs.C
+++ b/StarDb/emc/cal/org_ped_eprs.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_eprs Allocated rows: 1440  Used rows: 1440  Row size: 4 bytes
 //  Table: emc_pedestal_st[0]--> emc_pedestal_st[1439]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.ped	 =          0; // pedestal for ADC channel ;
   for (Int_t i=0;i<1440;i++) tableSet->AddAt(&row,i);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_ped_eprs_h.C
+++ b/StarDb/emc/cal/org_ped_eprs_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_ped_eprs_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          5; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bemc.C
+++ b/StarDb/emc/cal/org_slp_bemc.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bemc Allocated rows: 4800  Used rows: 4800  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[4799]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.p0	 =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<4800;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bemc_h.C
+++ b/StarDb/emc/cal/org_slp_bemc_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bemc_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          2; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bprs.C
+++ b/StarDb/emc/cal/org_slp_bprs.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bprs Allocated rows: 4800  Used rows: 4800  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[4799]
@@ -11,5 +11,5 @@ St_DataSet *CreateTable() {
   row.p0       =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<4800;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bprs_h.C
+++ b/StarDb/emc/cal/org_slp_bprs_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bprs_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          2; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bsmde.C
+++ b/StarDb/emc/cal/org_slp_bsmde.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bsmde Allocated rows: 18000  Used rows: 18000  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[17999]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.p0	 =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<18000;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bsmde_h.C
+++ b/StarDb/emc/cal/org_slp_bsmde_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bsmde_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          1; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bsmdp.C
+++ b/StarDb/emc/cal/org_slp_bsmdp.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bsmdp Allocated rows: 18000  Used rows: 18000  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[17999]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.p0	 =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<18000;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_bsmdp_h.C
+++ b/StarDb/emc/cal/org_slp_bsmdp_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_bsmdp_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =         15; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_eemc.C
+++ b/StarDb/emc/cal/org_slp_eemc.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_eemc Allocated rows: 1440  Used rows: 1440  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[1439]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.p0	 =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<1440;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_eemc_h.C
+++ b/StarDb/emc/cal/org_slp_eemc_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_eemc_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          5; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_eprs.C
+++ b/StarDb/emc/cal/org_slp_eprs.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_eprs Allocated rows: 1440  Used rows: 1440  Row size: 4 bytes
 //  Table: emc_adcslope_st[0]--> emc_adcslope_st[1439]
@@ -12,5 +12,5 @@ St_DataSet *CreateTable() {
   row.p0	 =          1; // adc slope for ADC channel ;
   for (Int_t i=0;i<1440;i++) tableSet->AddAt(&row,i);
   // ----------------- end of code ---------------
-  return (St_DataSet *)tableSet;
+  return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/cal/org_slp_eprs_h.C
+++ b/StarDb/emc/cal/org_slp_eprs_h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/cal/org_slp_eprs_h Allocated rows: 1  Used rows: 1  Row size: 24 bytes
 //  Table: emc_calib_header_st[0]--> emc_calib_header_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.nsub	 =          5; // see emc_def.h ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/ems/control_toadc.C
+++ b/StarDb/emc/ems/control_toadc.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ems/control_toadc Allocated rows: 1  Used rows: 1  Row size: 224 bytes
 //  Table: control_toadc_st[0]--> control_toadc_st[0]
@@ -75,5 +75,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.c3[7]	 =          0;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/ems/ems_control.C
+++ b/StarDb/emc/ems/ems_control.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ems/ems_control Allocated rows: 1  Used rows: 1  Row size: 340 bytes
 //  Table: ems_control_st[0]--> ems_control_st[0]
@@ -96,5 +96,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.ideal_jet_mode	 =          1; // mode for idel jet finder 1=ideal,2=1-nuotrino,3=charged only ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/jet/emc_egrid_par.C
+++ b/StarDb/emc/jet/emc_egrid_par.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/jet/emc_egrid_par Allocated rows: 1  Used rows: 1  Row size: 16 bytes
 //  Table: emc_egrid_par_st[0]--> emc_egrid_par_st[0]
@@ -15,5 +15,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.ideal_phi_nbin	 =        100; // Size of energy matrix for ideal egrid ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/emc/jet/emc_jetpar.C
+++ b/StarDb/emc/jet/emc_jetpar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/jet/emc_jetpar Allocated rows: 1  Used rows: 1  Row size: 76 bytes
 //  Table: emc_jetpar_st[0]--> emc_jetpar_st[0]
@@ -30,5 +30,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.eta_min	 =         -2; // maxinum eta for jet ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcClusterPars.C
+++ b/StarDb/ftpc/ftpcClusterPars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcClusterPars Allocated rows: 1  Used rows: 1  Row size: 156 bytes
 //  Table: ftpcClusterPars_st[0]--> ftpcClusterPars_st[0]
@@ -54,5 +54,5 @@ memset(&row,0,tableSet->GetRowSize());
     
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcFastSimGas.C
+++ b/StarDb/ftpc/ftpcFastSimGas.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcFastSimGas Allocated rows: 1  Used rows: 1  Row size: 100 bytes
 //  Table: ftpcFastSimGas_st[0]--> ftpcFastSimGas_st[0]
@@ -36,5 +36,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.errorAzimuthalEstimates[3]    =         0; // D= ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcFastSimPars.C
+++ b/StarDb/ftpc/ftpcFastSimPars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcFastSimPars Allocated rows: 1  Used rows: 1  Row size: 44 bytes
 //  Table: ftpcFastSimPars_st[0]--> ftpcFastSimPars_st[0]
@@ -22,5 +22,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.clusterChargeConversionFactor =        6.; // D= convert adc counts to charge;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcSlowSimGas.C
+++ b/StarDb/ftpc/ftpcSlowSimGas.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcSlowSimGas Allocated rows: 132  Used rows: 132  Row size: 24 bytes
 //  Table: ftpcSlowSimGas_st[0]--> ftpcSlowSimGas_st[131]
@@ -1065,5 +1065,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lorentzAngle	 =   0.130551; // lorentz angle of drift electrons ;
 tableSet->AddAt(&row,131);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcSlowSimPars.C
+++ b/StarDb/ftpc/ftpcSlowSimPars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcSlowSimPars Allocated rows: 1  Used rows: 1  Row size: 44 bytes
 //  Table: ftpcSlowSimPars_st[0]--> ftpcSlowSimPars_st[0]
@@ -22,5 +22,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.slowSimPressure         = 1013.25; // D = atmospheric pressure used;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcTrackingPars.C
+++ b/StarDb/ftpc/ftpcTrackingPars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcTrackingPars Allocated rows: 1  Used rows: 1  Row size: ??? bytes
 //  Table: ftpcTrackingPars_st[0]--> ftpcTrackingPars_st[0]
@@ -106,5 +106,5 @@ memset(&row,0,tableSet->GetRowSize());
 
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/ftpc/ftpcdEdxPars.C
+++ b/StarDb/ftpc/ftpcdEdxPars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ftpcdEdxPars Allocated rows: 1  Used rows: 1  Row size: 40 bytes
 //  Table: ftpcdEdxPars_st[0]--> ftpcdEdxPars_st[0]
@@ -21,5 +21,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.a_large_number	 =      1e+10; // a large number ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/global/vertices/stk_vtx.C
+++ b/StarDb/global/vertices/stk_vtx.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/vertices/stk_vtx Allocated rows: 1  Used rows: 1  Row size: 48 bytes
 //  Table: stk_vtx_st[0]--> stk_vtx_st[0]
@@ -23,5 +23,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =          0;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/global/vertices/stk_vtx_direct.C
+++ b/StarDb/global/vertices/stk_vtx_direct.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/vertices/stk_vtx_direct Allocated rows: 1  Used rows: 1  Row size: 16 bytes
 //  Table: stk_vtx_direct_st[0]--> stk_vtx_direct_st[0]
@@ -15,5 +15,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.sx[2]	 =     0.0005;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/mwc/mwcpars/cal.C
+++ b/StarDb/mwc/mwcpars/cal.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/mwcpars/cal Allocated rows: 384  Used rows: 384  Row size: 12 bytes
 //  Table: mwc_cal_st[0]--> mwc_cal_st[383]
@@ -1929,5 +1929,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.ps	 =          0; // Pedestal dispersion ;
 tableSet->AddAt(&row,383);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/mwc/mwcpars/geom.C
+++ b/StarDb/mwc/mwcpars/geom.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/mwcpars/geom Allocated rows: 1  Used rows: 1  Row size: 28 bytes
 //  Table: mwc_geo_st[0]--> mwc_geo_st[0]
@@ -18,5 +18,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.r2min	 =    125.488; // Inner radius outer sectors ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/mwc/mwcpars/mpar.C
+++ b/StarDb/mwc/mwcpars/mpar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/mwcpars/mpar Allocated rows: 1  Used rows: 1  Row size: 32 bytes
 //  Table: mwc_mpar_st[0]--> mwc_mpar_st[0]
@@ -19,5 +19,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.min_ion	 =          0; // Minimum ionization ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/sgrpars/pix_info.C
+++ b/StarDb/svt/sgrpars/pix_info.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/sgrpars/pix_info Allocated rows: 4  Used rows: 4  Row size: 28 bytes
 //  Table: sgr_pixmap_st[0]--> sgr_pixmap_st[3]
@@ -45,5 +45,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.ZMax	 =         20; // Maximum Zscaled values in pixmap. ;
 tableSet->AddAt(&row,3);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/sprpars/sprpar.C
+++ b/StarDb/svt/sprpars/sprpar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/sprpars/sprpar Allocated rows: 1  Used rows: 1  Row size: 8 bytes
 //  Table: spr_sprpar_st[0]--> spr_sprpar_st[0]
@@ -13,5 +13,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.p	 =          0; // momentum cut off for dE/dx in GeV/c ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/srspars/srs_activea.C
+++ b/StarDb/svt/srspars/srs_activea.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/srspars/srs_activea Allocated rows: 4  Used rows: 4  Row size: 44 bytes
 //  Table: srs_activea_st[0]--> srs_activea_st[3]
@@ -61,5 +61,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.param[9]	 =          0;
 tableSet->AddAt(&row,3);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/srspars/srs_srspar.C
+++ b/StarDb/svt/srspars/srs_srspar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/srspars/srs_srspar Allocated rows: 1  Used rows: 1  Row size: 84 bytes
 //  Table: srs_srspar_st[0]--> srs_srspar_st[0]
@@ -32,5 +32,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.vd	 =          700000; // drift velocity ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/stkpars/stk_filler.C
+++ b/StarDb/svt/stkpars/stk_filler.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/stkpars/stk_filler Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: stk_filler_st[0]--> stk_filler_st[0]
@@ -71,5 +71,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.wth87	 =        120; // wafer cone 7 to 8 ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/config.C
+++ b/StarDb/svt/svgpars/config.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/config Allocated rows: 1  Used rows: 1  Row size: 1168 bytes
 //  Table: svg_config_st[0]--> svg_config_st[0]
@@ -303,5 +303,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =          0;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/geom.C
+++ b/StarDb/svt/svgpars/geom.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/geom Allocated rows: 536  Used rows: 536  Row size: 68 bytes
 //  Table: svg_geom_st[0]--> svg_geom_st[535]
@@ -10194,5 +10194,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =      32.25;
 tableSet->AddAt(&row,535);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/geom.C.6cm
+++ b/StarDb/svt/svgpars/geom.C.6cm
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/geom Allocated rows: 536  Used rows: 536  Row size: 68 bytes
 //  Table: svg_geom_st[0]--> svg_geom_st[535]
@@ -10194,5 +10194,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =      32.25;
 tableSet->AddAt(&row,535);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/geom.C.MDC4
+++ b/StarDb/svt/svgpars/geom.C.MDC4
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/geom Allocated rows: 536  Used rows: 536  Row size: 68 bytes
 //  Table: svg_geom_st[0]--> svg_geom_st[535]
@@ -10194,5 +10194,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =      32.25;
 tableSet->AddAt(&row,535);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/geomy1l.C
+++ b/StarDb/svt/svgpars/geomy1l.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/geom Allocated rows: 7  Used rows: 7 
 //  Table: svg_geom_st[0]--> svg_geom_st[7]
@@ -142,5 +142,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.x[2]	 =        -18;
 tableSet->AddAt(&row,6);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/svt/svgpars/shape.C
+++ b/StarDb/svt/svgpars/shape.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/svgpars/shape Allocated rows: 2  Used rows: 2  Row size: 88 bytes
 //  Table: svg_shape_st[0]--> svg_shape_st[1]
@@ -57,5 +57,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.shape[9]	 =          0;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/fmtpars/fmtpar.C
+++ b/StarDb/tpc/fmtpars/fmtpar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/fmtpars/fmtpar Allocated rows: 1  Used rows: 1  Row size: 88 bytes
 //  Table: tfc_fmtpar_st[0]--> tfc_fmtpar_st[0]
@@ -33,5 +33,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.printf	 =          0; // output flag ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tclpars/tclpar.C
+++ b/StarDb/tpc/tclpars/tclpar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tclpars/tclpar Allocated rows: 1  Used rows: 1  Row size: 48 bytes
 //  Table: tcl_tclpar_st[0]--> tcl_tclpar_st[0]
@@ -23,5 +23,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.triage_rmscut	 =          3; // cut on rms_pad + rms_tdc ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tclpars/type.C
+++ b/StarDb/tpc/tclpars/type.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tclpars/type Allocated rows: 1  Used rows: 1  Row size: 28 bytes
 //  Table: tcl_tpc_index_type_st[0]--> tcl_tpc_index_type_st[0]
@@ -18,5 +18,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.tptrack_tpsegment	 =          7; // correlate tptrack and tpsegment tables ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tfspars/tfs_fsctrl.C
+++ b/StarDb/tpc/tfspars/tfs_fsctrl.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tfspars/tfs_fsctrl Allocated rows: 1  Used rows: 1  Row size: 32 bytes
 //  Table: tfs_fsctrl_st[0]--> tfs_fsctrl_st[0]
@@ -42,5 +42,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.sprf_ta[1]	 =      0.637;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tfspars/tfs_fspar.C
+++ b/StarDb/tpc/tfspars/tfs_fspar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tfspars/tfs_fspar Allocated rows: 1  Used rows: 1  Row size: 160 bytes
 //  Table: tfs_fspar_st[0]--> tfs_fspar_st[0]
@@ -23,5 +23,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.zbmax	 =        512; // total time bins ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tidpars/tdeparm.C
+++ b/StarDb/tpc/tidpars/tdeparm.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tidpars/tdeparm Allocated rows: 1  Used rows: 1  Row size: 60 bytes
 //  Table: tdeparm_st[0]--> tdeparm_st[0]
@@ -27,7 +27,7 @@ memset(&row,0,tableSet->GetRowSize());
     row.truncfact	 =        0.3; // fraction of dedx values to truncate ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }
 
 

--- a/StarDb/tpc/tidpars/tpipar.C
+++ b/StarDb/tpc/tidpars/tpipar.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tidpars/tpipar Allocated rows: 1  Used rows: 1  Row size: 132 bytes
 //  Table: tpipar_st[0]--> tpipar_st[0]
@@ -44,5 +44,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.skew[7]	 =          0;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.20000217.000000.C
+++ b/StarDb/tpc/tptpars/tpt_pars.20000217.000000.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.20000301.000005.C
+++ b/StarDb/tpc/tptpars/tpt_pars.20000301.000005.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.er99.C
+++ b/StarDb/tpc/tptpars/tpt_pars.er99.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.sd97.C
+++ b/StarDb/tpc/tptpars/tpt_pars.sd97.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.year_1a.C
+++ b/StarDb/tpc/tptpars/tpt_pars.year_1a.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.year_1c.C
+++ b/StarDb/tpc/tptpars/tpt_pars.year_1c.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.year_1h.C
+++ b/StarDb/tpc/tptpars/tpt_pars.year_1h.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_pars.year_2a.C
+++ b/StarDb/tpc/tptpars/tpt_pars.year_2a.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_pars Allocated rows: 2  Used rows: 2  Row size: 160 bytes
 //  Table: tpt_pars_st[0]--> tpt_pars_st[1]
@@ -95,5 +95,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.lfit     =          0; // straigth line fit;
 tableSet->AddAt(&row,1);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tptpars/tpt_spars.C
+++ b/StarDb/tpc/tptpars/tpt_spars.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tptpars/tpt_spars Allocated rows: 1  Used rows: 1  Row size: 216 bytes
 //  Table: tpt_spars_st[0]--> tpt_spars_st[0]
@@ -65,5 +65,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.outlimit	 =          4; // ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.19991216.000000.C
+++ b/StarDb/tpc/tsspars/tsspar.19991216.000000.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.19991217.000000.C
+++ b/StarDb/tpc/tsspars/tsspar.19991217.000000.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.er99.C
+++ b/StarDb/tpc/tsspars/tsspar.er99.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.es99.C
+++ b/StarDb/tpc/tsspars/tsspar.es99.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.sd97.C
+++ b/StarDb/tpc/tsspars/tsspar.sd97.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.y2018.C
+++ b/StarDb/tpc/tsspars/tsspar.y2018.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.y2019.C
+++ b/StarDb/tpc/tsspars/tsspar.y2019.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.year_1a.C
+++ b/StarDb/tpc/tsspars/tsspar.year_1a.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/tsspars/tsspar.year_1c.C
+++ b/StarDb/tpc/tsspars/tsspar.year_1c.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/tsspars/tsspar Allocated rows: 1  Used rows: 1  Row size: 240 bytes
 //  Table: tss_tsspar_st[0]--> tss_tsspar_st[0]
@@ -52,5 +52,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.z_laser	 =        100; // z drift length of pointlaser source(cm) ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }

--- a/StarDb/tpc/ttepars/tte_control.C
+++ b/StarDb/tpc/ttepars/tte_control.C
@@ -1,4 +1,4 @@
-St_DataSet *CreateTable() { 
+TDataSet *CreateTable() { 
 // -----------------------------------------------------------------
 // Top/ttepars/tte_control Allocated rows: 1  Used rows: 1  Row size: 12 bytes
 //  Table: tte_control_st[0]--> tte_control_st[0]
@@ -14,5 +14,5 @@ memset(&row,0,tableSet->GetRowSize());
     row.res	 =          0; // Turn on/off calculation of the residuals ;
 tableSet->AddAt(&row,0);
 // ----------------- end of code ---------------
- return (St_DataSet *)tableSet;
+ return (TDataSet *)tableSet;
 }


### PR DESCRIPTION
The typedefs aliasing St_DataSet to TDataSet are not required. This prevents us from running some nightly tests which load DB tables which utilize this alias.

Fix error: unknown type name 'St_DataSet' in ROOT6 tests

```
LoadTable: .L /star-sw/StarDb/tpc/tsspars/tsspar.y2019.C
In file included from input_line_851:1:
/star-sw/StarDb/tpc/tsspars/tsspar.y2019.C:3:1: error: unknown type name 'St_DataSet'
St_DataSet *CreateTable() {
^
/star-sw/StarDb/tpc/tsspars/tsspar.y2019.C:57:10: error: use of undeclared identifier 'St_DataSet'
 return (St_DataSet *)tableSet;
         ^
/star-sw/StarDb/tpc/tsspars/tsspar.y2019.C:57:22: error: expected expression
 return (St_DataSet *)tableSet;
                     ^
root4star: .sl79_gcc485/OBJ/StRoot/St_db_Maker/St_db_Maker.cxx:932: virtual TDataSet* St_db_Maker::LoadTable(TDataSet*): Assertion `!ee' failed.
sh: line 1:   133 Aborted                 (core dumped) MALLOC_CHECK_=3 root4star -b -q -l 'bfc.C(50, "pp2022,StiCA,BEmcChkStat,ftt,-picowrite,-hitfilt,-evout", "/star/rcf/test/daq/2022/040/23040001/st_fwd_23040001_raw_0000003.daq")'
Error: Process completed with exit code 134.
```