### PR TITLE
[root6] Fix call to memset in TpcAvgCurrent.C

### DIFF
--- a/StarDb/Calibrations/tpc/TpcAvgCurrent.C
+++ b/StarDb/Calibrations/tpc/TpcAvgCurrent.C
@@ -1,7 +1,9 @@
+#include <cstring>
+
 TDataSet *CreateTable() {
   if (!gROOT->GetClass("St_TpcAvgCurrent")) return 0;
   TpcAvgCurrent_st row;
-  memset(row, 0, sizeof(TpcAvgCurrent_st));
+  std::memset(&row, 0, sizeof(TpcAvgCurrent_st));
   St_TpcAvgCurrent *tableSet = new St_TpcAvgCurrent("TpcAvgCurrent",1);
   tableSet->AddAt(&row);
   return (TDataSet *)tableSet;


### PR DESCRIPTION
```
StWarning: StDbSql::QueryDb(table,time) line=439 TpcAvgCurrent  has No data for query
LoadTable: .L /star-sw/StarDb/Calibrations/tpc/TpcAvgCurrent.C
In file included from input_line_983:1:
/star-sw/StarDb/Calibrations/tpc/TpcAvgCurrent.C:6:3: error: no matching function for call to 'memset'
  memset(row, 0, sizeof(TpcAvgCurrent_st));
  ^~~~~~
/usr/include/string.h:62:14: note: candidate function not viable: no known conversion from 'TpcAvgCurrent_st' to 'void *' for 1st argument; take the address of the argument with &
extern void *memset (void *__s, int __c, size_t __n) __THROW __nonnull ((1));
             ^
root4star: .sl79_gcc485/OBJ/StRoot/St_db_Maker/St_db_Maker.cxx:932: virtual TDataSet* St_db_Maker::LoadTable(TDataSet*): Assertion `!ee' failed.
Aborted
```
