### PR TITLE
Backport patches for embedding

### DIFF
--- a/StRoot/RTS/src/DAQ_TPX/tpxFCF.cxx
+++ b/StRoot/RTS/src/DAQ_TPX/tpxFCF.cxx
@@ -1617,6 +1617,10 @@ void tpxFCF::dump(tpxFCF_cl *cl, int row)
 
 		}
 
+		if(do_cuts==1 && run_compatibility >= 22) {	// ADDED in FY22, pp500
+			// kill ONEDPAD unless they fall before the trigger
+			if((cl->t_max > 20) && (fla & FCF_ONEPAD)) return ;
+		}
 	}
 
 

--- a/StRoot/RTS/src/DAQ_TPX/tpxGain.cxx
+++ b/StRoot/RTS/src/DAQ_TPX/tpxGain.cxx
@@ -828,7 +828,7 @@ void tpxGain::do_default(int sec)
 	return ;
 }
 
-int tpxGain::from_file(char *fname, int sec)
+int tpxGain::from_file(const char *fname, int sec)
 {
 	FILE *f ;
 	int s, r, p ;
@@ -999,7 +999,7 @@ int tpxGain::from_file(char *fname, int sec)
 }
 
 
-int tpxGain::to_file(char *fname) 
+int tpxGain::to_file(const char *fname) 
 {
 
 	FILE *f ;

--- a/StRoot/RTS/src/DAQ_TPX/tpxGain.h
+++ b/StRoot/RTS/src/DAQ_TPX/tpxGain.h
@@ -139,7 +139,7 @@ public:
 		return (gains[s-1] + r*TPX_MAX_PAD + (p-1)) ;
 	}
 
-	int from_file(char *fname, int sector = 0) ;
+	int from_file(const char *fname, int sector = 0) ;
 
 
 	// [sector 1-24][RDO 1-6][fee-index 0-35]
@@ -193,7 +193,7 @@ public:
 
 
 	// below used only during calculation
-	int to_file(char *fname) ;
+	int to_file(const char *fname) ;
 
 	void init(int sec=0) ;			// zap's structs; assume all TPX
 	void accum(char *evbuff, int bytes) ;	// parses one RDO's worth of pulser data

--- a/StRoot/StDetectorDbMaker/StDetectorDbChairs.cxx
+++ b/StRoot/StDetectorDbMaker/StDetectorDbChairs.cxx
@@ -37,8 +37,8 @@ void PrintTable(const Char_t *str, TTable *table) {
   Bool_t iprt = kTRUE;
   if (St_db_Maker::GetValidity(table,t) > 0) {
     if (table->InheritsFrom("St_tpcCorrection")) {
-      St_tpcCorrection *t = (St_tpcCorrection *) table;
-      tpcCorrection_st *s = t->GetTable(); Nrows = s->nrows;}
+      St_tpcCorrection *tt = (St_tpcCorrection *) table;
+      tpcCorrection_st *s = tt->GetTable(); Nrows = s->nrows;}
     if (Nrows > 10) Nrows = 10;
     CHECKTABLE(tpcCorrection);
     CHECKTABLE(tpcHVPlanes);
@@ -306,9 +306,8 @@ MakeChairInstance2(tpcCorrection,St_TpcdXdYC,Calibrations/tpc/TpcdXdY);
 MakeChairInstance2(GatingGrid,St_GatingGridC,Calibrations/tpc/GatingGrid);
 //________________________________________________________________________________
 Double_t St_GatingGridC::CalcCorrection(Int_t i, Double_t x) {// drift time in microseconds
-  if (x < 0) return 0;
-  GatingGrid_st *cor =  ((St_GatingGrid *) Table())->GetTable() + i;
   Double_t value = -10;
+  GatingGrid_st *cor =  ((St_GatingGrid *) Table())->GetTable() + i;
   if (x <= cor->t0) return value;
   Double_t corD = 1. - TMath::Exp(-(x-cor->t0)/(cor->settingTime/4.6));
   if (corD < 1e-4) return value;

--- a/StRoot/StMcEventMaker/PACKAGE
+++ b/StRoot/StMcEventMaker/PACKAGE
@@ -1,5 +1,5 @@
 # $Id $
 # package StMcEventMaker
 # author: 
-Library:libStMcEventMaker.so:LIBS +=   -lgen_Tables  -lsim_Tables  -lStChain  -l_StEEmcUtil  -l_StEmcUtil  -lStMcEvent
+Library:libStMcEventMaker.so:LIBS +=   -lgen_Tables  -lsim_Tables  -lStChain  -lStEEmcUtil  -lStEmcUtil  -lStMcEvent
 #Library:libStMcEventMaker.so:LIBS +=   -lgen_Tables  -lsim_Tables  -lStChain  -lStEEmcUtil  -lStEmcUtil  -lStMcEvent

--- a/StRoot/StMcEventMaker/StMcEventMaker.cxx
+++ b/StRoot/StMcEventMaker/StMcEventMaker.cxx
@@ -334,6 +334,8 @@ struct vertexFlag {
 	      int primaryFlag; };
 
 static const char rcsid[] = "$Id: StMcEventMaker.cxx,v 1.79 2016/08/04 01:54:33 perev Exp $";
+static long NTracks = 0;
+
 ClassImp(StMcEventMaker)
 #define AddHit2Track(G2Type,DET) \
   Int_t iTrkId = ( G2Type ## HitTable[ihit].track_p) - 1;	\
@@ -524,7 +526,9 @@ Int_t StMcEventMaker::Make()
     // Now we check if we have the pointer, if we do, then we can access the tables!
   
     if (g2t_vertexTablePointer && g2t_trackTablePointer){
-	
+      long NVertices = g2t_vertexTablePointer->GetNRows();
+      NTracks = g2t_trackTablePointer->GetNRows();
+      if (NVertices > 0 && NTracks > 0) {
 	//
 	// g2t_event Table
 	//
@@ -789,7 +793,6 @@ Int_t StMcEventMaker::Make()
 	//______________________________________________________________________
 	// Step 2 - Fill Vertices - we do not fill parent/daughters until Step 3
 	
-	long NVertices = g2t_vertexTablePointer->GetNRows();
 	  
 	vector<vertexFlag> vtemp(NVertices); // Temporary array for Step 3
        
@@ -838,7 +841,6 @@ Int_t StMcEventMaker::Make()
 	//______________________________________________________________________
 	// Step 3 - Fill Tracks - we do not fill associated hits until Step 4
 	
-	long NTracks = g2t_trackTablePointer->GetNRows();
 	size_t usedTracksG2t = 0;
 	long NGeneratorTracks = (particleTablePointer) ? particleTablePointer->GetNRows() : 0;
 	size_t usedTracksEvGen = 0;
@@ -1067,12 +1069,14 @@ Int_t StMcEventMaker::Make()
 		long nPseudoPadrow = 0;
 		long ihit;
 		for(ihit=0; ihit<NHits; ihit++) {
-		    if (tpcHitTable[ihit].volume_id < 101 || tpcHitTable[ihit].volume_id > 2445) {
-			if (tpcHitTable[ihit].volume_id <= 202445 &&
-			    tpcHitTable[ihit].volume_id > 2445) nPseudoPadrow++; 
+#if 1 /* keep all tpc hits => Inner TPC sector upgrade */
+		    if (tpcHitTable[ihit].volume_id < 101 || tpcHitTable[ihit].volume_id > 2472) {
+			if (tpcHitTable[ihit].volume_id <= 202472 &&
+			    tpcHitTable[ihit].volume_id > 2472) nPseudoPadrow++; 
 			else nBadVolId++;
 			continue;
 		    }
+#endif
 		    //		    g2t_tpc_hitTablePointer->Print(ihit,1);		  
 		    th = new StMcTpcHit(&tpcHitTable[ihit]);
 		    //		    cout << "McTpcHit\t" << ihit << *th << endl;
@@ -1295,6 +1299,7 @@ Int_t StMcEventMaker::Make()
 	//_______________________________________________________________
 	// At this point StMcEvent should be loaded.
 		
+      }
     }
     
     
@@ -1350,6 +1355,7 @@ void StMcEventMaker::fillBemc(St_g2t_emc_hit* g2t_emc_hitTablePointer)
 // 	cout << "eta       " << eta      << endl;
 // 	cout << "sub       " << sub      << endl;
 // 	cout << "detector  " << detector << endl;
+	if (emcHitTable->track_p <= 0 || emcHitTable->track_p > NTracks) continue;
 	tr   = ttemp[emcHitTable->track_p - 1];
 	de   = emcHitTable->de;
 		    
@@ -1423,6 +1429,7 @@ void StMcEventMaker::fillBsmd(St_g2t_emc_hit* g2t_smd_hitTablePointer)
     long NHits = g2t_smd_hitTablePointer->GetNRows();
     for(long ihit=0; ihit<NHits; ihit++,smdHitTable++) { 
 	geomBsmd->getVolIdBsmd(smdHitTable->volume_id, module,eta,sub,detector); // Must check ??
+	if (smdHitTable->track_p <= 0 || smdHitTable->track_p > NTracks) continue;
 	tr   = ttemp[smdHitTable->track_p - 1];
 	de   = smdHitTable->de;
 
@@ -1485,7 +1492,7 @@ void StMcEventMaker::fillEemc(St_g2t_emc_hit* g2t_tile, St_g2t_emc_hit* g2t_smd)
     const EEmcMCHit *h  = mEemcGeant.getGeantHits(nHit);
     for(Int_t i=0; i<nHit; i++,h++) {
 	int detId=h->detector;
-	assert(h->track_p>0); // tmp, to catch bugs,JB
+	if (h->track_p <= 0 || h->track_p > NTracks) continue;
 	StMcTrack *tr = ttemp[h->track_p - 1];
 	int Beta=0,Bsub=0,Bmodule=0; // barrel indexes
 	/* barrel indexes are used to lable eemc hits 
@@ -1579,6 +1586,7 @@ void StMcEventMaker::fillFpd(St_g2t_emc_hit* g2t_fpd_hitTablePointer)
     volume_id /= 1000;
     int nstb = volume_id % 10;
     int ew = volume_id / 10;
+    if (hit.track_p <= 0 || hit.track_p > NTracks) continue;
     StMcTrack* track = ttemp[hit.track_p - 1];
     // Store ew in module, nstb in sub, and ch in eta
     StMcCalorimeterHit* fpdHit = new StMcCalorimeterHit(ew,ch,nstb,hit.de,track);
@@ -1612,6 +1620,7 @@ void StMcEventMaker::fillFsc(St_g2t_emc_hit* g2t_fsc_hitTablePointer)
     int module = 1; 		// only one FSC exists at the moment :)
     int eta = floor(float(volume_id) / float(80)); // X coordinate
     int sub = volume_id % 80; 	// Y coordinate
+    if (hit.track_p <= 0 || hit.track_p > NTracks) continue;
     StMcTrack* track = ttemp[hit.track_p - 1];
     // Store ew in module, nstb in sub, and ch in eta
     StMcCalorimeterHit* fscHit = new StMcCalorimeterHit(module,eta,sub,hit.de,track);

--- a/StRoot/StTpcHitMaker/StTpcHitMaker.cxx
+++ b/StRoot/StTpcHitMaker/StTpcHitMaker.cxx
@@ -442,17 +442,6 @@ Int_t StTpcHitMaker::Make() {
     LOG_WARN << "TPC status indicates it is unusable for this event. Ignoring hits." << endm;
     return kStOK;
   }
-#ifdef __GENE__ /* I have no idea what the codes after */
-  if ( kMode == kTpx || kMode == kTpc || kMode == kiTPC ) {
-    pEvent = dynamic_cast<StEvent *> (GetInputDS("StEvent"));
-    if (Debug()) {LOG_INFO << "StTpcHitMaker::Make : StEvent has been retrieved " <<pEvent<< endm;}
-    if (! pEvent) {LOG_INFO << "StTpcHitMaker::Make : StEvent has not been found " << endm; return kStWarn;}
-    pHitCollection = pEvent->tpcHitCollection();
-  } else {
-    pEvent = 0;
-    pHitCollection = 0;
-  }
-#endif
 
   static Int_t minSector = IAttr("minSector");
   static Int_t maxSector = IAttr("maxSector");

--- a/StRoot/StTpcHitMaker/StTpcHitMaker.flow
+++ b/StRoot/StTpcHitMaker/StTpcHitMaker.flow
@@ -1,0 +1,356 @@
+StTpcRTSHitMaker::Make
+	daq_dta::finalize
+	daq_tpx::get
+		
+		daq_tpx::handle_cld_sim
+                        for each sim->iterate
+              1744                            LOG(NOTE,"No algo assigned for sector %d -- creating one!",sim->sec) ;
+1745                            fcf_algo[sim->sec] = new tpxFCF ;
+1746                            fcf_algo[sim->sec]->config(0x3F,1,sim_row_count,sim_tpx_rowlen) ;       // assume all 6 RDOs; extra data + annotations
+1747                            fcf_algo[sim->sec]->run_compatibility = fcf_run_compatibility ;
+1748                            fcf_algo[sim->sec]->do_cuts = fcf_do_cuts ;
+1749
+1750                            fcf_algo[sim->sec]->apply_gains(sim->sec,gain_algo) ;
+1751
+1752                            fcf_algo[sim->sec]->start_evt() ;
+1753
+1754                            if(fcf_tmp_storage==0) {
+1755                                    fcf_tmp_storage = (u_int *)valloc(FCF_TMP_BYTES) ;
+1756                            }
+            
+			tpxFCF::apply_gains
+			tpxFCF::tpxFCF	
+			tpxFCF::config
+				do_cuts = 2 ;   // 1 means always, 2 means don't cut edges (for i.e. pulser run), 0 means don't... 
+						   tpxFCF::tpxFCF (this=0x7dc7df0) at .sl73_x8664_gcc485/obj/StRoot/RTS/src/DAQ_TPX/tpxFCF.cxx:314
+		online/RTS/src/ESB/tpx.C:1186
+		if(run_type == RUN_TYPE_PULSER) fcf[i]->do_cuts = 2 ;	// to get even the bad edge
+		else fcf[i]->do_cuts = 1 ;	// just cut em...
+
+
+                        tpxFCF::stage2
+				tpxFCF::dump(tpxFCF_cl*, int)
+
+	daq_itpc::get
+		daq_itpc::handle_cld_sim
+			itpc_fcf_c::do_fc
+
+	dtaX = fTpx->get("cld_sim")       
+		handle_cld_sim(sec,row) daq_tpx::handle_cld_sim (this=0x75faa70, sec=-1, row=-1)
+
+
+================================================================================
+online/RTS/src/ESB/ddl.C
+	DET = new tpxHandler(sector) ;
+	DET->rb_mask = 1 << rb ;
+//	DET->rb[rb] = ddl ;
+	DET->set_mask(0,DET->rb_mask) ;
+
+	DET->subdet_id = sector ;
+
+	DET->run_type = RUN_TYPE_PED ;	// as the default...
+	DET->tcd_in_use = 0 ;		// default is self triggering...
+
+	DET->standalone = 1 ;
+================================================================================
+daq_tpx::put
+	daq_dta::create
+		daq_dta::release
+================================================================================
+StTpcRTSHitMaker::Make
+	dta = daq_itpc::put (this=0x59636f0, in_bank=0x7fffc3abda6a "adc_sim", sec=0, row=40, pad=0, p1=0x596c490, p2=0x0) 
+		adc_sim->create(32*1024,(char *)"adc_sim",rts_id,DAQ_DTA_STRUCT(daq_sim_adc_tb)) ;
+	daq_dta::finalize (this=0x5963ad0, obj_cou=3, sec=20, row=1, pad=21)
+		*store_cur = {sec = 20, row = 1, pad = 21, type = -90 '\246', nitems = 3}
+                   int bytes = sizeof(daq_store) + store_cur->nitems * hdr->obj_bytes ;
+(gdb) ptyp *hdr
+type = struct daq_store_hdr {
+    int hdr_bytes;
+    int hdr_version;
+    u_int endianess;
+    int obj_bytes;
+    char obj_name[32];
+    u_int bytes_used;
+    char describe[128];
+}
+p *hdr = {hdr_bytes = 180, hdr_version = 0, endianess = 67305985, obj_bytes = 8, obj_name = "daq_sim_adc_tb", '\000' <repeats 17 times>, bytes_used = 200,   describe = "adc_sim[31]:daq_sim_adc_tb[8 bytes]:Nov  8 2020\0..."}
+
+StTpcRTSHitMaker:INFO  - *** sec 20, row  1, pad  21:   3 pixels
+StTpcRTSHitMaker:INFO  -      0: adc   13, tb 326: track    1
+StTpcRTSHitMaker:INFO  -      1: adc   11, tb 327: track    1
+StTpcRTSHitMaker:INFO  -      2: adc    7, tb 328: track    1
+StTpcRTSHitMaker:INFO  - *** sec 20, row  1, pad  22:   5 pixels
+StTpcRTSHitMaker:INFO  -      0: adc    9, tb 325: track    1
+StTpcRTSHitMaker:INFO  -      1: adc   25, tb 326: track    1
+StTpcRTSHitMaker:INFO  -      2: adc   31, tb 327: track    1
+StTpcRTSHitMaker:INFO  -      3: adc   17, tb 328: track    1
+StTpcRTSHitMaker:INFO  -      4: adc    5, tb 329: track    1
+StTpcRTSHitMaker:INFO  - *** sec 20, row  1, pad  23:   4 pixels
+StTpcRTSHitMaker:INFO  -      0: adc    5, tb 325: track    1
+StTpcRTSHitMaker:INFO  -      1: adc    9, tb 326: track    1
+StTpcRTSHitMaker:INFO  -      2: adc   13, tb 327: track    1
+StTpcRTSHitMaker:INFO  -      3: adc    7, tb 328: track    1
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  1: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 22.015625[21:23], tb 326.828125[325:329], cha 153, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make Pad =   (sector= 20, row= 1, pad= 22.0156, tbuck= 326.828)
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make LS =    TPC_Local_Sector( (( (2.23985, 55.8, 192.403) , 20,1 )
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make L =     TPC_Local( (( (47.1942, -29.8889, -16.315) , 20,1 )
+Tpc s/r  20/  1 id     1 xyz:    47.194   -29.889   -16.315 q(keV)   1.15 idT     1 qa 100 fl  0 us 0 dX  0.00 pmin/max  21/ 23 np  3 tmin/max 325/329 nt  5 tm 326.83 pad  22.02 adc  153
+
+
+	dtaX = daq_itpc::get (this=0x59636f0, bank=0x7fffc3abda86 "cld_sim", sec=-1, row=-1, pad=-1, p1=0x0, p2=0x0)
+		daq_det::Make 
+			daq_det::presence
+                daq_itpc::handle_cld_sim (this=0x59636f0, sec=-1
+			itpc_fcf_c::itpc_fcf_c()
+			itpc_fcf_c::init (this=0x60480e0, sec=20, fname=0x0)
+			itpc_fcf_c::init (this=0x60480e0, gain=0x5963b90)
+			fcf[s]->do_ch_sim(sim->row,sim->pad,sim_array,track_array) ;
+
+
+Continuing.
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  1: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 21.968750[21:23], tb 327.203125[326:330], cha 112, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make Pad =   (sector= 20, row= 1, pad= 21.9688, tbuck= 327.203)
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make LS =    TPC_Local_Sector( (( (2.26329, 55.8, 192.631) , 20,1 )
+StTpcRTSHitMaker:INFO  - StTpcRTSHitMaker::Make L =     TPC_Local( (( (47.1825, -29.9092, -16.0864) , 20,1 )
+
+
+
+StTpcRTSHitMaker:INFO  - *** sec 20, row  1, Sum adc = 60
+StTpcRTSHitMaker:INFO  - *** sec 20, row  2, Sum adc = 154
+StTpcRTSHitMaker:INFO  - *** sec 20, row  3, Sum adc = 497
+StTpcRTSHitMaker:INFO  - *** sec 20, row  4, Sum adc = 319
+StTpcRTSHitMaker:INFO  - *** sec 20, row  5, Sum adc = 175
+StTpcRTSHitMaker:INFO  - *** sec 20, row  6, Sum adc = 159
+StTpcRTSHitMaker:INFO  - *** sec 20, row  7, Sum adc = 208
+StTpcRTSHitMaker:INFO  - *** sec 20, row  8, Sum adc = 220
+StTpcRTSHitMaker:INFO  - *** sec 20, row  9, Sum adc = 286
+StTpcRTSHitMaker:INFO  - *** sec 20, row 10, Sum adc = 154
+StTpcRTSHitMaker:INFO  - *** sec 20, row 11, Sum adc = 203
+StTpcRTSHitMaker:INFO  - *** sec 20, row 12, Sum adc = 293
+StTpcRTSHitMaker:INFO  - *** sec 20, row 13, Sum adc = 100
+StTpcRTSHitMaker:INFO  - *** sec 20, row 14, Sum adc = 212
+StTpcRTSHitMaker:INFO  - *** sec 20, row 15, Sum adc = 308
+StTpcRTSHitMaker:INFO  - *** sec 20, row 16, Sum adc = 115
+StTpcRTSHitMaker:INFO  - *** sec 20, row 17, Sum adc = 198
+StTpcRTSHitMaker:INFO  - *** sec 20, row 18, Sum adc = 709
+StTpcRTSHitMaker:INFO  - *** sec 20, row 19, Sum adc = 175
+StTpcRTSHitMaker:INFO  - *** sec 20, row 20, Sum adc = 228
+StTpcRTSHitMaker:INFO  - *** sec 20, row 21, Sum adc = 130
+StTpcRTSHitMaker:INFO  - *** sec 20, row 22, Sum adc = 202
+StTpcRTSHitMaker:INFO  - *** sec 20, row 23, Sum adc = 83
+StTpcRTSHitMaker:INFO  - *** sec 20, row 24, Sum adc = 168
+StTpcRTSHitMaker:INFO  - *** sec 20, row 25, Sum adc = 124
+StTpcRTSHitMaker:INFO  - *** sec 20, row 26, Sum adc = 538
+StTpcRTSHitMaker:INFO  - *** sec 20, row 27, Sum adc = 355
+StTpcRTSHitMaker:INFO  - *** sec 20, row 28, Sum adc = 66
+StTpcRTSHitMaker:INFO  - *** sec 20, row 29, Sum adc = 113
+StTpcRTSHitMaker:INFO  - *** sec 20, row 30, Sum adc = 82
+StTpcRTSHitMaker:INFO  - *** sec 20, row 31, Sum adc = 135
+StTpcRTSHitMaker:INFO  - *** sec 20, row 32, Sum adc = 268
+StTpcRTSHitMaker:INFO  - *** sec 20, row 33, Sum adc = 160
+StTpcRTSHitMaker:INFO  - *** sec 20, row 34, Sum adc = 171
+StTpcRTSHitMaker:INFO  - *** sec 20, row 35, Sum adc = 234
+StTpcRTSHitMaker:INFO  - *** sec 20, row 36, Sum adc = 247
+StTpcRTSHitMaker:INFO  - *** sec 20, row 37, Sum adc = 134
+StTpcRTSHitMaker:INFO  - *** sec 20, row 38, Sum adc = 111
+StTpcRTSHitMaker:INFO  - *** sec 20, row 39, Sum adc = 92
+StTpcRTSHitMaker:INFO  - *** sec 20, row 40, Sum adc = 212
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  1: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 22.281250[22:23], tb 326.656250[325:328], cha 60, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  2: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 23.078125[22:24], tb 326.531250[325:329], cha 154, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  3: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 24.125000[23:26], tb 326.437500[324:329], cha 508, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  4: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 24.984375[24:26], tb 326.281250[324:329], cha 323, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  5: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 26.093750[25:27], tb 325.718750[324:328], cha 166, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  6: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 27.140625[26:28], tb 325.500000[324:327], cha 161, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  7: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 27.140625[26:28], tb 325.468750[324:328], cha 211, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  8: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 28.156250[27:29], tb 325.109375[323:328], cha 225, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row  9: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 29.125000[28:30], tb 324.718750[323:327], cha 291, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 10: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 30.078125[29:31], tb 324.578125[323:327], cha 156, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 11: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 31.203125[30:32], tb 324.093750[322:326], cha 202, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 12: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 32.312500[31:34], tb 324.015625[322:326], cha 292, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 13: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 33.218750[32:34], tb 323.640625[322:326], cha 100, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 14: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 33.328125[32:34], tb 323.437500[321:326], cha 212, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 15: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 34.375000[33:36], tb 323.265625[321:326], cha 312, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 16: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 35.750000[35:37], tb 322.640625[321:324], cha 116, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 17: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 36.828125[36:38], tb 322.765625[321:325], cha 197, fla 0x10, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 18: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 37.906250[36:39], tb 322.562500[320:330], cha 714, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 19: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 38.875000[38:40], tb 322.203125[320:324], cha 166, fla 0x10, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 20: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 40.046875[39:42], tb 321.968750[320:324], cha 211, fla 0x10, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 21: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 40.250000[39:41], tb 321.312500[319:323], cha 134, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 22: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 41.593750[41:43], tb 321.718750[320:324], cha 209, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 24: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 43.734375[43:45], tb 320.843750[319:323], cha 167, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 25: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 44.640625[44:45], tb 320.437500[319:322], cha 127, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 26: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 46.000000[45:47], tb 320.296875[318:323], cha 559, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 27: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 47.140625[46:48], tb 320.187500[318:323], cha 360, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 29: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 48.781250[48:50], tb 319.609375[318:321], cha 113, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 30: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 49.687500[49:50], tb 319.125000[318:321], cha 82, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 31: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 50.859375[50:52], tb 319.062500[318:321], cha 134, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 32: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 52.281250[51:53], tb 318.593750[317:321], cha 269, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 33: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 53.406250[52:54], tb 318.468750[316:321], cha 160, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 34: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 54.703125[53:56], tb 317.968750[316:320], cha 162, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 35: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 55.031250[54:56], tb 318.000000[316:320], cha 238, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 36: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 56.218750[55:58], tb 317.937500[316:321], cha 242, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 37: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 57.343750[56:58], tb 317.343750[315:320], cha 136, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 39: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 59.703125[59:61], tb 316.734375[315:318], cha 93, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 40: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 61.140625[60:62], tb 316.718750[315:320], cha 216, fla 0x0, Id 1, Q 100 
+
+
+
+StTpcRTSHitMaker:INFO  - *** sec 20, row 14, Sum adc = 130
+StTpcRTSHitMaker:INFO  - *** sec 20, row 15, Sum adc = 95
+StTpcRTSHitMaker:INFO  - *** sec 20, row 16, Sum adc = 36
+StTpcRTSHitMaker:INFO  - *** sec 20, row 17, Sum adc = 122
+StTpcRTSHitMaker:INFO  - *** sec 20, row 18, Sum adc = 155
+StTpcRTSHitMaker:INFO  - *** sec 20, row 19, Sum adc = 106
+StTpcRTSHitMaker:INFO  - *** sec 20, row 20, Sum adc = 72
+StTpcRTSHitMaker:INFO  - *** sec 20, row 21, Sum adc = 148
+StTpcRTSHitMaker:INFO  - *** sec 20, row 22, Sum adc = 34
+StTpcRTSHitMaker:INFO  - *** sec 20, row 23, Sum adc = 68
+StTpcRTSHitMaker:INFO  - *** sec 20, row 24, Sum adc = 91
+StTpcRTSHitMaker:INFO  - *** sec 20, row 25, Sum adc = 106
+StTpcRTSHitMaker:INFO  - *** sec 20, row 26, Sum adc = 83
+StTpcRTSHitMaker:INFO  - *** sec 20, row 27, Sum adc = 186
+StTpcRTSHitMaker:INFO  - *** sec 20, row 28, Sum adc = 164
+StTpcRTSHitMaker:INFO  - *** sec 20, row 29, Sum adc = 126
+StTpcRTSHitMaker:INFO  - *** sec 20, row 30, Sum adc = 105
+StTpcRTSHitMaker:INFO  - *** sec 20, row 31, Sum adc = 248
+StTpcRTSHitMaker:INFO  - *** sec 20, row 32, Sum adc = 102
+StTpcRTSHitMaker:INFO  - *** sec 20, row 33, Sum adc = 125
+StTpcRTSHitMaker:INFO  - *** sec 20, row 34, Sum adc = 79
+StTpcRTSHitMaker:INFO  - *** sec 20, row 35, Sum adc = 56
+StTpcRTSHitMaker:INFO  - *** sec 20, row 36, Sum adc = 60
+StTpcRTSHitMaker:INFO  - *** sec 20, row 37, Sum adc = 128
+StTpcRTSHitMaker:INFO  - *** sec 20, row 38, Sum adc = 74
+StTpcRTSHitMaker:INFO  - *** sec 20, row 39, Sum adc = 124
+StTpcRTSHitMaker:INFO  - *** sec 20, row 40, Sum adc = 47
+StTpcRTSHitMaker:INFO  - *** sec 20, row 41, Sum adc = 208
+StTpcRTSHitMaker:INFO  - *** sec 20, row 42, Sum adc = 84
+StTpcRTSHitMaker:INFO  - *** sec 20, row 43, Sum adc = 69
+StTpcRTSHitMaker:INFO  - *** sec 20, row 44, Sum adc = 76
+StTpcRTSHitMaker:INFO  - *** sec 20, row 45, Sum adc = 56
+
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 14: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 51.250000[50:52], tb 308.859375[307:311], cha 130, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 15: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 52.531250[52:53], tb 308.718750[307:311], cha 95, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 16: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 54.000000[54:54], tb 308.281250[307:310], cha 36, fla 0x1, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 17: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 55.406250[55:56], tb 307.812500[306:310], cha 122, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 18: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 56.765625[56:58], tb 307.500000[306:310], cha 155, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 19: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 57.031250[56:58], tb 307.218750[306:309], cha 106, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 20: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 58.406250[58:59], tb 306.625000[305:308], cha 72, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 21: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 59.703125[59:61], tb 306.562500[305:309], cha 148, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 22: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 61.000000[61:61], tb 306.296875[305:308], cha 34, fla 0x1, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 23: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 61.562500[61:62], tb 305.875000[304:308], cha 68, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 24: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 62.875000[62:64], tb 305.609375[304:307], cha 91, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 25: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 64.312500[63:65], tb 305.171875[304:307], cha 106, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 26: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 65.593750[65:66], tb 304.953125[303:307], cha 83, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 27: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 67.125000[66:68], tb 304.484375[303:307], cha 186, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 28: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 68.671875[68:70], tb 304.218750[302:307], cha 164, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 29: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 69.000000[68:70], tb 303.765625[302:306], cha 126, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 30: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 70.421875[69:71], tb 303.406250[302:305], cha 105, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 31: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 71.921875[71:73], tb 303.156250[301:306], cha 248, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 32: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 73.281250[72:74], tb 302.718750[301:305], cha 102, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 33: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 73.906250[73:75], tb 302.421875[301:304], cha 125, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 34: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 75.359375[75:76], tb 302.203125[301:304], cha 79, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 35: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 76.609375[76:77], tb 301.593750[300:303], cha 56, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 36: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 78.390625[78:79], tb 301.265625[300:303], cha 60, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 37: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 79.906250[79:81], tb 301.125000[299:303], cha 128, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 38: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 81.421875[81:82], tb 301.062500[300:303], cha 74, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 39: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 81.812500[81:83], tb 300.531250[299:303], cha 124, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 40: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 83.468750[83:84], tb 300.125000[299:302], cha 47, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 41: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 85.078125[84:86], tb 299.671875[298:302], cha 208, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 42: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 86.468750[86:87], tb 299.406250[298:301], cha 84, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 44: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 87.562500[87:88], tb 298.671875[297:300], cha 76, fla 0x0, Id 1, Q 100 
+StTpcRTSHitMaker:INFO  - CLD sec 20: row 45: 1 clusters
+StTpcRTSHitMaker:INFO  -     pad 88.453125[88:89], tb 298.218750[297:300], cha 56, fla 0x0, Id 1, Q 100 
+================================================================================
+type = struct tpxFCF::stage1 {
+    unsigned short count;
+    unsigned short f;
+    double g;
+    double t0;
+    tpxFCF_cl cl[64];
+}
+
+struct stage1  *get_working(int row, int pad) => working_storage[s][row]
+struct stage1 *get_stage1(int row, int pad)   => storage + row_ix[row] + (pad-1) 
+================================================================================
+sec:20
+ Tpx:   0
+        0       0       0       0       0       0       0       0       0       0
+        0       0       0       142     144     144     144     144     0       0
+        0       51      51      102     102     154     153     205     204     0
+        0       51      51      102     102     51      51      0       0       205
+        204     154     153     102     102
+        iTpc:   0
+        52      54      56      58      60      62      62      64      66      68
+        70      72      74      74      76      78      80      82      84      86
+        86      88      90      92      94      96      98      98      100     102
+        104     106     108     110     110     112     114     116     118     120
+

--- a/StRoot/StTpcHitMaker/StTpcRTSHitMaker.cxx
+++ b/StRoot/StTpcHitMaker/StTpcRTSHitMaker.cxx
@@ -6,6 +6,7 @@
  ***************************************************************************
  *
  * Description:  Make clusters from StTpcRawData and fill the StEvent      */
+//#define __USE_GAIN_FROM_FILE__
 #include <assert.h>
 #include <sys/types.h>
 #include <stdio.h>
@@ -29,12 +30,17 @@
 #include "StDetectorDbMaker/St_itpcPadPlanesC.h"
 #include "StDetectorDbMaker/St_tpcPadConfigC.h"
 #include "StDetectorDbMaker/St_tpcStatusC.h"
+#ifdef __USE_GAIN_FROM_FILE__
+#include "StDetectorDbMaker/StPath2tpxGain.h"
+#include "StDetectorDbMaker/StPath2itpcGain.h"
+#endif /* __USE_GAIN_FROM_FILE__ */
 #include "StMessMgr.h" 
 #include "StDAQMaker/StDAQReader.h"
 #include "StRtsTable.h"
 #include "DAQ_TPX/daq_tpx.h"
 #include "DAQ_ITPC/daq_itpc.h"
 #include "DAQ_READER/daq_dta.h"
+#include "DAQ_READER/daq_det.h"
 #include "DAQ_READER/daqReader.h"
 #include "RTS/src/DAQ_TPX/tpxFCF_flags.h" // for FCF flag definition
 #include "RTS/src/DAQ_TPX/daq_tpx.h"
@@ -43,6 +49,11 @@
 #include "RTS/src/DAQ_TPX/tpxGain.h"
 #include "RTS/src/DAQ_TPX/tpxFCF.h"
 #include "RTS/src/DAQ_TPX/tpxStat.h"
+#include "RTS/src/DAQ_ITPC/itpcFCF.h"
+#ifdef __TFG__VERSION__
+#include "TPC23/tpx23.h"
+#include "TPC23/itpc23.h"
+#endif /*  __TFG__VERSION__ */
 #include "TBenchmark.h"
 ClassImp(StTpcRTSHitMaker); 
 #define __DEBUG__
@@ -51,12 +62,14 @@ ClassImp(StTpcRTSHitMaker);
 #else
 #define PrPP(A,B)
 #endif
-UChar_t StTpcRTSHitMaker::mTpx_RowLen[46]  = {0};
-UChar_t StTpcRTSHitMaker::miTpc_RowLen[41] = {0};
 //________________________________________________________________________________
 StTpcRTSHitMaker::~StTpcRTSHitMaker() {
   SafeDelete(fTpx);
   SafeDelete(fiTpc);
+#ifdef __TFG__VERSION__
+  SafeDelete(fTpx23);
+  SafeDelete(fiTpc23);
+#endif /*  __TFG__VERSION__ */
 }
 //________________________________________________________________________________
 Int_t StTpcRTSHitMaker::Init() {
@@ -65,189 +78,213 @@ Int_t StTpcRTSHitMaker::Init() {
   bin0Hits = 0;
   return StMaker::Init();
 }
+#ifdef __USE_GAIN_FROM_FILE__
+//________________________________________________________________________________
+Int_t StTpcRTSHitMaker::from_file(daq_dta *gain_dta, const Char_t *fname) {
+  // example of gains; will use file for that
+  FILE *f = fopen(fname,"r") ;
+  if(f==0) {
+    LOG_ERROR <<  "Can't open gain file\t" << fname << endm;
+    return -1 ;
+  }
+  static struct g_s_t {
+    float g ;
+    float t ;
+  } g_s[25][41][121] ;
+  
+  Int_t bad_ch = 0 ;
+  Int_t all_ch = 0 ;
+  while(!feof(f)) {
+    char buff[128] ;
+    Int_t sec,rdo,port,ch,row,pad ;
+    float g, t ;
+    
+    if(fgets(buff,sizeof(buff),f)==0) continue ;
+    
+    if(buff[0]=='#') continue ;
+    if(strlen(buff)<1) continue ;
+    
+    Int_t ret = sscanf(buff,"%d %d %d %d %d %d %f %f",&sec,&rdo,&port,&ch,&row,&pad,&g,&t) ;
+    if(ret != 8) continue ;
+    
+    if(g<0.01) bad_ch++ ;
+    all_ch++ ;
+    
+    g_s[sec][row][pad].g = g ;
+    g_s[sec][row][pad].t = t ;
+  }
+  LOG_INFO << Form("From gain file %s: %d/%d bad channels",fname,bad_ch,all_ch) << endm;
+  fclose(f) ;
+  // and now load them up
+  for(Int_t s=1;s<=24;s++) {	// sectors loop
+    for(Int_t r=1;r<=40;r++) {	// rows loop
+      daq_det_gain *gain = (daq_det_gain *) gain_dta->request(121) ;
+      for(Int_t p=0;p<=120;p++) {	// pad loop
+	gain[p].gain = g_s[s][r][p].g ;
+	gain[p].t0 = g_s[s][r][p].t ;
+      }
+      gain_dta->finalize(121,s,r) ;
+    }
+  }
+  return 1;
+}
+#endif /* __USE_GAIN_FROM_FILE__ */
 //________________________________________________________________________________
 Int_t StTpcRTSHitMaker::InitRun(Int_t runnumber) {
   SetAttr("minSector",1);
   SetAttr("maxSector",24);
   SetAttr("minRow",1);
   if (IAttr("Cosmics")) StTpcHitMaker::SetCosmics();
-  Int_t sector = 20;
-  // Fill no. of pad per row 
-  //    mTpx_RowLen = new UChar_t[St_tpcPadConfigC::instance()->numberOfRows(sector)+1];
-  for (Int_t row = 1; row <= St_tpcPadPlanesC::instance()->padRows(); row++) {
-    mTpx_RowLen[row] = St_tpcPadPlanesC::instance()->padsPerRow(row);
-  }
-  if (St_tpcPadConfigC::instance()->iTPC(sector)) {
-    for (Int_t row = 1; row <= St_tpcPadPlanesC::instance()->innerPadRows(); row++) {
-      mTpx_RowLen[row] = St_tpcPadPlanesC::instance()->padsPerRow(row);
-    }
-  }
-#if 0
-  cout << "sec:" << sector<< endl << " Tpx:";
-  for (Int_t row = 0; row <= 45; row++) {cout << "\t" << (int) mTpx_RowLen[row]; if (row%10 == 0) cout << endl;} 
-  cout << endl;
-  cout << "\tiTpc:";
-  for (Int_t row = 0; row <= 40; row++) {cout << "\t" << (int) miTpc_RowLen[row]; if (row%10 == 0) cout << endl;} 
-  cout << endl;
-#endif
   SetAttr("maxRow",St_tpcPadConfigC::instance()->numberOfRows(20));
   SafeDelete(fTpx);
-  fTpx = new daq_tpx() ; 
-  if (GetDate() >= 20091215) fTpx->fcf_run_compatibility = 10 ;
-  // change default value 2 to 
-  fTpx->fcf_do_cuts = 1; // 1 means always, 2 means don't cut edges (for i.e. pulser run), 0 means don't...
-  //  if (GetDate() >= 20121215) fTpx->fcf_style = 2 ;  // from online/RTS/src/ESB/tpx.C new for FY13!
-  if (GetDate() <= 20090101) fminCharge = 40;
-  // Check presence iTPC
   SafeDelete(fiTpc);
-  static Bool_t fNoiTPCLu  = IAttr("NoiTPCLu");
-  if (! fNoiTPCLu) {
-    for(Int_t sector=1;sector<=24;sector++) {
-      if (St_tpcPadConfigC::instance()->iTPC(sector)) {
-	fiTpc = new daq_itpc() ;
-	break;
-      }
-    }
-  }
-  StMaker* maskMk = GetMakerInheritsFrom("StMtdTrackingMaskMaker");
-  unsigned int mask = (maskMk ? maskMk->UAttr("TpcSectorsByMtd") : ~0U); // 24 bit masking for sectors 1..24
-#if 0 
- // Prepare scaled hit maxima
-  // No hit maxima if these DB params are 0
-  Int_t maxHitsPerSector = St_tpcMaxHitsC::instance()->maxSectorHits();
-  Int_t maxBinZeroHits = St_tpcMaxHitsC::instance()->maxBinZeroHits();
-  Int_t livePads = 0;
-  Int_t totalPads = 0;
-  Float_t liveFrac = 1;
-#endif
-  // Load gains
-  daq_det_gain *gain = 0;
-  // do gains example; one loads themfrom database but I don't know how...
-  daq_dta *dta_Tpx  = fTpx->put("gain"); // , 0, 45,0, mTpx_RowLen);
-#if 0
-  Int_t totalSecPads = 0;
-#endif
-  for(Int_t sector=1;sector<=24;sector++) {
-    if (!((1U<<(sector-1)) & mask)) continue; // sector masking
-#if 0
-    Int_t liveSecPads = 0;
-    totalSecPads = 0;
-#endif
-    // Tpx
-    Int_t rowMin = 1;
-    if (St_tpcPadConfigC::instance()->iTPC(sector)) rowMin = 14; 
-    for(Int_t rowO = 1; rowO <= 45; rowO++) {
-      Int_t Npads = St_tpcPadPlanesC::instance()->padsPerRow(rowO);
-#if 0
-      Int_t nBadPads = 3;
-      if (rowO ==  1 || 
-	  (rowO >= 5 && rowO <= 14) || 
-	  rowO == 19 ||
-	  rowO == 23 ||
-	  rowO == 24 ||
-	  rowO == 29 ||
-	  rowO == 33 ||
-	  rowO == 34 ||
-	  rowO == 39 ||
-	  rowO == 43)  nBadPads = 2;
-      else if (rowO >= 44) nBadPads = 1;
-      Int_t padMin = nBadPads + 1;
-      Int_t padMax = Npads - nBadPads;
+#ifdef __TFG__VERSION__
+  SafeDelete(fTpx23);
+  SafeDelete(fiTpc23);
+#endif /*  __TFG__VERSION__ */
+#ifdef __USE_GAIN_FROM_FILE__
+    const Char_t *fname  = StPath2tpxGain::instance()->GetPath();
+    const Char_t *fnameITPC  = StPath2itpcGain::instance()->GetPath();
 #else
-      Int_t padMin = 1;
-      Int_t padMax = Npads;
-#endif
-      gain = (daq_det_gain *) dta_Tpx->request(Npads+1);    // max pad+1            
-      for(Int_t pad = 0; pad <= Npads; pad++) {
-	gain[pad].gain = 0.; // be sure that dead pads are killed
-	gain[pad].t0   = 0.;
-	if (rowO >= rowMin && pad >= padMin && pad <= padMax) {
-	  if (St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad) <= 0) continue;
-	  gain[pad].gain = St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad);
-	  gain[pad].t0   = St_tpcPadGainT0C::instance()->T0(sector,rowO,pad);
+    const Char_t *fname  = "none";
+    const Char_t *fnameITPC  = "none";
+#endif /* __USE_GAIN_FROM_FILE__ */
+#ifdef __TFG__VERSION__
+  if ( IAttr("TPC23")) { // TPC23
+    Int_t log_level = 0 ;
+    fTpx23  = new tpx23;
+    fTpx23->log_level = log_level;
+    if (fTpx23->gains_from_cache(fname) < 0) {	// REQUIRED even if no gain correction
+      // Tpx Load gains from Db
+      for(Int_t sector=1;sector<=24;sector++) {
+	Int_t rowMin = 1;
+	if (St_tpcPadConfigC::instance()->iTPC(sector)) rowMin = 14; 
+	for(Int_t rowO = 1; rowO <= 45; rowO++) {
+	  Int_t Npads = St_tpcPadPlanesC::instance()->padsPerRow(rowO);
+	  Int_t padMin = 1;
+	  Int_t padMax = Npads;
+	  for(Int_t pad = 0; pad <= Npads; pad++) {
+	    fTpx23->rp_gain[sector-1][rowO][pad].gain = 0.; // be sure that dead pads are killed
+	    fTpx23->rp_gain[sector-1][rowO][pad].t0   = 0.;
+	    if (rowO >= rowMin && pad >= padMin && pad <= padMax) {
+	      if (St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad) <= 0) continue;
+	      fTpx23->rp_gain[sector-1][rowO][pad].gain = St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad);
+	      fTpx23->rp_gain[sector-1][rowO][pad].t0   = St_tpcPadGainT0C::instance()->T0(sector,rowO,pad);
+	    }
+	  }
 	}
       }
-      // daq_dta::finalize(u_int obj_cou, int sec, int row, int pad)
-      dta_Tpx->finalize(Npads+1,sector,rowO);
-#if 0
-      if (maxHitsPerSector > 0 || maxBinZeroHits > 0) {
-	totalSecPads += Npads;
-	Int_t row = rowO;
-	if (St_tpcPadConfigC::instance()->iTPC(sector) && rowO > 13)  row = rowO + 40 - 13;
-	if (StDetectorDbTpcRDOMasks::instance()->isRowOn(sector,row) &&
-	    St_tpcAnodeHVavgC::instance()->livePadrow(sector,row))
-	  liveSecPads += Npads;
-      }
-#endif
     }
-  }
-  // iTpc
-  if (fiTpc) {
-    daq_dta * dta_iTpc = fiTpc->put("gain"); // , 0, 40, 0, miTpc_RowLen);
-    for(Int_t sector=1;sector<=24;sector++) {
-      if (! St_tpcPadConfigC::instance()->iTPC(sector)) continue;
-      for(Int_t row = 1; row <= 40; row++) {
-	Int_t Npads = St_itpcPadPlanesC::instance()->padsPerRow(row);
-	gain = (daq_det_gain *) dta_iTpc->request(Npads+1);	// max pad+1		
-	for(Int_t pad = 0; pad <= Npads; pad++) {
-	  gain[pad].gain = 0.; // be sure that dead pads are killed
-	  gain[pad].t0   = 0.;
-	  if (pad < 1) continue; // kill pad0 just in case..
-	  if (St_itpcPadGainT0C::instance()->Gain(sector,row,pad) <= 0) continue;
-	  gain[pad].gain = St_itpcPadGainT0C::instance()->Gain(sector,row,pad);
-	  gain[pad].t0   = St_itpcPadGainT0C::instance()->T0(sector,row,pad);
-	  //#define __DEBUG_GAIN__
+    fTpx23->run_start() ;
+    // iTPC23
+    fiTpc23 = new itpc23 ;
+    fiTpc23->log_level = log_level;
+    if (fiTpc23->gains_from_cache(fnameITPC) < 0) {	// REQUIRED even if no gain correction
+      for(Int_t sector=1;sector<=24;sector++) {
+	if (! St_tpcPadConfigC::instance()->iTPC(sector)) continue;
+	for(Int_t row = 1; row <= 40; row++) {
+	  Int_t Npads = St_itpcPadPlanesC::instance()->padsPerRow(row);
+	  for(Int_t pad = 0; pad <= Npads; pad++) {
+	    fiTpc23->rp_gain[sector-1][row][pad].gain = 0.; // be sure that dead pads are killed
+	    fiTpc23->rp_gain[sector-1][row][pad].t0   = 0.;
+	    if (pad < 1) continue; // kill pad0 just in case..
+	    if (St_itpcPadGainT0C::instance()->Gain(sector,row,pad) <= 0) continue;
+	    fiTpc23->rp_gain[sector-1][row][pad].gain = St_itpcPadGainT0C::instance()->Gain(sector,row,pad);
+	    fiTpc23->rp_gain[sector-1][row][pad].t0   = St_itpcPadGainT0C::instance()->T0(sector,row,pad);
+	    //#define __DEBUG_GAIN__
 #ifdef __DEBUG_GAIN__
-	  cout << Form("Gain/T0 s/r/p %3i/%3i/%3i %7.2f %7.2f",sector,row,pad,gain[pad].gain,gain[pad].t0) << endl;
+	    cout << Form("Gain/T0 s/r/p %3i/%3i/%3i %7.2f %7.2f",sector,row,pad,fiTpc23->rp_gain[sector-1][row][pad].gain,fiTpc23->rp_gain[sector-1][row][pad].t0) << endl;
 #endif /* __DEBUG_GAIN__ */
+	  }
 	}
-	// daq_dta::finalize(u_int obj_cou, int sec, int row, int pad)
-	dta_iTpc->finalize(Npads+1,sector,row);
-#if 0
-	if (maxHitsPerSector > 0 || maxBinZeroHits > 0) {
-	  totalSecPads += Npads;
-	  if (StDetectorDbTpcRDOMasks::instance()->isRowOn(sector,row) &&
-	      St_tpcAnodeHVavgC::instance()->livePadrow(sector,row))
-	    liveSecPads += Npads;
+      }
+    }
+    fiTpc23->run_start() ;
+  } else {
+#endif /*  __TFG__VERSION__ */
+    fTpx = new daq_tpx() ; 
+    if (GetDate() >= 20091215) fTpx->fcf_run_compatibility = 10 ;
+    if (GetDate() >= 20191215) fTpx->fcf_run_compatibility = 22 ;
+    // change default value 2 to 
+    fTpx->fcf_do_cuts = 1; // 1 means always, 2 means don't cut edges (for i.e. pulser run), 0 means don't...
+    //  if (GetDate() >= 20121215) fTpx->fcf_style = 2 ;  // from online/RTS/src/ESB/tpx.C new for FY13!
+    if (GetDate() <= 20090101) fminCharge = 40;
+    // do gains example; one loads them from database but I don't know how...
+    //    daq_dta *dta_Tpx  = fTpx->put("gain"); 
+    tpxGain *gain = fTpx->gain_algo;
+    // gain->do_default(sector) ;	// zap to all 1...
+    if (gain->from_file(fname, 0) < 0) {
+      for(Int_t sector=1;sector<=24;sector++) {
+	// Tpx
+	Int_t rowMin = 1;
+	if (St_tpcPadConfigC::instance()->iTPC(sector)) rowMin = 14; 
+	for(Int_t rowO = 1; rowO <= 45; rowO++) {
+	  Int_t Npads = St_tpcPadPlanesC::instance()->padsPerRow(rowO);
+	  Int_t padMin = 1;
+	  Int_t padMax = Npads;
+	  //	daq_det_gain *gain = (daq_det_gain *) dta_Tpx->request(Npads+1);    // max pad+1            
+	  for(Int_t pad = 0; pad <= Npads; pad++) {
+	    //	  gain[pad].gain = 0.; // be sure that dead pads are killed
+	    //	  gain[pad].t0   = 0.;
+	    gain->set_gains(sector, rowO, pad, 0, 0);
+	    if (rowO >= rowMin && pad >= padMin && pad <= padMax) {
+	      if (St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad) <= 0) continue;
+	      //	    gain[pad].gain = St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad);
+	      //	    gain[pad].t0   = St_tpcPadGainT0C::instance()->T0(sector,rowO,pad);
+	      gain->set_gains(sector, rowO, pad, St_tpcPadGainT0C::instance()->Gain(sector,rowO,pad), St_tpcPadGainT0C::instance()->T0(sector,rowO,pad));
+	    }
+	  }
+	  // daq_dta::finalize(uint32_t obj_cou, Int_t sec, Int_t row, Int_t pad)
+	  //	dta_Tpx->finalize(Npads+1,sector,rowO);
 	}
-#endif
+      }
     }
+    //    ((daq_tpx*) dta_Tpx)->InitRun(runnumber);
+    // Check presence iTPC
+    static Bool_t fNoiTPCLu  = IAttr("NoiTPCLu");
+    if (! fNoiTPCLu) {
+      for(Int_t sector=1;sector<=24;sector++) {
+	if (St_tpcPadConfigC::instance()->iTPC(sector)) {
+	  fiTpc = new daq_itpc() ;
+	  break;
+	}
+      }
     }
-#if 0
-    livePads += liveSecPads;
-    totalPads += totalSecPads;
-    if (maxHitsPerSector > 0) {
-      liveFrac = TMath::Max(0.1f,
-			    ((Float_t) liveSecPads) / (1e-15f + (Float_t) totalSecPads));
-      maxHits[sector-1] = (Int_t) (liveFrac * maxHitsPerSector);
-      if (Debug()) {LOG_INFO << "maxHits in sector " << sector
-			     << " = " << maxHits[sector-1] << endm;}
-    } else {
-      maxHits[sector-1] = 0;
-      if (Debug()) {LOG_INFO << "No maxHits in sector " << sector << endm;}
-    }
-    if (maxBinZeroHits > 0) {
-      liveFrac = TMath::Max(0.1f,
-			    ((Float_t) livePads) / (1e-15f + (Float_t) totalPads));
-      maxBin0Hits = (Int_t) (liveFrac * maxBinZeroHits);
-      if (Debug()) {LOG_INFO << "maxBinZeroHits " << maxBin0Hits << endm;}
-    } else {
-      maxBin0Hits = 0;
-      if (Debug()) {LOG_INFO << "No maxBinZeroHits" << endm;}
-    }
-#endif
+    // iTpc
+    if (fiTpc) {
+      daq_dta * dta_iTpc = fiTpc->put("gain"); // , 0, 40, 0, miTpc_RowLen);
+#ifdef __USE_GAIN_FROM_FILE__
+      if (from_file(dta_iTpc, fname) < 0) {
+#endif /* __USE_GAIN_FROM_FILE__ */
+	for(Int_t sector=1;sector<=24;sector++) {
+	  if (! St_tpcPadConfigC::instance()->iTPC(sector)) continue;
+	  for(Int_t row = 1; row <= 40; row++) {
+	    Int_t Npads = St_itpcPadPlanesC::instance()->padsPerRow(row);
+	    daq_det_gain *gain = (daq_det_gain *) dta_iTpc->request(Npads+1);	// max pad+1		
+	    for(Int_t pad = 0; pad <= Npads; pad++) {
+	      gain[pad].gain = 0.; // be sure that dead pads are killed
+	      gain[pad].t0   = 0.;
+	      if (pad < 1) continue; // kill pad0 just in case..
+	      if (St_itpcPadGainT0C::instance()->Gain(sector,row,pad) <= 0) continue;
+	      gain[pad].gain = St_itpcPadGainT0C::instance()->Gain(sector,row,pad);
+	      gain[pad].t0   = St_itpcPadGainT0C::instance()->T0(sector,row,pad);
+	      //#define __DEBUG_GAIN__
+#ifdef __DEBUG_GAIN__
+	      cout << Form("Gain/T0 s/r/p %3i/%3i/%3i %7.2f %7.2f",sector,row,pad,gain[pad].gain,gain[pad].t0) << endl;
+#endif /* __DEBUG_GAIN__ */
+	    }
+	    // daq_dta::finalize(uint32_t obj_cou, Int_t sec, Int_t row, Int_t pad)
+	    dta_iTpc->finalize(Npads+1,sector,row);
+	  }
+	  //      ((daq_itpc *) dta_iTpc)->InitRun(runnumber);
+	}
+#ifdef __USE_GAIN_FROM_FILE__
+      }
+#endif /* __USE_GAIN_FROM_FILE__ */
+    } // 
+#ifdef __TFG__VERSION__
   }
-  /*
-    InitRun will setup the internal representations of gain 
-    and other necessary structures but if the gains have not
-    been previously loaded as shown in the example above they
-    will be set to 1.0!
-  */
-#if 0
-  if (St_tpcPadConfigC::instance()->numberOfRows(20) <= 45) { // hack for now take Tonko's defaults for iTpx
-    fTpx->InitRun(runnumber);
-  }
-#endif
+#endif /*  __TFG__VERSION__ */
   PrintAttr();
   return kStOK;
 }
@@ -312,6 +349,9 @@ Int_t StTpcRTSHitMaker::Make() {
     LOG_WARN << "TPC status indicates it is unusable for this event. Ignoring hits." << endm;
     return kStOK;
   }
+#ifdef __TFG__VERSION__
+  if (IAttr("TPC23")) return Make23();
+#endif /*  __TFG__VERSION__ */
   static Short_t ADCs[__MaxNumberOfTimeBins__];
 #ifdef __TFG__VERSION__
   static Int_t IDTs[__MaxNumberOfTimeBins__];
@@ -347,10 +387,13 @@ Int_t StTpcRTSHitMaker::Make() {
   static Int_t  maxSector = IAttr("maxSector");
   static Int_t  minRow    = IAttr("minRow");
   static Int_t  maxRow    = IAttr("maxRow");
+  StMaker* maskMk = GetMakerInheritsFrom("StMtdTrackingMaskMaker");
+  UInt_t   mask = (maskMk ? maskMk->UAttr("TpcSectorsByMtd") : ~0U); // 24 bit masking for sectors 1..24
   bin0Hits = 0;
   for (Int_t sector = minSector; sector <= maxSector; sector++) {
     StTpcDigitalSector *digitalSector = tpcRawData->GetSector(sector);
     if (! digitalSector) continue;
+    if (!((1U<<(sector-1)) & mask)) continue; // sector masking
     UShort_t Id = 0;
     Int_t hitsAdded = 0;
     for (Int_t iTpcType  = 1; iTpcType >= 0; iTpcType--) {// Tpx iTPC
@@ -359,24 +402,22 @@ Int_t StTpcRTSHitMaker::Make() {
       Int_t row2 = maxRow;
       // Check presense of iTPC and adjust row range
       if (St_tpcPadConfigC::instance()->iTPC(sector)) {
-	//  daq_tpx::get(const char *bank="*", int c1=-1, int c2=-1, int c3=-1, void *p1=0, void *p2=0)
-	//           put(const char *bank="*", int c1=-1, int c2=-1, int c3=-1, void *p1=0, void *p2=0)
-	// daq_itpc::get(const char *bank="*",int c1=-1, int c2=-1, int c3=-1, void *p1=0, void *p2=0)
-	//           put(const char *in_bank="*", int sector=-1, int row=-1, int pad=-1, void *p1=0, void *p2=0)
+	//  daq_tpx::get(const Char_t *bank="*", Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	//           put(const Char_t *bank="*", Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	// daq_itpc::get(const Char_t *bank="*",Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	//           put(const Char_t *in_bank="*", Int_t sector=-1, Int_t row=-1, Int_t pad=-1, void *p1=0, void *p2=0)
 	if (! iTpcType) { // Tpx
-	  if (! fTpx) continue;
 	  row1 = TMath::Max(row1, 41); 
-	  dta = fTpx->put("adc_sim"); // , 0, 45,0, mTpx_RowLen); 
+	  if (fTpx) dta = fTpx->put("adc_sim"); 
 	} else { // iTpc           {
-	  if (! fiTpc) continue;
 	  row2 = TMath::Min(40, row2); 
-	  dta = fiTpc->put("adc_sim"); // , 0, 40, 0, miTpc_RowLen); 
+	  if (fiTpc) dta = fiTpc->put("adc_sim"); 
 	}
       } else { // no iTPC
-	if (! fTpx) continue;
 	row2 = TMath::Min(45, row2);
-	dta = fTpx->put("adc_sim"); // , 0, 45,0, mTpx_RowLen);
+	if (fTpx) dta = fTpx->put("adc_sim"); 
       }
+      if (! dta) continue;
       Int_t NoAdcs = 0;
       for (Int_t row = row1; row <= row2; row++) {
 	if (! St_tpcPadGainT0BC::instance()->livePadrow(sector,row)) continue;
@@ -408,7 +449,7 @@ Int_t StTpcRTSHitMaker::Make() {
 #ifdef __BENCHMARK__
 	    //	    myBenchmark->Start("StTpcRTSHitMaker::Make::finalize");
 #endif
-	    // daq_dta::finalize(u_int obj_cou, int s=0, int row=0, int pad=0) ;
+	    // daq_dta::finalize(uint32_t obj_cou, Int_t s=0, Int_t row=0, Int_t pad=0) ;
 	    dta->finalize(l,sector,rowO,pad);
 #ifdef __BENCHMARK__
 	    //	    myBenchmark->Stop("StTpcRTSHitMaker::Make::finalize");
@@ -417,7 +458,7 @@ Int_t StTpcRTSHitMaker::Make() {
 	  }
 	} // pad loop
       } // row loop      
-	if (! NoAdcs) continue;
+      if (! NoAdcs) continue;
 	daq_dta *dtaX = 0;
 	if (! iTpcType) {
 	  if (fTpx) dtaX = fTpx->get("adc_sim");
@@ -427,33 +468,18 @@ Int_t StTpcRTSHitMaker::Make() {
 	dta = dtaX;
 	if (Debug()) {
 	  PrintAdc(dta);
-#if 0
-	  // verify data!
-	  while(dta && dta->iterate()) {
-	    LOG_INFO << Form("*** sec %2d, row %2d, pad %3d: %3d pixels",dta->sec,dta->row,dta->pad,dta->ncontent) << endm;
-	    for(UInt_t i=0;i<dta->ncontent;i++) {
-	      if (Debug() > 1 || dta->sim_adc[i].track_id) {
-		LOG_INFO << Form("    %2d: adc %4d, tb %3d: track %4d",i,
-			   dta->sim_adc[i].adc,
-				 dta->sim_adc[i].tb,
-				 dta->sim_adc[i].track_id
-				 ) << endm;
-	      }
-	    }
-	  }
-#endif
 	}
 	dtaX  = 0;
 	if (! iTpcType) { //Tpx
 	  if (! fTpx) continue;
 	  if (IAttr("TpxClu2D")) {
-	    dtaX = fTpx->get("cld_2d_sim"); //, sector, rowO, 0, &mTpx_RowLen); // rerun the 2D cluster finder on the simulated data...
+	    dtaX = fTpx->get("cld_2d_sim"); 
 	  } else {
-	    dtaX = fTpx->get("cld_sim");;   //, sector, rowO, 0, &mTpx_RowLen); // rerun the cluster finder on the simulated data...
+	    dtaX = fTpx->get("cld_sim");;   
 	  }
 	} else { // iTpc
 	  if (! fiTpc) continue;
-	  dtaX = fiTpc->get("cld_sim"); // ,sector, sector, row, 0, mTpx_RowLen); // rerun the cluster finder on the simulated data...
+	  dtaX = fiTpc->get("cld_sim"); 
 	}
 	if (! dtaX) continue;
 	daq_dta *dd = dtaX;
@@ -570,3 +596,280 @@ Int_t StTpcRTSHitMaker::Make() {
 #endif
   return kStOK;
 }
+#ifdef __TFG__VERSION__
+//________________________________________________________________________________
+Int_t StTpcRTSHitMaker::Make23() {
+  if (! fTpx23 && ! fiTpc23) return kStErr;
+#ifdef __BENCHMARK__
+  TBenchmark *myBenchmark = new TBenchmark();
+  myBenchmark->Reset();
+  //  myBenchmark->Start("StTpcRTSHitMaker::Make");
+#endif
+  if (St_tpcStatusC::instance()->isDead()) {
+    LOG_WARN << "TPC status indicates it is unusable for this event. Ignoring hits." << endm;
+    return kStOK;
+  }
+  static Short_t ADCs[__MaxNumberOfTimeBins__];
+  static Int_t IDTs[__MaxNumberOfTimeBins__];
+  static StTpcCoordinateTransform transform;
+  static StThreeVectorF hard_coded_errors;
+  StEvent*   rEvent      = (StEvent*)    GetInputDS("StEvent");
+  if (! rEvent) {
+    LOG_WARN << "There is no StEvent" << endm;
+    return kStWarn;
+  }
+  StTpcHitCollection *hitCollection = rEvent->tpcHitCollection();
+  if (! hitCollection )  {
+    hitCollection = new StTpcHitCollection();
+    rEvent->setTpcHitCollection(hitCollection);
+  }
+  TDataSet*  tpcRawEvent =               GetInputDS("Event");
+  if (! tpcRawEvent) {
+    LOG_WARN << "There is not Tpc Raw Event" << endm;
+    return kStWarn;
+  }
+  //  if (Debug()) tpcRawEvent->ls();
+  StTpcRawData *tpcRawData = (StTpcRawData *) tpcRawEvent->GetObject();
+  if (! tpcRawData) {
+    LOG_WARN << "There is not Tpc Raw Data" << endm;
+    return kStWarn;
+  }
+  // create (or reuse) the adc_sim bank...
+  // add a bunch of adc data for a specific sector:row:pad
+  static Int_t  minSector = IAttr("minSector");
+  static Int_t  maxSector = IAttr("maxSector");
+  static Int_t  minRow    = IAttr("minRow");
+  static Int_t  maxRow    = IAttr("maxRow");
+  bin0Hits = 0;
+  for (Int_t sector = minSector; sector <= maxSector; sector++) {
+    StTpcDigitalSector *digitalSector = tpcRawData->GetSector(sector);
+    if (! digitalSector) continue;
+    UShort_t Id = 0;
+    Int_t hitsAdded = 0;
+    //    daq_dta *dta  = 0;
+    for (Int_t iTpcType  = 1; iTpcType >= 0; iTpcType--) {// Tpx iTPC
+      tpc23_base *tpc23 = 0;
+      Int_t row1 = minRow;
+      Int_t row2 = maxRow;
+      // Check presense of iTPC and adjust row range
+      if (St_tpcPadConfigC::instance()->iTPC(sector)) {
+	//  daq_tpx::get(const Char_t *bank="*", Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	//           put(const Char_t *bank="*", Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	// daq_itpc::get(const Char_t *bank="*",Int_t c1=-1, Int_t c2=-1, Int_t c3=-1, void *p1=0, void *p2=0)
+	//           put(const Char_t *in_bank="*", Int_t sector=-1, Int_t row=-1, Int_t pad=-1, void *p1=0, void *p2=0)
+	if (! iTpcType) { // Tpx
+	  row1 = TMath::Max(row1, 41); 
+	  tpc23 = fTpx23;
+	} else { // iTpc           {
+	  row2 = TMath::Min(40, row2); 
+	  tpc23 = fiTpc23;
+	}
+      } else { // no iTPC
+	row2 = TMath::Min(45, row2);
+	tpc23 = fTpx23;
+      }
+      if (! tpc23) continue;
+      for (Int_t row = row1; row <= row2; row++) {
+	if (! St_tpcPadGainT0BC::instance()->livePadrow(sector,row)) continue;
+	tpc23->sim_evt_start(sector) ;	// prepare start of event
+	Int_t NoAdcs = 0;
+	Int_t Npads = digitalSector->numberOfPadsInRow(row);
+	Int_t rowO = row;
+	//	daq_dta *dta  = 0;
+	if (! iTpcType) {
+	  if (St_tpcPadConfigC::instance()->iTPC(sector) && row > 40) { // Tpx sector with iTPC
+	    rowO = row - 40 + 13; // old row countx1
+	  }
+	}
+	for(Int_t pad = 1; pad <= Npads; pad++) {
+	  UInt_t ntimebins = digitalSector->numberOfTimeBins(row,pad);
+	  if (! ntimebins) continue;
+	  // allocate space for at least 512 pixels (timebins)
+	  //	  daq_sim_adc_tb *d = (daq_sim_adc_tb *) dta->request(__MaxNumberOfTimeBins__);
+	  // add adc data for this specific sector:row:pad
+	  digitalSector->getTimeAdc(row,pad,ADCs,IDTs);
+	  UInt_t l = 0;
+	  for (UInt_t k = 0; k < __MaxNumberOfTimeBins__; k++) {
+	    if (ADCs[k]) {
+	      l++;
+	    }
+	  }
+	  if (l > 0) {
+	    Int_t padrow = rowO;
+	    tpc23->sim_do_pad(padrow,pad,ADCs,IDTs) ;
+	    NoAdcs += l;
+	  }
+	} // pad loop
+
+	if (NoAdcs) {
+	  
+	  // Tonko's     ------------------------------------------------------------ 
+	  
+	  // allocate output storage based upon the count of found sequences
+	  const Int_t words_per_cluster = 5 ;       // 5 for simulation, 2 normally
+
+	  tpc23->s2_max_words = tpc23->sequence_cou*words_per_cluster + 2000 ;      // and add a bit more...
+	  
+	  tpc23->s2_start = (UInt_t *) malloc(tpc23->s2_max_words*4) ;
+	  
+	  // this actually runs the clusterfinder
+	  tpc23->evt_stop() ;
+	  
+      
+	  if(tpc23->s2_words) {	// if anything found..
+	    UInt_t *p_buff = tpc23->s2_start ;
+	    UInt_t *end_buff = p_buff + tpc23->s2_words ;
+	    if (Debug()) {
+	      cout << Form("*** sequences found %d",tpc23->sequence_cou) << endl ;
+	    }
+
+                       if(tpc23->s2_words >= tpc23->s2_max_words) {
+			 LOG_ERROR << "Whoa -- lots of words " << tpc23->s2_words << "/" << tpc23->s2_max_words << "\t"
+				   <<  "\tsector " << sector << "\trow " << row << endm;
+                       }
+
+	    while(p_buff < end_buff) {
+				UInt_t padrow ;
+				UInt_t version ;
+				UInt_t int_cou ;
+				Int_t ints_per_cluster ;
+				// TPX and iTPC have slightly different formats; maintained compatibility
+				if(tpc23 == fTpx23) {// det==0) {	// TPX
+					padrow = *p_buff++ ;
+					int_cou = *p_buff++ ;
+
+					version = (padrow>>16) ;
+
+					ints_per_cluster = 5 ;	// 5 for sim, 2 for real
+				}
+				else {	
+					padrow = *p_buff++ ;
+					version = *p_buff++ ;
+					int_cou = *p_buff++ ;
+
+					ints_per_cluster = (padrow>>16) ;
+					
+				}
+	  
+	  padrow &= 0xFFFF ;
+	  
+	  Int_t clusters = int_cou / ints_per_cluster ;
+	  
+	  for(Int_t i=0;i<clusters;i++) {
+	    daq_sim_cld_x dc ;
+	    tpc23->fcf_decode(p_buff,&dc,version) ;
+	    
+	    // nice flags printout
+	    char c_flags[128] ;
+	    c_flags[0] = 0 ;
+	    
+	    if(dc.cld.flags & FCF_ONEPAD) strcat(c_flags,"one+") ;
+	    if(dc.cld.flags & FCF_MERGED) strcat(c_flags,"merge+") ;
+	    if(dc.cld.flags & FCF_DEAD_EDGE) strcat(c_flags,"dead+") ;
+	    if(dc.cld.flags & FCF_ROW_EDGE) strcat(c_flags,"edge+") ;						if(dc.cld.flags & FCF_ONEPAD) strcat(c_flags," one") ;
+	    if(dc.cld.flags & FCF_BROKEN_EDGE) strcat(c_flags,"small+") ;
+	    if(dc.cld.flags & FCF_BIG_CHARGE) strcat(c_flags,"charge+") ;
+	    
+	    if(strlen(c_flags)) {
+	      c_flags[strlen(c_flags)-1] = 0 ;
+	    }
+	    if (Debug()) {
+	      cout << Form("row %d/%d: %f %d %d %f %d %d %d 0x%02X[%s]",row,rowO,
+			   dc.cld.pad,dc.cld.p1,dc.cld.p2,
+			   dc.cld.tb,dc.cld.t1,dc.cld.t2,
+			   dc.cld.charge,
+			   dc.cld.flags,c_flags) << endl;
+	      cout << Form("   track_id %u, quality %d, pixels %d, max_adc %d",
+			   dc.reserved[0],
+			   dc.quality,
+			   dc.pixels,               //<<<<<<<<<<   Add to TpcHit ?
+			   dc.max_adc) << endl;;    //<<<<<<<<<<
+	    }
+	    
+	    p_buff += ints_per_cluster ;
+	    // Tonko's end    ------------------------------------------------------------ 
+	    Int_t   IdTruth  = dc.reserved[0];
+	    UShort_t quality = dc.quality;
+	    // Fill TpcHit
+	    if (dc.cld.p1 > dc.cld.p2) continue;
+	    if (dc.cld.t1 > dc.cld.t2) continue;
+	    if (dc.cld.tb >= __MaxNumberOfTimeBins__) continue;
+	    if (dc.cld.charge < fminCharge) continue;
+	    if ( ! (dc.cld.pad >  0 && dc.cld.pad <= 182 && 
+		    dc.cld.tb  >= 0 && dc.cld.tb  <  512)) continue;
+	    /*tpxFCF.h
+	      #define FCF_ONEPAD              1
+	      #define FCF_DOUBLE_PAD          2       // offline: merged
+	      #define FCF_MERGED              2
+	      #define FCF_BIG_CHARGE          8
+	      #define FCF_ROW_EDGE           16      // 0x10 touched end of row
+	      #define FCF_BROKEN_EDGE        32      // 0x20 touches one of the mezzanine edges
+	      #define FCF_DEAD_EDGE          64      // 0x40 touches a dead pad 
+	    */
+	    if ( dc.cld.flags && (dc.cld.flags & ~(FCF_ONEPAD | FCF_MERGED | FCF_BIG_CHARGE))) continue;
+	    Float_t pad  = dc.cld.pad;
+	    Int_t iRdo    = StDetectorDbTpcRDOMasks::instance()->rdoForPadrow(sector,row,pad);
+	    if ( ! StDetectorDbTpcRDOMasks::instance()->isOn(sector,iRdo)) continue;
+	    
+	    StTpcPadCoordinate Pad(sector, row, dc.cld.pad, dc.cld.tb); PrPP(Make,Pad);
+	    static StTpcLocalSectorCoordinate LS;
+	    static StTpcLocalCoordinate L;
+	    transform(Pad,LS,kFALSE,kTRUE); PrPP(Make,LS); // don't useT0, useTau                  
+	    transform(LS,L);                                                                             PrPP(Make,L);
+	    UInt_t hw = 1;   // detid_tpc
+	    //yf        if (isiTpcSector) hw += 1U << 1;
+	    hw += sector << 4;     // (row/100 << 4);   // sector
+	    hw += row  << 9;       // (row%100 << 9);   // row
+#ifndef __TFG__VERSION__
+	    Double_t q = ADC2GeV*dc.cld.charge;
+#else /* used in TFG till 07/31/20 */
+	    Double_t q = 0; 
+#endif /* ! __TFG__VERSION__ */
+	    Id++;
+	    StTpcHit *hit = StTpcHitMaker::StTpcHitFlag(L.position(),hard_coded_errors,hw,q
+							, (UChar_t ) 0  // counter 
+							, IdTruth
+							, quality
+							, Id                                   // id =0,
+							, dc.cld.p1 //  mnpad
+							, dc.cld.p2 //  mxpad
+							, dc.cld.t1 //  mntmbk
+							, dc.cld.t2 //  mxtmbk
+							, dc.cld.pad
+							, dc.cld.tb 
+							, dc.cld.charge
+							, dc.cld.flags);
+	    if (! hit) continue;
+	    hitsAdded++;
+	    if (hit->minTmbk() == 0) bin0Hits++;
+	    if (Debug() > 1) hit->Print();
+	    hitCollection->addHit(hit);
+	    if (Debug() > 1) {cout << "Add hit #" << hitCollection->numberOfHits() << endl;}
+	  }
+	}
+	tpc23->run_stop() ;	// dumps some statistics...
+	
+	// free allocated storage
+	free(tpc23->s2_start) ;
+	tpc23->s2_start = 0 ;
+      } // clusters loop
+      } // row loop      
+      
+    } // end of row
+      
+      
+    } // end iTpcType loop
+  } // end of sector
+  
+    
+    
+  if (! IAttr("NoTpxAfterBurner")) StTpcHitMaker::AfterBurner(hitCollection);
+#ifdef __BENCHMARK__
+  myBenchmark->Stop("StTpcRTSHitMaker::Make");
+  myBenchmark->Show("StTpcRTSHitMaker::Make");
+  myBenchmark->Show("StTpcRTSHitMaker::Make::finalize");
+  delete myBenchmark;
+#endif
+  return kStOK;
+}
+#endif /*  __TFG__VERSION__ */

--- a/StRoot/StTpcHitMaker/StTpcRTSHitMaker.h
+++ b/StRoot/StTpcHitMaker/StTpcRTSHitMaker.h
@@ -70,26 +70,40 @@ class daq_tpx;
 class daq_itpc;
 class daq_dta;
 class daq_cld;
+class tpc23_base;
 class StTpcRTSHitMaker : public StMaker {
  public:
- StTpcRTSHitMaker(const char *name="tpc_hits") : StMaker(name), fTpx(0), fiTpc(0), fminCharge(0) {memset(mTpx_RowLen, 0, sizeof(mTpx_RowLen));}
+ StTpcRTSHitMaker(const char *name="tpc_hits") : StMaker(name), fTpx(0), fiTpc(0), 
+#ifdef __TFG__VERSION__
+    fTpx23(0), fiTpc23(0),
+#endif /*  __TFG__VERSION__ */
+    fminCharge(0) {}
   virtual ~StTpcRTSHitMaker();
   
   Int_t               Init();
   Int_t               InitRun(Int_t runnumber);
+  Int_t               InitRun23(Int_t runnumber);
   Int_t               Make();
+#ifdef __TFG__VERSION__
+  Int_t               Make23();
+#endif /*  __TFG__VERSION__ */
+#ifdef __USE_GAIN_FROM_FILE__
+  Int_t               from_file(daq_dta *gain_dta, const Char_t *fname = "");
+#endif /* __USE_GAIN_FROM_FILE__ */
   void PrintCld(daq_cld *cld = 0, Int_t IdTruth = 0, Int_t quality=0);
   void PrintAdc(daq_dta *dta  = 0);
  private:
   daq_tpx  *fTpx; //!
   daq_itpc *fiTpc; //!
+#ifdef __TFG__VERSION__
+  tpc23_base   *fTpx23; //!
+  tpc23_base  *fiTpc23; //!
+#endif /*  __TFG__VERSION__ */
   Bool_t    fNoiTPCLu; //!
   Double_t  fminCharge; // ! minimum cluster charge in ADC
   Int_t     maxHits[24];
   Int_t     maxBin0Hits;
   Int_t     bin0Hits;
-  static UChar_t mTpx_RowLen[46];
-  static UChar_t miTpc_RowLen[41];
   // cvs
   virtual const char *GetCVS() const    {
     static const char cvs[]="Tag $Name:  $ $Id: StTpcRTSHitMaker.h,v 1.19 2021/05/10 21:13:19 fisyak Exp $  built " __DATE__ " " __TIME__ ; return cvs;

--- a/StRoot/StTpcRSMaker/StTpcRSMaker.h
+++ b/StRoot/StTpcRSMaker/StTpcRSMaker.h
@@ -151,7 +151,7 @@ class StTpcRSMaker : public StMaker {
   const Double_t ElectronRangeEnergy; //!
   const Double_t ElectronRangePower;  //!
   const Int_t NoOfSectors;            //!
-  const Int_t NoOfPads;               //!
+  Int_t NoOfPads;                     //!
   const Int_t NoOfTimeBins;           //!
   Double_t   mCutEle;                 //! cut for delta electrons
  public:    

--- a/StRoot/StdEdxY2Maker/StTpcdEdxCorrection.h
+++ b/StRoot/StdEdxY2Maker/StTpcdEdxCorrection.h
@@ -93,6 +93,7 @@ class StTpcdEdxCorrection : public TObject {
   
   void SetDebug(Int_t m=0) {m_Debug = m;}
   void SetMask (Long_t m=0) {m_Mask = m;}
+  void SetSimulation(Bool_t k = kTRUE)     {m_IsSimulation = k;}
   void ReSetCorrections();
   St_tpcGas         *tpcGas()              {return m_tpcGas;}
   //  St_trigDetSums    *trigDetSums()         {return m_trigDetSums;}
@@ -115,6 +116,7 @@ class StTpcdEdxCorrection : public TObject {
   Float_t           Adc2GeV()              {return mAdc2GeV;}
   void Print(Option_t *opt = "") const;
   Bool_t            IsFixedTarget()        {return m_isFixedTarget;}
+  Bool_t            IsSimulation()         {return m_IsSimulation;}
  private:
   Long_t               m_Mask;                  //!
   St_tpcGas           *m_tpcGas;                //!
@@ -123,6 +125,11 @@ class StTpcdEdxCorrection : public TObject {
   dEdxCorrection_t     m_Corrections[kTpcAllCorrections];//!
   Int_t                m_Debug;                 //!
   Bool_t               m_isFixedTarget;
+  Bool_t               m_IsSimulation;
+  Double_t             m_TrigT0; //us
+  Double_t             mTimeBinWidth; 
+  Double_t             mInnerSectorzOffset;
+  Double_t             mOuterSectorzOffset;
 };
 //________________________________________________________________________________
 class dEdxY2_t {

--- a/StarDb/Calibrations/tpc/TpcResponseSimulator.y2019.C
+++ b/StarDb/Calibrations/tpc/TpcResponseSimulator.y2019.C
@@ -89,14 +89,14 @@ TDataSet *CreateTable() {
   row.tauXO                 =  74.6e-9;// secs Tpx Outer integration time 
   row.tauCI                 =   0;  
   row.tauCO                 =   0;  
-  row.SigmaJitterTI         = 0.52; //1.5*0.4317/4.5;// 0.4317;// 0.25;//ad  0.0;// b for Tpx inner 
+  row.SigmaJitterTI         = 0.0; //1.5*0.4317/4.5;// 0.4317;// 0.25;//ad  0.0;// b for Tpx inner 
   row.SigmaJitterTO         = 0.52; //1.5*0.4300/5.;// 0.4300;// E: 0.4801;//0.25;//ad  0.0;// b for Tpx outer 
-  row.SigmaJitterXI         = 0.1027785/2.;// 0.1027785; // P: 0.1353*1.05/1.10; //O: 0.1353*1.05;// N: 0.1353; // C:0.;
+  row.SigmaJitterXI         = 0.1027785/2./1.5;// 0.1027785; // P: 0.1353*1.05/1.10; //O: 0.1353*1.05;// N: 0.1353; // C:0.;
   row.SigmaJitterXO         = 0.107525/2.; // 0.107525;  // P: 0.1472*1.05/1.03; //O: 0.1472*1.05;// N: 0.1472; // C:0.;
   row.longitudinalDiffusion = 0.03624; // Magboltz // HD 0.03624*1.5; //HC 0.03624; // Magboltz 
-  row.longitudinalDiffusionI= row.longitudinalDiffusion;
-  row.transverseDiffusion   = 0.02218*TMath::Sqrt(1 + row.OmegaTau*row.OmegaTau) ; // Magboltz
-  row.transverseDiffusionI  = 0.896  *row.transverseDiffusion;
+  row.longitudinalDiffusionI= row.longitudinalDiffusion*0.51;
+  row.transverseDiffusion   = 0.02263*TMath::Sqrt(1 + row.OmegaTau*row.OmegaTau) ; // Magboltz
+  row.transverseDiffusionI  = 0.63  *row.transverseDiffusion;
   row.NoElPerAdc            = 335.;   // No. of electrons per 1 ADC count
   row.OmegaTauScaleI        =  2.145*1.515;// HC 1.;// 2.145*1.515;  //i; 2.145*1.4;  //h 2.145;  //ad 2.145*1.25;  //b effective reduction of OmegaTau near Inner sector anode wire
   row.OmegaTauScaleO        = 1.8  *1.201;  //HC 1.;// 1.8  *1.201;  //i 1.8  *1.1;    //h 1.8;    //ad 1.8  *1.25;  //b effective reduction of OmegaTau near Outer sector anode wire
@@ -127,8 +127,8 @@ TDataSet *CreateTable() {
   //row.T0offset   = 0.50 + 1.65431e-01 -  3.45247e-01 -1.54583e+00 -2.90686e-03+ 1.54353e+00 + 0.0191135  -1.20938e-03 ; //E
   // row.T0offset   = 0.50 -1.43663e-01 -0.00932877;//g // 01/18/12 Xianglei Zhu from Run 11 AuAu 27 & 19.6 GeV embedding 
   row.T0offset   = 0.50 -1.43663e-01 -0.00932877 + 0.0416;//g // 12/18/19 from Run 19 AuAu19.6 GeV simulation
-  row.T0offsetI  =  0.0803082                      -0.145027; // ~/work/Tpc/TpcRS/2019/TpcRS_19GeV; TI_1->Fit("pol2"); par[0]
-  row.T0offsetO  = 0.5*(-6.04314e-02-3.44168e-02)-0.00930199;// TO_1->Fit("pol2","er","",-100,0) => par[0] = -6.04314e-02; TO_1->Fit("pol2","er","",0,100); par[0] = -3.44168e-02 ?
+  row.T0offsetI  = -1.58786167960479896e-01;
+  row.T0offsetO  = -1.94071983062808762e-01-1.76429075511644329e-02;
 
   tableSet->AddAt(&row);
   // ----------------- end of code ---------------


### PR DESCRIPTION
* All codes in PR #466 are included, to fix the offline cluster finder (PRs #417 and #429), update TpcRS parameter for Run19 (PR #463).
* Codes in PR #281 are included, to fix the gating grid simulation and to fix the StMcEventMaker for iTPC simulation.

These patches are needed for SL21d based embedding productions (Run18 Isobar st_hf/st_upc, Run19 FXT, Run20 FXT runs).