### PR TITLE
cons: fix for multiple include dirs returned by xml2-config

### DIFF
--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -983,8 +983,8 @@
 
     $XMLINCDIR = `$xml --cflags`;
     chomp($XMLINCDIR);
+    $XMLINCDIR =~ s/ -I/:/g;
     $XMLINCDIR =~ s/-I//g;
-    $XMLINCDIR =~ s/ /:/g;
     my $XML  = `$xml --libs`; # die "$XML\n";
     my(@libs)= split(" ", $XML);
 

--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -983,7 +983,8 @@
 
     $XMLINCDIR = `$xml --cflags`;
     chomp($XMLINCDIR);
-    $XMLINCDIR =~ s/-I//;
+    $XMLINCDIR =~ s/-I//g;
+    $XMLINCDIR =~ s/ /:/g;
     my $XML  = `$xml --libs`; # die "$XML\n";
     my(@libs)= split(" ", $XML);
 


### PR DESCRIPTION
xml2-config --cflags may return multiple paths in which case cons
expects them to be separated by ':'
