### PR TITLE
fix: remove ClassDef from StEpdGeom

### DIFF
--- a/StRoot/StEpdUtil/StEpdGeom.h
+++ b/StRoot/StEpdUtil/StEpdGeom.h
@@ -215,9 +215,6 @@ class StEpdGeom{
   /// \param tilenumber tile on supsersector [1,31]
   /// \eastwest         east (-1) or west (+1) wheel
   short Row(short position, short tilenumber, short eastwest);
-
-  ClassDef(StEpdGeom,0)
-
 };
 
 inline bool StEpdGeom::IsWest(short uniqueID){return uniqueID>0;}


### PR DESCRIPTION
This type is neither an StMaker nor an IO class so, using ClassDef is not critical. On the contrary, it causes an error due to missing virtual destructor when included in compiled code. E.g. see https://github.com/star-bnl/star-sw/pull/492