### PR TITLE
Edited mistake in params file

### DIFF
--- a/StRoot/StRefMultCorr/Param.h
+++ b/StRoot/StRefMultCorr/Param.h
@@ -478,9 +478,9 @@ const string mParamStr_ref1[nID_ref1][nSet_ref1] = {
   {
     "2019:200:20190042,20193026:-100,100",                     // Year, energy, run start end, Vz range
     "12,18,25,36,49,66,88,113,144,180,223,274,334,404,486,588",      // Centrality definition
-    "100",    // Normalization start
+    "150",    // Normalization start
     "0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00",   // Vz correction parameters (switched to new scheme, parameters defined near the shape corrections)
-    "1.13418,-1.68334e-2,1.68995e-3,1.03279e-2,-4.42083e-1,1.47591e-3,4.36703e-1",  // Trigger efficiency
+    "1.13418,-1.68334e-2,1.68995e-3,1.03279e-2,-4.42083e-1,0,1.47591e-3,4.36703e-1",  // Trigger efficiency
     "2.14803e+02,-4.58703e-4" // Luminosity correction
   }
 };


### PR DESCRIPTION
There were two edits made to the params file. One was to change the refMultCorr value below which the trigger efficiency gets applied from 100 to 150. The second was to update one of the trigger efficiency parameters to 0 to indicate there is no Vz-dependent trigger efficiency applied.