### PR TITLE
Star simulations 2023 ideal timestamp

### DIFF
--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -160,7 +160,7 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
   {"y2022a",      20211015,     1, "y2022a",   "y2022 production geometry, AgML,xgeometry"},  
 
  { "y2023",       20230410,     0, "y2023",    "y2023 first cut geometry, AgML,xgeometry"},    
- { "y2023a",      20230415,     0, "y2023a",    "y2023a production geometry, AgML,xgeometry"},    
+ { "y2023a",      20230410,     1, "y2023a",    "y2023a production geometry, AgML,xgeometry"},    
 
   {"dev2021",     21201210,     1, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},
   {"dev2022",     21211210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},

--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -159,7 +159,8 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
   {"y2022",       20211015,     0, "y2022",    "y2022 first cut geometry, AgML,xgeometry"},   
   {"y2022a",      20211015,     1, "y2022a",   "y2022 production geometry, AgML,xgeometry"},  
 
-  {"y2023",       20230410,     0, "y2023",    "y2023 first cut geometry, AgML,xgeometry"},    
+ { "y2023",       20230410,     0, "y2023",    "y2023 first cut geometry, AgML,xgeometry"},    
+ { "y2023a",      20230415,     0, "y2023a",    "y2023a production geometry, AgML,xgeometry"},    
 
   {"dev2021",     21201210,     1, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},
   {"dev2022",     21211210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},

--- a/StRoot/StChain/GeometryDbAliases.h
+++ b/StRoot/StChain/GeometryDbAliases.h
@@ -159,7 +159,7 @@ static const DbAlias_t fDbAlias[] = {// geometry  Comment            old
   {"y2022",       20211015,     0, "y2022",    "y2022 first cut geometry, AgML,xgeometry"},   
   {"y2022a",      20211015,     1, "y2022a",   "y2022 production geometry, AgML,xgeometry"},  
 
-  {"y2023",       20221215,     0, "y2023",    "y2023 first cut geometry, AgML,xgeometry"},    
+  {"y2023",       20230410,     0, "y2023",    "y2023 first cut geometry, AgML,xgeometry"},    
 
   {"dev2021",     21201210,     1, "dev2021",  "-deprecated- geometry for 2021+ forward program,AgML,xgeometry"},
   {"dev2022",     21211210,     1, "dev2022",  "development geometry for 2022+ forward program,AgML,xgeometry"},

--- a/StarDb/AgMLGeometry/Geometry.y2023a.C
+++ b/StarDb/AgMLGeometry/Geometry.y2023a.C
@@ -1,0 +1,7 @@
+#include "CreateGeometry.h"
+TDataSet *CreateTable() 
+{
+  // Return the requested geometry
+  return CreateGeometry("y2023a");
+}
+

--- a/StarVMC/Geometry/StarGeo.xml
+++ b/StarVMC/Geometry/StarGeo.xml
@@ -71,8 +71,32 @@
   </Geometry>
 
   <Geometry tag="y2023" comment="STAR initial cut tag y2023">
-    <!-- Note:  Current version of sTGC has overlaps which are being resolved.  
-         I anticipate updates to forward detectors during the run. -->
+    <Construct sys="cave" config="CAVE06"  />
+    <Construct sys="upst" config="UPSTon"  />
+    <Construct sys="shld" config="SHLDon"  />
+    <Construct sys="zcal" config="ZCALon"  />
+    <Construct sys="scon" config="SCON14"  />
+    <Construct sys="pipe" config="PIPE12ft" />
+    <Construct sys="targ" config="TARGv1"  /> 
+    <Construct sys="tpce" config="TPCEv6"  />
+    <Construct sys="btof" config="BTOFv8"  />
+    <Construct sys="vpdd" config="VPDD08"  />
+    <Construct sys="calb" config="CALB02"  />
+    <Construct sys="ecal" config="ECALv6"  />
+    <Construct sys="bbcm" config="BBCMin"  />
+    <Construct sys="epdm" config="EPDMv1"  />
+    <Construct sys="magp" config="MAGPon"  />
+    <Construct sys="mutd" config="MUTD16"  />
+    <Construct sys="wcal" config="WCALv1" simu="1" />
+    <Construct sys="hcal" config="HCALv1" simu="1" />
+    <Construct sys="plat" config="PLATon" simu="2" />
+    <Construct sys="pres" config="PRESof" simu="2" /> 
+    <Construct sys="fstm" config="FSTMv1" />
+    <Construct sys="stgm" config="STGCv1" />
+    <Construct sys="etof" config="ETOFv14f"  />
+  </Geometry>
+
+  <Geometry tag="y2023a" comment="STAR initial production tag y2023">
     <Construct sys="cave" config="CAVE06"  />
     <Construct sys="upst" config="UPSTon"  />
     <Construct sys="shld" config="SHLDon"  />

--- a/StarVMC/xgeometry/xgeometry.age
+++ b/StarVMC/xgeometry/xgeometry.age
@@ -2540,6 +2540,7 @@ If LL>0
   case y2022a { y2022a: y2022 first production geometry; Geom =        'y2022a    '; call geom_y2022a;} 
 
   case y2023 { y2023: y2023 first cut geometry; Geom =        'y2023     '; call geom_y2023;} 
+  case y2023a { y2023a: y2023a production tag; Geom =         'y2023a    '; call geom_y2023a;} 
 
   case dev2021 { dev2021:  First cut forward upgrades; Geom =        'dev2021   '; call geom_dev2021;} 
   case dev2022 { dev2022:  First cut forward upgrades; Geom =        'dev2022   '; call geom_dev2022;} 


### PR DESCRIPTION
STAR simulation (ideal) timeline moved to 04/10/2023.  

Production tag y2023a defined.  Will be frozen closer to offline data productions.