### PR TITLE
hotfix for broken event.root files in DEV with StFwdTracks

### DIFF
--- a/StRoot/StEvent/StFwdTrack.h
+++ b/StRoot/StEvent/StFwdTrack.h
@@ -26,7 +26,7 @@
 class StFcsCluster;
 
 
-struct StFwdTrackProjection {
+struct StFwdTrackProjection : public StObject {
     StFwdTrackProjection() {}
     StFwdTrackProjection ( const StFwdTrackProjection & other) {
         mXYZ = other.mXYZ;
@@ -70,9 +70,11 @@ struct StFwdTrackProjection {
     float dz(){
         return sqrt( mCov[8] );
     }
+
+    ClassDef(StFwdTrackProjection, 1)
 };
 
-struct StFwdTrackSeedPoint {
+struct StFwdTrackSeedPoint : public StObject {
     StFwdTrackSeedPoint() {}
     StFwdTrackSeedPoint(    StThreeVectorD xyz, 
                             short sec, 
@@ -88,6 +90,8 @@ struct StFwdTrackSeedPoint {
     unsigned short mTrackId;
     short mSector;
     float mCov[9];
+    
+    ClassDef(StFwdTrackSeedPoint, 1)
 };
 
 class StFwdTrack : public StObject {
@@ -169,7 +173,7 @@ protected:
     StPtrVecFcsCluster mEcalClusters;
     StPtrVecFcsCluster mHcalClusters;
     
-    ClassDef(StFwdTrack,1)
+    ClassDef(StFwdTrack,2)
 
 };
 


### PR DESCRIPTION
I have been unable to read back event.root files created with FWD track info in DEV. The BFC ends with a set fault. 

I found that adding missing StObject and ClassDef to StFwdTrack causes the chain to run without segfault and the data to be read correctly. 

However, I am still getting messages like:
StIOMaker:ERROR - TBufferFile::CheckByteCount : object of class StEventClusteringHints read too few bytes: 1401 instead of 3177

So far I have not been able to pin down the source of this error. I tried using "//!" to remove various members from the StFwdTrack but nothing resolved the above ERROR message. I wanted to put this PR in so that the event.root files are at least readable without causing a segmentation fault. 