### PR TITLE
fix: load libiconv module into envs

### DIFF
--- a/mgr/config/v0.2.3-rhel7-root5.34.38-32b.config
+++ b/mgr/config/v0.2.3-rhel7-root5.34.38-32b.config
@@ -6,3 +6,4 @@ module purge
 module unuse /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86_64/
 module use   /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86/
 module load star-env-0.2.3-root-5.34.38
+module load libiconv-1.16

--- a/mgr/config/v0.2.3-rhel7-root5.34.38-64b.config
+++ b/mgr/config/v0.2.3-rhel7-root5.34.38-64b.config
@@ -6,3 +6,4 @@ module purge
 module unuse /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86/
 module use   /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86_64/
 module load star-env-0.2.3-root-5.34.38
+module load libiconv-1.16


### PR DESCRIPTION
While linking StDbLib the linker cannot find libiconv, an indirect dependency via libxml2, unless it searches paths in LD_LIBRARY_PATH