### PR TITLE
Add RHICf Run and Event number in StMuRHICfxxx

### DIFF
--- a/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.cxx
@@ -13,12 +13,15 @@ StMuRHICfRawHit::~StMuRHICfRawHit()
 
 void StMuRHICfRawHit::clear()
 {	
+  mRHICfRunNumber = 0;
+  mRHICfEventNumber = 0;
+  mRunType = 999;
   mBunchNumber = 0;
   mRHICfTrigger = 0;
   mRunTime[0] = 0;
   mRunTime[1] = 0;
   mRunTRGM = 0;
-  mRunType = 999;
+
 
   memset(mPlateADC, 0, sizeof(mPlateADC));
   memset(mPlateADCDelay, 0, sizeof(mPlateADCDelay));
@@ -30,8 +33,10 @@ void StMuRHICfRawHit::clear()
   memset(mGPI1, 0, sizeof(mGPI1));
 }
 
-void StMuRHICfRawHit::setBunchNumber(UInt_t bunch){mBunchNumber = bunch;}
+void StMuRHICfRawHit::setRHICfRunNumber(UInt_t run){mRHICfRunNumber = run;}
+void StMuRHICfRawHit::setRHICfEventNumber(UInt_t event){mRHICfEventNumber = event;}
 void StMuRHICfRawHit::setRunType(UInt_t type){mRunType = type;}
+void StMuRHICfRawHit::setBunchNumber(UInt_t bunch){mBunchNumber = bunch;}
 void StMuRHICfRawHit::setTriggerNumber(UInt_t trigger){mRHICfTrigger = trigger;}
 void StMuRHICfRawHit::setRunTime(Int_t idx, UInt_t time){mRunTime[idx] = time;}
 void StMuRHICfRawHit::setRunTRGM(UInt_t trgm){mRunTRGM = trgm;}
@@ -49,8 +54,10 @@ void StMuRHICfRawHit::setCAD0(Int_t idx, UInt_t val){mCAD0[idx] = val;}
 void StMuRHICfRawHit::setGPI0(Int_t idx, UInt_t val){mGPI0[idx] = val;}
 void StMuRHICfRawHit::setGPI1(Int_t idx, UInt_t val){mGPI1[idx] = val;}
 
-UInt_t StMuRHICfRawHit::getBunchNumber(){return mBunchNumber;}
+UInt_t StMuRHICfRawHit::getRHICfRunNumber(){return mRHICfRunNumber;}
+UInt_t StMuRHICfRawHit::getRHICfEventNumber(){return mRHICfEventNumber;}
 UInt_t StMuRHICfRawHit::getRunType(){return mRunType;}
+UInt_t StMuRHICfRawHit::getBunchNumber(){return mBunchNumber;}
 UInt_t StMuRHICfRawHit::getTriggerNumber(){return mRHICfTrigger;}
 UInt_t StMuRHICfRawHit::getRunTime(Int_t idx){return mRunTime[idx];}
 UInt_t StMuRHICfRawHit::getRunTRGM(){return mRunTRGM;}

--- a/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
@@ -65,7 +65,7 @@ class StMuRHICfRawHit : public TObject
     UInt_t mGPI0[kRHICfNgpi0]; // GPI0
     UInt_t mGPI1[kRHICfNgpi1]; // GPI1
 
-  ClassDef(StMuRHICfRawHit,1)
+  ClassDef(StMuRHICfRawHit,2)
 };
 
 #endif

--- a/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
@@ -45,6 +45,9 @@ class StMuRHICfRawHit : public TObject
     UInt_t getGPI1(Int_t idx);
 
   private:
+
+    // Important note: the _RHICf_ Run and Event numbers are distinct from the _STAR_ Run and Event numbers,
+    // originating from RHICf's own raw data acquisition and studies outside of the STAR framework.
     UInt_t mRHICfRunNumber;
     UInt_t mRHICfEventNumber;
     UInt_t mRunType;

--- a/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuRHICfRawHit.h
@@ -12,8 +12,10 @@ class StMuRHICfRawHit : public TObject
 
     void clear();
 
-    void setBunchNumber(UInt_t bunch);
+    void setRHICfRunNumber(UInt_t run);
+    void setRHICfEventNumber(UInt_t event);
     void setRunType(UInt_t type);
+    void setBunchNumber(UInt_t bunch);
     void setTriggerNumber(UInt_t trigger);
     void setRunTime(Int_t idx, UInt_t time);
     void setRunTRGM(UInt_t trgm);
@@ -26,8 +28,10 @@ class StMuRHICfRawHit : public TObject
     void setGPI0(Int_t idx, UInt_t val);
     void setGPI1(Int_t idx, UInt_t val);
 
-    UInt_t getBunchNumber();
+    UInt_t getRHICfRunNumber();
+    UInt_t getRHICfEventNumber();
     UInt_t getRunType();
+    UInt_t getBunchNumber();
     UInt_t getTriggerNumber();
     UInt_t getRunTime(Int_t idx);
     UInt_t getRunTRGM();
@@ -41,8 +45,10 @@ class StMuRHICfRawHit : public TObject
     UInt_t getGPI1(Int_t idx);
 
   private:
-    UInt_t mBunchNumber;
+    UInt_t mRHICfRunNumber;
+    UInt_t mRHICfEventNumber;
     UInt_t mRunType;
+    UInt_t mBunchNumber;
     UInt_t mRHICfTrigger;
     UInt_t mRunTime[kRHICfNorder];
     UInt_t mRunTRGM;

--- a/StRoot/StMuDSTMaker/COMMON/StMuRHICfUtil.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuRHICfUtil.cxx
@@ -52,8 +52,10 @@ void StMuRHICfUtil::fillMuRHICf(StMuRHICfCollection* muColl, StRHICfCollection* 
   StMuRHICfRawHit* muRHICfRawHit = muColl -> addRawHit();
   StRHICfRawHit* rhicfRawHit = coll -> rawHitCollection();
 
-  muRHICfRawHit -> setBunchNumber(coll->getBunchNumber());
+  muRHICfRawHit -> setRHICfRunNumber(coll->getRHICfRunNumber());
+  muRHICfRawHit -> setRHICfEventNumber(coll->getRHICfEventNumber());
   muRHICfRawHit -> setRunType(coll->getRunType());
+  muRHICfRawHit -> setBunchNumber(coll->getBunchNumber());
   muRHICfRawHit -> setTriggerNumber(coll->getTriggerNumber());
   muRHICfRawHit -> setRunTime(0, coll->getRunTime(0));
   muRHICfRawHit -> setRunTime(1, coll->getRunTime(1));
@@ -84,8 +86,11 @@ void StMuRHICfUtil::fillRHICf(StRHICfCollection* coll, StMuRHICfCollection* muCo
 
   StMuRHICfRawHit* muRHICfRawHit = muColl -> getRawHit();
   StRHICfRawHit* rhicfRawHit = coll -> rawHitCollection();
-  coll -> setBunchNumber(muRHICfRawHit->getBunchNumber());
+
+  coll -> setRHICfRunNumber(muRHICfRawHit->getRHICfRunNumber());
+  coll -> setRHICfEventNumber(muRHICfRawHit->getRHICfEventNumber());
   coll -> setRunType(muRHICfRawHit->getRunType());
+  coll -> setBunchNumber(muRHICfRawHit->getBunchNumber());
   coll -> setTriggerNumber(muRHICfRawHit->getTriggerNumber());
   coll -> setRunTime(0, muRHICfRawHit->getRunTime(0));
   coll -> setRunTime(1, muRHICfRawHit->getRunTime(1));


### PR DESCRIPTION
To add the RHICfRun and RHICfEvent numbers, I request this 3rd PR.

The modification of StMuRHICfRawHit is to store this data at the MuDst level,
and StMuRHICfUtil is to move the data from the StEvent to the StMuDst level.

A list of PRs for adding run and event numbers before the MuDst production and release STAR libraries:

1) StRHICfCollection
2) StHRICfDbMaker
**3) this PR**
4) StRHICfRawHitMaker

