### PR TITLE
Add RHICfRun and Event number in StRHICfRawHitMaker

### DIFF
--- a/StRoot/StRHICfRawHitMaker/StRHICfRawHitMaker.cxx
+++ b/StRoot/StRHICfRawHitMaker/StRHICfRawHitMaker.cxx
@@ -67,7 +67,7 @@ Int_t StRHICfRawHitMaker::Make()
     unsigned short* rawdata = (unsigned short*) daqData->GetTable();
 
     // Insert general data
-      unsigned int rhicfRunIdx = mRHICfDbMaker->getRHICfRunNumberAddress();
+    unsigned int rhicfRunIdx   = mRHICfDbMaker->getRHICfRunNumberAddress();
     unsigned int rhicfEventIdx = mRHICfDbMaker->getRHICfEventNumberAddress();
     mRHICfCollection -> setRHICfRunNumber(gendata[rhicfRunIdx]);
     mRHICfCollection -> setRHICfEventNumber(gendata[rhicfEventIdx]);

--- a/StRoot/StRHICfRawHitMaker/StRHICfRawHitMaker.cxx
+++ b/StRoot/StRHICfRawHitMaker/StRHICfRawHitMaker.cxx
@@ -67,6 +67,10 @@ Int_t StRHICfRawHitMaker::Make()
     unsigned short* rawdata = (unsigned short*) daqData->GetTable();
 
     // Insert general data
+      unsigned int rhicfRunIdx = mRHICfDbMaker->getRHICfRunNumberAddress();
+    unsigned int rhicfEventIdx = mRHICfDbMaker->getRHICfEventNumberAddress();
+    mRHICfCollection -> setRHICfRunNumber(gendata[rhicfRunIdx]);
+    mRHICfCollection -> setRHICfEventNumber(gendata[rhicfEventIdx]);
     mRHICfCollection -> setRunType(getRunType());
 
     unsigned int bunchIdx = mRHICfDbMaker->getBunchNumberAddress();


### PR DESCRIPTION

Saving variables into RHICfCollection from DAQ

A list of PRs for adding run and event numbers before the MuDst production and release STAR libraries:

1) StRHICfCollection
2) StHRICfDbMaker
3) StMuDSTMaker/COMMON/StMuRHICfRawHit
**4) this PR**