### PR TITLE
Added mstu72 and mstu73 variable in StarGenPPEvent.*

### DIFF
--- a/StRoot/StarGenerator/EVENT/StarGenPPEvent.cxx
+++ b/StRoot/StarGenerator/EVENT/StarGenPPEvent.cxx
@@ -20,6 +20,8 @@ StarGenPPEvent::StarGenPPEvent( const Char_t *name, const Char_t *title )
     sHat(0.),
     tHat(0.),
     uHat(0.),
+    mstu72(0),
+    mstu73(0),
     ptHat(0.),
     thetaHat(0.),
     phiHat(0.),

--- a/StRoot/StarGenerator/EVENT/StarGenPPEvent.h
+++ b/StRoot/StarGenerator/EVENT/StarGenPPEvent.h
@@ -37,14 +37,17 @@ class StarGenPPEvent : public StarGenEvent
   Bool_t   valence2;  ///< True if yellow beam parton is in valence
   
   Double_t sHat,tHat,uHat; ///< Mandelstam variables
-  
+
+  Int_t mstu72;       ///<  Line number of an event record, ("======")
+  Int_t mstu73;       ///<  Line number of an event record, ("======")
+    
   Double_t ptHat;     ///< pT of the recoiling particles
   Double_t thetaHat;  ///< theta of the recoiling particles 
   Double_t phiHat;    ///< phi of the recoiling particles
 
   Double_t weight;    ///< Weight of the event 
 
-  ClassDef(StarGenPPEvent,1);
+  ClassDef(StarGenPPEvent,2);
 
 };
  


### PR DESCRIPTION
Provided updates to StarGenPPEvent to include the mstu72 and mstu73 variables that will help delimit the event record based on Underlying Event and Parton Level. The two variables are defined using the Pythia common block PYDAT1 under the StarPythia6 framework. 
