### PR TITLE
Bug fix for StFcsWaveformFitMaker

### DIFF
--- a/StRoot/StFcsWaveformFitMaker/PeakAnaPainter.h
+++ b/StRoot/StFcsWaveformFitMaker/PeakAnaPainter.h
@@ -46,7 +46,7 @@ Painter class for PeakAna
 
 class PeakAna;
 
-class PeakAnaPainter
+class PeakAnaPainter : public TObject
 {
 public:
   PeakAnaPainter();

--- a/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.cxx
+++ b/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.cxx
@@ -370,7 +370,7 @@ int StFcsWaveformFitMaker::InitRun(int runNumber) {
 }
 
 int StFcsWaveformFitMaker::Finish(){
-  if(mFilename && mPad>=0){
+  if( mFilename ){
     char file[200];
     sprintf(file,"%s.pdf]",mFilename);
     mCanvas->Print(file);
@@ -1017,9 +1017,8 @@ float StFcsWaveformFitMaker::gausFit(TGraphAsymmErrors* g, float* res, TF1*& fun
     return res[0];
 }
 
-void StFcsWaveformFitMaker::drawFit(TGraphAsymmErrors* g, TF1* func){
+void StFcsWaveformFitMaker::drawFit(TGraphAsymmErrors* gg, TF1* func){
   const int MAXPAD=4*4;
-  TGraphAsymmErrors* gg = getGraph();
   if(gg==0){
     LOG_WARN<<"Found no TGraphAsymmErrors at mHitIdx="<<mHitIdx<<endm;
     return;

--- a/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.h
+++ b/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.h
@@ -77,7 +77,7 @@ public:
     
     void setDebug(int v=1)        {SetDebug(v);}
     void setTest(int v);           //!< Set test level. Intended to be used for single files. Output file name can be changed with #writeFile(), see #mTest for meaning of values
-    void setEnergySelect(int ecal=10, int hcal=10, int pres=1) {mEnergySelect[0]=ecal; mEnergySelect[1]=hcal; mEnergySelect[2]=pres;}
+    void setEnergySelect(int ecal=13, int hcal=13, int pres=1) {mEnergySelect[0]=ecal; mEnergySelect[1]=hcal; mEnergySelect[2]=pres;}
     void setEnergySumScale(double ecal=1.0, double hcal=1.0, double pres=1.0) {mEnergySumScale[0]=ecal; mEnergySumScale[1]=hcal; mEnergySumScale[2]=pres;}
     void setCenterTimeBins(int v, int min=0, int max=512) {mCenterTB=v; mMinTB=min; mMaxTB=max;}
     void setAdcSaturation(int v)  {mAdcSaturation=(double)v;}
@@ -268,7 +268,7 @@ public:
 
  protected:
     TClonesArray mChWaveData;  //!< Contains all graph data
-    void drawFit(TGraphAsymmErrors* g, TF1* func); //!< Draw a single TGraph
+    void drawFit(TGraphAsymmErrors* gg, TF1* func); //!< Draw a single TGraph
     StFcsPulseAna* mPulseFit;   //!< Pointer to peak finder used by some analysis methods
 
     /**@brief Variable to use when testing #StFcsWaveformFitMaker algorithms


### PR DESCRIPTION
Fixed a bug where pdf wasn't being saved properly in Finish() and some minor changes.
 - Default energy select now matches the one in the constructor.
 - PeakAnaPainter now inherits from TObject as it should.