### PR TITLE
fix: consolidate 32-bit and 64-bit configs

### DIFF
--- a/mgr/config/v0.2.3-rhel7-root5.34.38.config
+++ b/mgr/config/v0.2.3-rhel7-root5.34.38.config
@@ -1,0 +1,16 @@
+#!/usr/bin/env csh
+
+# this is in place of buggy `module clear` (module VERSION=3.2.10 DATE=2012-12-21)
+unsetenv _LMFILES_*
+module purge
+
+if ( $USE_64BITS == 1 ) then
+    module unuse /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86/
+    module use   /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86_64/
+else
+    module unuse /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86_64/
+    module use   /cvmfs/star.sdcc.bnl.gov/star-spack/spack/share/spack/modules/linux-rhel7-x86/
+endif
+
+module load star-env-0.2.3-root-5.34.38
+module load libiconv-1.16

--- a/mgr/default.config
+++ b/mgr/default.config
@@ -1,1 +1,1 @@
-config/v0.2.3-rhel7-root5.34.38-32b.config
+config/v0.2.3-rhel7-root5.34.38.config


### PR DESCRIPTION
Introduce a single config file capable of setting up either 32-bit or 64-bit environment.

Something like this should work:

```
setup 64b
starver dev
setup 32b
starver dev
```