### PR TITLE
Fix segfault in unused StSvtSeqAdjMaker

### DIFF
--- a/StRoot/StSvtSeqAdjMaker/StSvtSeqAdjMaker.cxx
+++ b/StRoot/StSvtSeqAdjMaker/StSvtSeqAdjMaker.cxx
@@ -221,6 +221,7 @@ StSvtSeqAdjMaker::StSvtSeqAdjMaker(const char *name) : StMaker(name)
   // Set up some defaults
 
   mPedFile = NULL;
+  hfile = NULL;
   mPedOffSet = 20;
   m_thresh_lo = 3+mPedOffSet;
   m_thresh_hi = 5+mPedOffSet; 
@@ -237,7 +238,6 @@ StSvtSeqAdjMaker::~StSvtSeqAdjMaker(){
 Int_t StSvtSeqAdjMaker::Init(){
 
 
-  hfile = NULL;
   GetSvtRawData();
   
   SetSvtData();


### PR DESCRIPTION
In some bfc.C tests, this maker may get instantiated but, Init() is never called. Pointers not initialized to NULL in the constructor may potentially be non-zero in the destructor, leading to needless seg faults when quitting root4star.

Simple test: root4star -b -q -l 'bfc.C(-1)'