### PR TITLE
Picodst fixes

### DIFF
--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -278,20 +278,20 @@ Int_t StPicoDstMaker::Init() {
         
         if (setVtxModeAttr() != kStOK) {
 	  LOG_ERROR << "Pico Vertex Mode is not set ... " << endm;
-	  return kStErr;
+	  return kStFatal;
 	}
       } //if (mVtxMode == PicoVtxMode::NotSet)
 
       // To write or not to write covariance matrices into the branch
       if (setCovMtxModeAttr() != kStOK) {
 	LOG_ERROR << "Pico covariance matrix I/O mode is not set ..." << endm;
-	return kStErr;
+	return kStFatal;
       }
 
       // To write or not to write BEmc Smd hits into the branch
       if (setBEmcSmdModeAttr() != kStOk) {
 	LOG_ERROR << "Pico BEmc Smd I/O mode is not set ..." << endm;
-	return kStErr;
+	return kStFatal;
       }
 
 #if !defined (__TFG__VERSION__)
@@ -308,7 +308,7 @@ Int_t StPicoDstMaker::Init() {
 
 	if (mOutputFileName == mInputFileName) {
 	  LOG_ERROR << "Input file is not a MuDst ... " << endm;
-	  return kStErr;
+	  return kStFatal;
 	}
       }
 #else /* __TFG__VERSION__ */

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -99,10 +99,10 @@
 #include "StPicoEvent/StPicoArrays.h"
 #include "StPicoEvent/StPicoDst.h"
 #include "StPicoDstMaker/StPicoDstMaker.h"
+#include "TSystem.h"
 #if defined (__TFG__VERSION__)
 #include "StarRoot/TDirIter.h"
 #include "StMuDSTMaker/COMMON/StMuProbPidTraits.h"
-#include "TSystem.h"
 #include "TH1.h"
 #include "TH2.h"
 static Int_t _debug = 0;
@@ -302,7 +302,7 @@ Int_t StPicoDstMaker::Init() {
 	mOutputFileName.ReplaceAll(".root", ".picoDst.root");
       }
       else {
-	mInputFileName = mInputFileName(mInputFileName.Index("st_"), mInputFileName.Length());
+	mInputFileName = gSystem->BaseName(mInputFileName);
 	mOutputFileName = mInputFileName;
 	mOutputFileName.ReplaceAll("MuDst.root", "picoDst.root");
 


### PR DESCRIPTION
Leszek reported (on the simulations list) an issue with converting simulation MuDsts to picoDsts.  The code issues a couple of errors, and then crashes.  I believe this is due to a faulty assumption in initialization.  The code relies on the filename begining with "st_" in order to determine the basename of the file, when the full path is given.  This fails for Leszek's case (and for any pure simualtion).   When the assumption fails, the initialization routine returns before creating the TTree.  This results in the crash during Make, when the null pointer to the TTree is deferenced.

This PR removes the faulty assumption, and makes early returns from Init() a "fatal" return rather than just an error.