### PR TITLE
Change from int to StarMagField::EBField type

### DIFF
--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -1918,7 +1918,7 @@ void StBFChain::SetDbOptions(StMaker *mk){
 			 << "\",\"MagFactor\")" << endm;
       if ( gClassTable->GetID("StarMagField") >= 0) {
 	TString cmd =
-	  Form("if (!StarMagField::Instance()) new StarMagField( 2, %f, kTRUE);",
+	  Form("if (!StarMagField::Instance()) new StarMagField( StarMagField::EBField::kMapped, %f, kTRUE);",
 	       FieldOptions[k].scale);
 	ProcessLine(cmd);
       }


### PR DESCRIPTION
Resolves a run-time error seen in tests of compiling software for ROOT 6.16.00. I also tested this fix in ROOT 5.34.38 to be sure it doesn't break it.

-Gene
____________________

    root4star -b -q -l 'bfc.C(-1)'

...

QA :INFO  - ProcessLine if (!StarMagField::Instance()) new StarMagField( 2, 1.000000, kTRUE);
input_line_668:2:37: error: no matching constructor for initialization of 'StarMagField'
 if (!StarMagField::Instance()) new StarMagField( 2, 1.000000, kTRUE);
                                    ^             ~~~~~~~~~~~~~~~~~~
/afs/rhic.bnl.gov/star/packages/SL23x/.sl73_x8664_gcc485/include/StarMagField.h:155:3: note: candidate constructor not viable: no known conversion from 'int' to 'StarMagField::EBField' for 1st argument
  StarMagField ( EBField map     = kMapped, Float_t Factor  =      1, 
  ^
/afs/rhic.bnl.gov/star/packages/SL23x/.sl73_x8664_gcc485/include/StarMagField.h:91:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
class StarMagField : public TVirtualMagField 
      ^
BFC:ERROR - StBFChain::ProcessLine command:if (!StarMagField::Instance()) new StarMagField( 2, 1.000000, kTRUE); has failed. Quit job.