### PR TITLE
Remove the St_geant_Maker dependencies in the event generator to starsim bridge

### DIFF
--- a/StRoot/StarGenerator/BASE/AgStarReader.cxx
+++ b/StRoot/StarGenerator/BASE/AgStarReader.cxx
@@ -10,6 +10,8 @@ ClassImp(AgStarReader);
 #include <map>
 using namespace std;
 
+#include <cassert>
+
 #include "StarGenerator/UTIL/StarParticleData.h"
 #include "StarGenerator/BASE/StarParticleStack.h"
 


### PR DESCRIPTION
Use direct calls into the starsim / GEANT3 libraries to push particles onto the G3 stack, eliminating the dependence on St_geant_Maker and the version of GEANT3 required by starsim.  This will allow the event generator framework to function
with either our legacy starsim / St_geant_Maker framework, or the new VMC / StGeant4Maker framework.
