### PR TITLE
fix: redefine overloaded virtual methods in derived class

### DIFF
--- a/StarVMC/geant3/TGeant3/TGeant3.h
+++ b/StarVMC/geant3/TGeant3/TGeant3.h
@@ -1080,7 +1080,8 @@ public:
 private:
   Int_t ConvertVolumePathString(const TString &volumeName,Int_t **lnam,
                                 Int_t **lnum);
-
+  virtual void ProcessEvent(Int_t);
+  virtual void ProcessEvent(Int_t, Bool_t);
 
 
 protected:


### PR DESCRIPTION
Compiler errors due to hidden virtual method appear when building the
code against ROOT6.24

```
g++ -m64 -fPIC -pipe -Wall -Woverloaded-virtual -std=c++0x -Wno-long-long -pthread -Werror -O2 -g -falign-loops -falign-jumps -falign-functions -Dsl79_gcc485 -D__ROOT__ -DNEW_DAQ_READER -I. -IStRoot -I.sl79_gcc485/include -I/star/ROOT/6.24.06/geant3/TGeant3 -I/opt/software/linux-scientific7-x86_64/gcc-4.8.5/root-6.24.06-gbmdgvxscayjf6nqc5tatcs424pan4gs/include -c .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.cxx -o .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.o
In file included from .sl79_gcc485/include/StarVMCApplication.h:10:0,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.h:21,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.cxx:98:
/opt/software/linux-scientific7-x86_64/gcc-4.8.5/root-6.24.06-gbmdgvxscayjf6nqc5tatcs424pan4gs/include/TVirtualMC.h:804:17: error: 'virtual void TVirtualMC::ProcessEvent(Int_t)' was hidden [-Werror=overloaded-virtual]
    virtual void ProcessEvent(Int_t eventId);
                 ^
In file included from .sl79_gcc485/include/TGeant3TGeo.h:12:0,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.h:22,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.cxx:98:
.sl79_gcc485/include/TGeant3.h:1061:16: error:   by 'virtual void TGeant3::ProcessEvent()' [-Werror=overloaded-virtual]
   virtual void ProcessEvent();
                ^
In file included from .sl79_gcc485/include/StarVMCApplication.h:10:0,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.h:21,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.cxx:98:
/opt/software/linux-scientific7-x86_64/gcc-4.8.5/root-6.24.06-gbmdgvxscayjf6nqc5tatcs424pan4gs/include/TVirtualMC.h:882:17: error: 'virtual void TVirtualMC::ProcessEvent(Int_t, Bool_t)' was hidden [-Werror=overloaded-virtual]
    virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible);
                 ^
In file included from .sl79_gcc485/include/TGeant3TGeo.h:12:0,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.h:22,
                 from .sl79_gcc485/OBJ/StarVMC/StVMCMaker/StVMCMaker.cxx:98:
.sl79_gcc485/include/TGeant3.h:1061:16: error:   by 'virtual void TGeant3::ProcessEvent()' [-Werror=overloaded-virtual]
   virtual void ProcessEvent();
                ^
```

See https://github.com/star-bnl/star-sw/pull/619 for details