### PR TITLE
fix: include missing header TLine.h

### DIFF
--- a/StRoot/StFgtPool/StFgtQaMakers/StFgtPedStatQA.cxx
+++ b/StRoot/StFgtPool/StFgtQaMakers/StFgtPedStatQA.cxx
@@ -80,6 +80,7 @@
 #include "StRoot/StFgtUtil/StFgtConsts.h"
 
 #include <TCanvas.h>
+#include <TLine.h>
 #include <TPave.h>
 #include <TPaveText.h>
 #include <TPaveStats.h>

--- a/StRoot/StSpinPool/StWalgo2011/WeventDisplay.cxx
+++ b/StRoot/StSpinPool/StWalgo2011/WeventDisplay.cxx
@@ -11,6 +11,7 @@
 #include <TFile.h>
 #include <TText.h>
 #include <TLatex.h>
+#include <TLine.h>
 #include <TList.h>
 #include <TBox.h>
 #include <TPaveText.h>

--- a/StRoot/StSpinPool/StWalgoB2009/WeventDisplay.cxx
+++ b/StRoot/StSpinPool/StWalgoB2009/WeventDisplay.cxx
@@ -10,6 +10,7 @@
 #include <TStyle.h>
 #include <TFile.h>
 #include <TText.h>
+#include <TLine.h>
 #include <TList.h>
 #include <TBox.h>
 #include <TPaveText.h>


### PR DESCRIPTION
These errors appear when building the code against ROOT6.24

```
.sl79_gcc11/OBJ/StRoot/StFgtPool/StFgtQaMakers/StFgtPedStatQA.cxx:434:18: error: invalid use of incomplete type 'class TLine'
  434 |             lineB->Draw();
      |                  ^~
In file included from .sl79_gcc11/OBJ/StRoot/StFgtPool/StFgtQaMakers/StFgtPedStatQA.cxx:84:
/opt/software/linux-scientific7-x86_64/gcc-11.2.1/root-6.24.06-vianfhcgeujnnnnhm7g6hhr3tnsiwfqt/include/TPaveText.h:19:7: note: forward declaration of 'class TLine'
   19 | class TLine;
      |       ^~~~~
```

See https://github.com/star-bnl/star-sw/pull/619 for details
