### PR TITLE
Updates to StFwdTrackMaker to allow running without XML config file

### DIFF
--- a/StRoot/StFwdTrackMaker/FwdTrackerConfig.cxx
+++ b/StRoot/StFwdTrackMaker/FwdTrackerConfig.cxx
@@ -9,6 +9,13 @@ std::stringstream FwdTrackerConfig::sstr;
 // template specializations
 ////
 
+/**
+ * @brief write a value to path
+ * 
+ * @tparam  template specialization for std::string
+ * @param path path to write, if it DNE it is created
+ * @param v value (of type string) to write
+ */
 template <>
 void FwdTrackerConfig::set( std::string path, std::string v ) {
 
@@ -17,6 +24,13 @@ void FwdTrackerConfig::set( std::string path, std::string v ) {
     mNodes[ path ] = v;
 }
 
+/**
+ * @brief write a value to path
+ * 
+ * @tparam  template specialization for bool
+ * @param path path to write, if it DNE it is created
+ * @param bv boolean to write
+ */
 template <>
 void FwdTrackerConfig::set( std::string path, bool bv ) {
 
@@ -28,7 +42,15 @@ void FwdTrackerConfig::set( std::string path, bool bv ) {
     mNodes[ path ] = v;
 }
 
-// Specialization for string to avoid extra conversions
+// 
+/**
+ * @brief Get a value from the path
+ * 
+ * @tparam  Specialization for string to avoid extra conversions
+ * @param path path to lookup
+ * @param dv default value if path DNE
+ * @return std::string value at path or default
+ */
 template <>
 std::string FwdTrackerConfig::get( std::string path, std::string dv ) const {
     // return default value if path DNE
@@ -39,13 +61,26 @@ std::string FwdTrackerConfig::get( std::string path, std::string dv ) const {
     return ( mNodes.at( path ) );
 }
 
-// conversion to string is a noop
+/**
+ * @brief conversion to string is a noop
+ * 
+ * @tparam  string specialization
+ * @param str input
+ * @return std::string output (unchanged)
+ */
 template <>
 std::string FwdTrackerConfig::convert( std::string str ) const {
    return str;
 }
 
-// specialization for bool adds recognition of strings "true" and "false" (lower case)
+/**
+ * @brief specialization for bool adds recognition of strings "true" and "false" (lower case)
+ * 
+ * @tparam  bool specialization, fallback to int check
+ * @param str input string 
+ * @return true for "true"
+ * @return false for "false"
+ */
 template <>
 bool FwdTrackerConfig::convert( std::string str ) const {
 
@@ -58,7 +93,13 @@ bool FwdTrackerConfig::convert( std::string str ) const {
     return static_cast<bool>(convert<int>( str ));
 }
 
-// get as ROOT TString
+/**
+ * @brief get as ROOT TString
+ * 
+ * @tparam  TString specialization
+ * @param str input value
+ * @return TString output as ROOT TString
+ */
 template <>
 TString FwdTrackerConfig::convert(std::string str) const {
     TString r(str);

--- a/StRoot/StFwdTrackMaker/FwdTrackerConfig.cxx
+++ b/StRoot/StFwdTrackMaker/FwdTrackerConfig.cxx
@@ -9,6 +9,25 @@ std::stringstream FwdTrackerConfig::sstr;
 // template specializations
 ////
 
+template <>
+void FwdTrackerConfig::set( std::string path, std::string v ) {
+
+    FwdTrackerConfig::canonize( path );
+    // convrt from string to type T and return
+    mNodes[ path ] = v;
+}
+
+template <>
+void FwdTrackerConfig::set( std::string path, bool bv ) {
+
+    FwdTrackerConfig::canonize( path );
+    // convrt from string to type T and return
+    std::string v = "false";
+    if (bv)
+        v = "true";
+    mNodes[ path ] = v;
+}
+
 // Specialization for string to avoid extra conversions
 template <>
 std::string FwdTrackerConfig::get( std::string path, std::string dv ) const {

--- a/StRoot/StFwdTrackMaker/FwdTrackerConfig.h
+++ b/StRoot/StFwdTrackMaker/FwdTrackerConfig.h
@@ -26,9 +26,13 @@ protected:
     std::map<std::string, std::string> mNodes;
     static std::stringstream sstr; // reused for string to numeric conversion
 
-    // assumes bare path and adds [i] until DNE
-    // reports lowest non-existant index
-    // starts at 1 since 0 is checked on existance
+    /**
+     * @brief get lowest non-existing path index
+     * assumes bare path and adds [i] until DNE
+     * starts at 1 since 0 is checked on existance
+     * @param path base path to check
+     * @return size_t index, starts at 1
+     */
     size_t pathCount( const std::string path ){
         size_t index = 1;
         std::string p = path + TString::Format( "[%zu]", index ).Data();
@@ -39,6 +43,14 @@ protected:
         return index;
     }
 
+    /**
+     * @brief Reads an xml document and writes it into map
+     * 
+     * @param xml xml document to map
+     * @param node starting node - allows recursive mapping
+     * @param level the integer index of the level of current parsing
+     * @param path the path for the current node
+     */
     void mapFile(TXMLEngine &xml, XMLNodePointer_t node, Int_t level, std::string path = "") {
         using namespace std;
         // add the path delimeter above top level
@@ -83,7 +95,11 @@ protected:
     } // mapFile
 public:
 
-    // sanitizes a path to its canonical form 
+    /**
+     * @brief Returns a path in its cannonical form
+     * 
+     * @param path Path to cannoize, returned in place by reference
+     */
     static void canonize( std::string &path ) {
         // remove whitespace
         path.erase(std::remove_if(path.begin(), path.end(), static_cast<int(*) (int)>(std::isspace)), path.end());
@@ -98,7 +114,11 @@ public:
         return;
     }
 
-    // dump config to a basic string representation - mostly for debugging
+    /**
+     * @brief dump config to a basic string representation - mostly for debugging
+     * 
+     * @return std::string 
+     */
     std::string dump() const {
         using namespace std;
         FwdTrackerConfig::sstr.str("");
@@ -109,8 +129,14 @@ public:
         return FwdTrackerConfig::sstr.str();
     }
 
-    // Does a path exist
-    // Either node or attribute - used to determine if default value is used
+    /**
+     * @brief returns whether or not a path exist
+     * Either node or attribute - used to determine if default value is used
+     * 
+     * @param path - the path to check
+     * @return true : path exists
+     * @return false : path DNE
+     */
     bool exists( std::string path ) const {
         FwdTrackerConfig::canonize( path );
         if ( 0 == mNodes.count( path ) )
@@ -118,8 +144,14 @@ public:
         return true;
     }
 
-    // generic conversion to type T from std::string
-    // override this for special conversions
+    /**
+     * @brief Generic conversion of type T from string
+     * override this for special conversions
+     * 
+     * @tparam T : Type to convert to and return
+     * @param s : input string to use for conversion
+     * @return T converted value of type T
+     */
     template <typename T>
     T convert( std::string s ) const {
         T rv;
@@ -130,8 +162,13 @@ public:
         return rv;
     }
 
-    // generic conversion to type T To std::string
-    // override this for special conversions
+    /**
+     * @brief Generic conversion of type T to a string
+     * 
+     * @tparam T : type to convert
+     * @param v : value of type T
+     * @return std::string output string with representation of T
+     */
     template <typename T>
     std::string convertTo( T v ) const {
         FwdTrackerConfig::sstr.str("");
@@ -141,7 +178,14 @@ public:
     }
 
 
-    // template function for getting any type that can be converted from string via stringstream
+    /**
+     * @brief template function for getting any type that can be converted from string via stringstream
+     * 
+     * @tparam T type to return 
+     * @param path path to lookup
+     * @param dv default value to return if the node DNE
+     * @return T return value of type T
+     */
     template <typename T>
     T get( std::string path, T dv ) const {
     
@@ -154,6 +198,13 @@ public:
         return convert<T>( mNodes.at( path ) );
     }
 
+    /**
+     * @brief Writes a value of type T to the map
+     * Uses convertTo<T> to convert type T to a string rep 
+     * @tparam T type of value to write
+     * @param path path to write to
+     * @param v value of type T
+     */
     template <typename T>
     void set( std::string path, T v ) {
         FwdTrackerConfig::canonize( path );
@@ -161,7 +212,14 @@ public:
         mNodes[ path ] = convertTo<T>( v );
     }
     
-
+    /**
+     * @brief Get a Vector object from config
+     * 
+     * @tparam T type of value for the vector object
+     * @param path path to lookup
+     * @param dv default value, can use initializer list
+     * @return std::vector<T> vector of type T returned
+     */
     template <typename T>
     std::vector<T> getVector( std::string path, std::vector<T> dv ) const {
         if ( !exists( path ) )
@@ -190,7 +248,12 @@ public:
         return result;
     }
 
-    // list the paths of children nodes for a given node
+    /**
+     * @brief list the paths of children nodes for a given node
+     * 
+     * @param path path to search for children
+     * @return std::vector<std::string> list of full paths to the children nodes
+     */
     std::vector<std::string> childrenOf( std::string path ) const {
         using namespace std;
         vector<string> result;
@@ -218,16 +281,27 @@ public:
         return result;
     }
 
-    // Constructor is noop, use load(...)
+    /**
+     * @brief Constructor is noop, use load(...)
+     * 
+     */
     FwdTrackerConfig() {}
 
-    // constructor that immediately loads an xml file
+    /**
+     * @brief Construct a new Fwd Tracker Config object and load a file
+     * 
+     * @param filename 
+     */
     FwdTrackerConfig(std::string filename) {
         load( filename );
     }
 
-    // Main setup routine.
-    // Loads the given XML file and maps it
+    /**
+     * @brief Main setup routine
+     * Loads the given XML file (or string) and maps it
+     * @param filename filename (or xml string) to load. If file the content is loaded as an xml doc
+     * @param asString false: filename is loaded and contents treated as xml doc, true: treat the string `filename` directly as an xml doc
+     */
     void load( std::string filename, bool asString = false ) {
         using namespace std;
 
@@ -268,5 +342,9 @@ template <>
 TString FwdTrackerConfig::convert(std::string str) const;
 template <>
 std::string FwdTrackerConfig::get( std::string path, std::string dv ) const;
+template <>
+void FwdTrackerConfig::set( std::string path, std::string v );
+template <>
+void FwdTrackerConfig::set( std::string path, bool bv );
 
 #endif

--- a/StRoot/StFwdTrackMaker/FwdTrackerConfig.h
+++ b/StRoot/StFwdTrackMaker/FwdTrackerConfig.h
@@ -130,7 +130,15 @@ public:
         return rv;
     }
 
-    
+    // generic conversion to type T To std::string
+    // override this for special conversions
+    template <typename T>
+    std::string convertTo( T v ) const {
+        FwdTrackerConfig::sstr.str("");
+        FwdTrackerConfig::sstr.clear();
+        FwdTrackerConfig::sstr << v;
+        return FwdTrackerConfig::sstr.str();
+    }
 
 
     // template function for getting any type that can be converted from string via stringstream
@@ -146,6 +154,12 @@ public:
         return convert<T>( mNodes.at( path ) );
     }
 
+    template <typename T>
+    void set( std::string path, T v ) {
+        FwdTrackerConfig::canonize( path );
+        // convrt from string to type T and return
+        mNodes[ path ] = convertTo<T>( v );
+    }
     
 
     template <typename T>
@@ -214,7 +228,7 @@ public:
 
     // Main setup routine.
     // Loads the given XML file and maps it
-    void load( std::string filename ) {
+    void load( std::string filename, bool asString = false ) {
         using namespace std;
 
         // empty the map of mNodes
@@ -224,7 +238,12 @@ public:
         TXMLEngine xml;
 
         // Now try to parse xml file
-        XMLDocPointer_t xmldoc = xml.ParseFile(filename.c_str());
+        XMLDocPointer_t xmldoc;
+        if (asString)
+            xmldoc = xml.ParseString(filename.c_str());
+        else
+            xmldoc = xml.ParseFile(filename.c_str());
+
         if (!xmldoc) { // parse failed, TODO inform of error
             mErrorParsing = true;
             return;

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -241,6 +241,7 @@ int StFwdTrackMaker::Finish() {
         
         // output file name
         string name = mFwdConfig.get<string>("Output:url", "fwdTrackerOutput.root");
+        LOG_INFO << "Saving StFwdTrackMaker Histograms to ROOT file: " << name << endm;
         TFile *fOutput = new TFile(name.c_str(), "RECREATE");
         fOutput->cd();
 
@@ -266,15 +267,7 @@ int StFwdTrackMaker::Finish() {
 }
 
 void StFwdTrackMaker::LoadConfiguration() {
-    // Initialize configuration file
-    std::string configFile = SAttr("config");
-    if (mConfigFile.length() > 4) {
-        configFile = mConfigFile;
-    }
-
-    bool loadDefaultConfig = false;
-    if (configFile.length() < 5){
-        loadDefaultConfig = true;
+    if (mConfigFile.length() < 5){    
         LOG_INFO << "Forward Tracker is using default config for ";
         if ( defaultConfig == defaultConfigData ){
             LOG_INFO << " DATA" << endm;
@@ -284,7 +277,7 @@ void StFwdTrackMaker::LoadConfiguration() {
         mFwdConfig.load( defaultConfig, true );
     } else {
         LOG_INFO << "Forward Tracker is using config from file : " <<  mConfigFile << endm;
-        mFwdConfig.load( configFile );
+        mFwdConfig.load( mConfigFile );
     }
     configLoaded = true;
 }
@@ -1708,7 +1701,7 @@ std::string StFwdTrackMaker::defaultConfigIdealSim = R"(
     <Output url="fwdTrackMaker_ideal_sim.root" />
     <Source ftt="GEANT"  />
 
-	<TrackFitter refitSi="true" mcSeed="true" >
+	<TrackFitter refit="true" mcSeed="true" >
         <Vertex sigmaXY="0.001" sigmaZ="0.01" includeInFit="true" smearMcVertex="true" />
     </TrackFitter>
 </config>

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -1702,41 +1702,14 @@ void StFwdTrackMaker::ProcessFwdTracks(  ){
 }
 
 
-std::string StFwdTrackMaker::defaultConfigSim = R"(
+std::string StFwdTrackMaker::defaultConfigIdealSim = R"(
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-    <Output url="fwdTrackMaker_sim.root" />
+    <Output url="fwdTrackMaker_ideal_sim.root" />
     <Source ftt="GEANT"  />
-    
-    <TrackFinder nIterations="1">
-        <Iteration nPhiSlices="8"> <!-- Options for first iteration -->
-            <SegmentBuilder>
-                <Criteria name="Crit2_RZRatio" min="0.0" max="10.0" />
-                <Criteria name="Crit2_DeltaPhi" min="0" max="180" />    
-                <Criteria name="Crit2_DeltaRho" min="-100" max="100"/>
-                <Criteria name="Crit2_StraightTrackRatio" min="0.9" max="1.1"/>
-            </SegmentBuilder>
 
-            <ThreeHitSegments>
-                <Criteria name="Crit3_3DAngle" min="0" max="90" />
-                <Criteria name="Crit3_PT" min="0" max="10000" />
-                <Criteria name="Crit3_ChangeRZRatio" min="0" max="100" />
-                <Criteria name="Crit3_2DAngle" min="0" max="100" />
-            </ThreeHitSegments>
-        </Iteration>
-
-        <Connector distance="1"/>
-
-        <SubsetNN active="false" min-hits-on-track="4" >
-            <Omega>0.99</Omega>
-            <StableThreshold>0.001</StableThreshold>
-        </SubsetNN> 
-
-        <HitRemover active="true" />
-    </TrackFinder>
-    
-	<TrackFitter refitSi="true" mcSeed="false" MaterialEffects="false" >
-        <Vertex sigmaXY="1" sigmaZ="70.0" includeInFit="true" smearMcVertex="true" />
+	<TrackFitter refitSi="true" mcSeed="true" >
+        <Vertex sigmaXY="0.001" sigmaZ="0.01" includeInFit="true" smearMcVertex="true" />
     </TrackFitter>
 </config>
 )";
@@ -1746,11 +1719,10 @@ std::string StFwdTrackMaker::defaultConfigSim = R"(
 std::string StFwdTrackMaker::defaultConfigData = R"(
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-    <Output url="daq.root" />
+    <Output url="stfwdtrackmaker_data.root" />
     <Source ftt="DATA" />
 
-    <SiRasterizer r="3.0" phi="0.04" />
-
+    <SiRasterizer r="3.0" phi="0.004" />
 
     <TrackFinder nIterations="1">
         <Iteration nPhiSlices="32" > <!-- Options for first iteration -->
@@ -1781,8 +1753,8 @@ std::string StFwdTrackMaker::defaultConfigData = R"(
         <HitRemover active="false" />
     </TrackFinder>
     
-	<TrackFitter refitSi="true" mcSeed="false" zeroB="true"  >
-        <Vertex sigmaXY="3" sigmaZ="100.0" includeInFit="true" smearMcVertex="false" />
+	<TrackFitter refitSi="true" mcSeed="false" zeroB="true">
+        <Vertex sigmaXY="0.01" sigmaZ="0.01" includeInFit="true" smearMcVertex="false" />
     </TrackFitter>
 </config>
 )";

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -76,6 +76,8 @@ float BDTCrit2::Crit2_DeltaRho = -999;
 float BDTCrit2::Crit2_DeltaPhi = -999;
 float BDTCrit2::Crit2_StraightTrackRatio = -999;
 
+
+
 //_______________________________________________________________________________________
 class GenfitUtils{
     public:
@@ -85,7 +87,6 @@ class GenfitUtils{
 
     
 }; // GenfitUtils
-
 
 // Basic sanity cuts on genfit tracks
 template<> bool GenfitUtils::accept( genfit::Track *track )
@@ -148,9 +149,7 @@ template<> bool GenfitUtils::accept( genfit::Track *track )
 
 };
 
-
 //______________________________________________________________________________________
-
 class SiRasterizer {
   public:
     SiRasterizer() {}
@@ -226,8 +225,6 @@ class ForwardTracker : public ForwardTrackMaker {
     }
 };
 
-
-
 //________________________________________________________________________
 StFwdTrackMaker::StFwdTrackMaker() : StMaker("fwdTrack"), mGenHistograms(false), mGenTree(false), mForwardTracker(nullptr), mForwardData(nullptr){
     SetAttr("useFtt",1);                 // Default Ftt on 
@@ -268,17 +265,36 @@ int StFwdTrackMaker::Finish() {
     return kStOk;
 }
 
-//________________________________________________________________________
-int StFwdTrackMaker::Init() {
-
+void StFwdTrackMaker::LoadConfiguration() {
     // Initialize configuration file
     std::string configFile = SAttr("config");
     if (mConfigFile.length() > 4) {
         configFile = mConfigFile;
-        LOG_INFO << "Forward Tracker is using config file : " <<  mConfigFile << endm;
     }
 
-    mFwdConfig.load( configFile );
+    bool loadDefaultConfig = false;
+    if (configFile.length() < 5){
+        loadDefaultConfig = true;
+        LOG_INFO << "Forward Tracker is using default config for ";
+        if ( defaultConfig == defaultConfigData ){
+            LOG_INFO << " DATA" << endm;
+        } else {
+            LOG_INFO << " Simulation" << endm;
+        }
+        mFwdConfig.load( defaultConfig, true );
+    } else {
+        LOG_INFO << "Forward Tracker is using config from file : " <<  mConfigFile << endm;
+        mFwdConfig.load( configFile );
+    }
+    configLoaded = true;
+}
+
+//________________________________________________________________________
+int StFwdTrackMaker::Init() {
+
+    if ( !configLoaded ){
+        LoadConfiguration();
+    }
 
     if (mGenTree) {
         mTreeFile = new TFile("fwdtree.root", "RECREATE");
@@ -580,8 +596,6 @@ void StFwdTrackMaker::loadFttHits( FwdDataSource::McTrackMap_t &mcTrackMap, FwdD
         return;
     }
 } // loadFttHits
-
-
 
 void StFwdTrackMaker::loadFttHitsFromStEvent( FwdDataSource::McTrackMap_t &mcTrackMap, FwdDataSource::HitMap_t &hitMap, int count ){
     LOG_DEBUG << "Loading FTT Hits from Data" << endm;
@@ -1686,3 +1700,89 @@ void StFwdTrackMaker::ProcessFwdTracks(  ){
         }
     }
 }
+
+
+std::string StFwdTrackMaker::defaultConfigSim = R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <Output url="fwdTrackMaker_sim.root" />
+    <Source ftt="GEANT"  />
+    
+    <TrackFinder nIterations="1">
+        <Iteration nPhiSlices="8"> <!-- Options for first iteration -->
+            <SegmentBuilder>
+                <Criteria name="Crit2_RZRatio" min="0.0" max="10.0" />
+                <Criteria name="Crit2_DeltaPhi" min="0" max="180" />    
+                <Criteria name="Crit2_DeltaRho" min="-100" max="100"/>
+                <Criteria name="Crit2_StraightTrackRatio" min="0.9" max="1.1"/>
+            </SegmentBuilder>
+
+            <ThreeHitSegments>
+                <Criteria name="Crit3_3DAngle" min="0" max="90" />
+                <Criteria name="Crit3_PT" min="0" max="10000" />
+                <Criteria name="Crit3_ChangeRZRatio" min="0" max="100" />
+                <Criteria name="Crit3_2DAngle" min="0" max="100" />
+            </ThreeHitSegments>
+        </Iteration>
+
+        <Connector distance="1"/>
+
+        <SubsetNN active="false" min-hits-on-track="4" >
+            <Omega>0.99</Omega>
+            <StableThreshold>0.001</StableThreshold>
+        </SubsetNN> 
+
+        <HitRemover active="true" />
+    </TrackFinder>
+    
+	<TrackFitter refitSi="true" mcSeed="false" MaterialEffects="false" >
+        <Vertex sigmaXY="1" sigmaZ="70.0" includeInFit="true" smearMcVertex="true" />
+    </TrackFitter>
+</config>
+)";
+
+
+
+std::string StFwdTrackMaker::defaultConfigData = R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <Output url="daq.root" />
+    <Source ftt="DATA" />
+
+    <SiRasterizer r="3.0" phi="0.04" />
+
+
+    <TrackFinder nIterations="1">
+        <Iteration nPhiSlices="32" > <!-- Options for first iteration -->
+            <SegmentBuilder>
+                <Criteria name="Crit2_RZRatio" min="0" max="1.20" />
+                <Criteria name="Crit2_DeltaRho" min="-50" max="50.9"/>
+                <Criteria name="Crit2_DeltaPhi" min="0" max="30.0" />
+                <Criteria name="Crit2_StraightTrackRatio" min="0.01" max="5.85"/>
+            </SegmentBuilder>
+
+            <ThreeHitSegments>
+				<Criteria name="Crit3_3DAngle" min="0" max="30" />
+                <Criteria name="Crit3_PT" min="0" max="100" />
+				<Criteria name="Crit3_ChangeRZRatio" min="0.8" max="1.21" />
+				<Criteria name="Crit3_2DAngle" min="0" max="30" />
+            </ThreeHitSegments>
+        </Iteration>
+
+        <Connector distance="1"/>
+
+        <SubsetNN active="true" min-hits-on-track="3" >
+            <!-- <InitialTemp>2.1</InitialTemp> -->
+            <!-- <InfTemp>0.1</InfTemp> -->
+            <Omega>0.99</Omega>
+            <StableThreshold>0.001</StableThreshold>
+        </SubsetNN> 
+
+        <HitRemover active="false" />
+    </TrackFinder>
+    
+	<TrackFitter refitSi="true" mcSeed="false" zeroB="true"  >
+        <Vertex sigmaXY="3" sigmaZ="100.0" includeInFit="true" smearMcVertex="false" />
+    </TrackFitter>
+</config>
+)";

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -191,7 +191,7 @@ class StFwdTrackMaker : public StMaker {
 
     // Helper functions for modifying configuration
     // NOTE: to override configuration, call individual functions after setConfigForXXX
-    
+    public:
     /**@brief Setup the StFwdTrackMaker for running on Data
      * Load the default configuration for Data. 
      * Note: Apply any overrides after calling this

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -117,7 +117,9 @@ class StFwdTrackMaker : public StMaker {
 
     void SetConfigFile(std::string n) {
         mConfigFile = n;
+        LoadConfiguration();
     }
+    void LoadConfiguration();
     void SetGenerateHistograms( bool _genHisto ){ mGenHistograms = _genHisto; }
     void SetGenerateTree(bool _genTree) { mGenTree = _genTree; }
     void SetVisualize( bool _viz ) { mVisualize = _viz; }
@@ -182,6 +184,54 @@ class StFwdTrackMaker : public StMaker {
     void FillTTree(); // if debugging ttree is turned on (mGenTree)
     void FitVertex();
 
+    static std::string defaultConfigSim;
+    static std::string defaultConfigData;
+    std::string defaultConfig;
+    bool configLoaded = false;
+
+    // Helper functions for modifying configuration
+    // NOTE: to override configuration, call individual functions after setConfigForXXX
+    void setConfigForData() { defaultConfig = defaultConfigData; LoadConfiguration(); }
+    void setConfigForSim()  { defaultConfig = defaultConfigSim; LoadConfiguration();  }
+    
+    // General / hit and uncertainty
+    void setOutputFilename( std::string fn ) { mFwdConfig.set( "Output:url", fn ); }
+    void setFttHitSource( std::string source ) { mFwdConfig.set( "Source:ftt", source ); }
+    void setFstRasterR( double r = 3.0 /*cm*/ ){ mFwdConfig.set<double>( "SiRasterizer:r", r ); }
+    void setFstRasterPhi( double phi = 0.00409 /*2*pi/(12*128)*/ ){ mFwdConfig.set<double>( "SiRasterizer:phi", phi ); }
+
+    //Track Finding
+    void setSeedFindingWithFtt() { mFwdConfig.set( "TrackFinder:source", "ftt" ); }
+    void setSeedFindingWithFst() { mFwdConfig.set( "TrackFinder:source", "fst" ); }
+    void setSeedFindingNumInterations( int n = 1 ) { mFwdConfig.set<int>("TrackFinder:nIterations", n); }
+    void setSeedFindingNumPhiSlices( int n = 8 ) { mFwdConfig.set<int>("TrackFinder.Iteration:nPhiSlices", n); }
+    void setSeedFindingConnectorDistance( int d = 1 ) { mFwdConfig.set<int>( "TrackFinder.Connector:distance", d ); }
+    void setSeedFindingUseSubsetNN( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder.SubsetNN:active", use ); }
+    void setSeedFindingMinHitsOnTrack( int n = 3 ) { mFwdConfig.set<int>( "TrackFinder.SubsetNN:min-hits-on-track", n ); }
+    void setSeedFindingUseHitRemover( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder.HitRemover:active", use ); }
+    void setUseTruthSeedFinding( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder:active", !use ); }
+
+    // Track Fitting
+    void setTrackFittingOff() { mFwdConfig.set( "TrackFitter:active", "false" ); }
+    void setFittingMaterialEffects( bool mat = true) { mFwdConfig.set<bool>( "TrackFitter:materialEffects", mat ); }
+    void setPrimaryVertexSigmaXY( double sXY ) { mFwdConfig.set<double>( "TrackFitter.Vertex:sigmaXY", sXY ); }
+    void setPrimaryVertexSigmaZ(  double sZ ) { mFwdConfig.set<double>( "TrackFitter.Vertex:sigmaZ", sZ ); }
+    void setIncludePrimaryVertexInFit( bool pvf = true ) { mFwdConfig.set<bool>( "TrackFitter.Vertex:includeInFit", pvf ); }
+    void setZeroB( bool zeroB = true ) { mFwdConfig.set<bool>( "TrackFitter:zeroB", zeroB ); }
+    void setConstB( bool constB = true ) { mFwdConfig.set<bool>( "TrackFitter:constB", constB ); }
+    void setUseMcSeedForFit( bool mcSeed = true ) { mFwdConfig.set<bool>( "TrackFitter:mcSeed", mcSeed ); }
+
+    void setRefitWithFst() { mFwdConfig.set( "TrackFitter:refitSi", "true" ); mFwdConfig.set( "TrackFitter:refitFtt", "false" ); }
+    void setRefitWithFtt() { mFwdConfig.set( "TrackFitter:refitSi", "false" ); mFwdConfig.set( "TrackFitter:refitFtt", "true" ); }
+
+    void setMaxFailedHitsInFit( int n = -1 /*no lim*/ ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MaxFailedHits", n);}
+    void setFitDebugLvl( int level = 0 /*0=no output*/ ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:DebugLvl", level); }
+    void setFitMaxIterations( int n=4 ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MaxIterations", n); }
+    void setFitMinIterations( int n = 1) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MinIterations", n); }
+
+    // for MC
+    void setSmearMcPrimaryVertex( bool pvs = true ) { mFwdConfig.set<bool>( "TrackFitter.Vertex:smearMcVertex", pvs ); }
+  
 };
 
 #endif

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -323,17 +323,13 @@ class StFwdTrackMaker : public StMaker {
     */
     void setUseMcSeedForFit( bool mcSeed = true ) { mFwdConfig.set<bool>( "TrackFitter:mcSeed", mcSeed ); }
 
-
-    /**@brief Sets the tracking to refit with Fst hits
-     * Note: This only makes sense if seed finding is done with FTT hits
-     * So calling this option sets SeedFinding with Ftt hits
+    /**@brief Sets the tracking to refit 
+     * This adds compatible hits from whichever detector was NOT used in seed finding
+     * if FTT seeding -> project to and add FST hits
+     * if FST seeding -> project to and add FTT hits
+     * @param refit : true, perform refit, false do not
     */
-    void setRefitWithFst() { setSeedFindingWithFtt(); mFwdConfig.set( "TrackFitter:refitSi", "true" ); mFwdConfig.set( "TrackFitter:refitFtt", "false" ); }
-    /**@brief Sets the tracking to refit with Ftt hits
-     * Note: This only makes sense if seed finding is done with FST hits
-     * So calling this option sets SeedFinding with Fst hits
-    */
-    void setRefitWithFtt() { setSeedFindingWithFst(); mFwdConfig.set( "TrackFitter:refitSi", "false" ); mFwdConfig.set( "TrackFitter:refitFtt", "true" ); }
+    void setTrackRefit( bool refit = true) { mFwdConfig.set<bool>( "TrackFitter:refit", refit ); }
 
     /**@brief Sets the maximum number of hits that can be considered failed before the entire track fit fails
      * @param n : number of failed hits allowed, -1 = no limit

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -184,52 +184,177 @@ class StFwdTrackMaker : public StMaker {
     void FillTTree(); // if debugging ttree is turned on (mGenTree)
     void FitVertex();
 
-    static std::string defaultConfigSim;
+    static std::string defaultConfigIdealSim;
     static std::string defaultConfigData;
     std::string defaultConfig;
     bool configLoaded = false;
 
     // Helper functions for modifying configuration
     // NOTE: to override configuration, call individual functions after setConfigForXXX
-    void setConfigForData() { defaultConfig = defaultConfigData; LoadConfiguration(); }
-    void setConfigForSim()  { defaultConfig = defaultConfigSim; LoadConfiguration();  }
     
-    // General / hit and uncertainty
+    /**@brief Setup the StFwdTrackMaker for running on Data
+     * Load the default configuration for Data. 
+     * Note: Apply any overrides after calling this
+    */
+    void setConfigForData() { defaultConfig = defaultConfigData; LoadConfiguration(); }
+    /**@brief Setup the StFwdTrackMaker for running on Data
+     * Load the default configuration for IDEAL simulation.
+     * This runs with MC track finding and MC-seeded track fitting.
+     * - MC track finding uses the MCTrackId to collect stgc/fst hits into track seeds 
+     * - MC-seeded track fitting uses the MC particle momentum to seed the track fit
+     * - Also uses the simulated MC primary vertex with smearing according to the simgaXY,Z
+     * Note: Apply any overrides after calling this
+    */
+    void setConfigForIdealSim()  { defaultConfig = defaultConfigIdealSim; LoadConfiguration();  }
+
+    /**@brief Setup the StFwdTrackMaker for running on Data
+     * Load the default configuration for Realistic simulation.
+     * This runs tracking on simulation using the same parameters / approach as on data.
+     * Note: Apply any overrides after calling this
+    */
+    void setConfigForRealisticSim()  { 
+      defaultConfig = defaultConfigData; 
+      LoadConfiguration();  
+      // Note: Once the slow sims work this override will not be needed
+      // because the slow sims will put hits into StEvent just like (data) reco chain
+      setFttHitSource( "GEANT" );
+    }
+
+
+    /**@brief Set the filename for output ROOT file
+     * @param fn : filename of output ROOT file
+    */
     void setOutputFilename( std::string fn ) { mFwdConfig.set( "Output:url", fn ); }
+    /**@brief Set the data source for FTT hits
+     * 
+     * @param source : {DATA, GEANT}, DATA means read from StEvent, GEANT means read directly from the GEANT hits
+    */
     void setFttHitSource( std::string source ) { mFwdConfig.set( "Source:ftt", source ); }
+    
+    /**@brief Enable or disable the Fst Rasterizer
+     * @param use : if true, load FST hits from GEANT and raster them according to r, phi resolutions.
+    */
+    void setUseFstRasteredGeantHits( bool use = true ){ mFwdConfig.set<bool>( "SiRasterizer:active", use ); }
+    /**@brief Set the resolution in R for rasterizing FST hits (from fast sim)
+     * Only used when the Rasterizer is enabled, which results from reading FST hits from GEANT
+     * @param r : resolution in r (cm)
+    */
     void setFstRasterR( double r = 3.0 /*cm*/ ){ mFwdConfig.set<double>( "SiRasterizer:r", r ); }
+    /**@brief Set the resolution in phi for rasterizing FST hits (from fast sim)
+     * Only used when the Rasterizer is enabled, which results from reading FST hits from GEANT
+     * @param phi : resolution in phi (rad)
+    */
     void setFstRasterPhi( double phi = 0.00409 /*2*pi/(12*128)*/ ){ mFwdConfig.set<double>( "SiRasterizer:phi", phi ); }
 
     //Track Finding
+    /**@brief Use Ftt hits in the Seed Finding
+     * 
+    */
     void setSeedFindingWithFtt() { mFwdConfig.set( "TrackFinder:source", "ftt" ); }
+    /**@brief Use Fst hits in the Seed Finding
+     * 
+    */
     void setSeedFindingWithFst() { mFwdConfig.set( "TrackFinder:source", "fst" ); }
+    /**@brief Set the number of track finding iterations
+     * @param n : number of iterations to run
+    */
     void setSeedFindingNumInterations( int n = 1 ) { mFwdConfig.set<int>("TrackFinder:nIterations", n); }
+    /**@brief Set the number of phi slices to split the track iterations into
+     * @param n : number of slices of equal size (2pi)/n
+    */
     void setSeedFindingNumPhiSlices( int n = 8 ) { mFwdConfig.set<int>("TrackFinder.Iteration:nPhiSlices", n); }
+    /**@brief Set the connector distance for track finding
+     * @param d : distance between planes (1 = adjacent)
+    */
     void setSeedFindingConnectorDistance( int d = 1 ) { mFwdConfig.set<int>( "TrackFinder.Connector:distance", d ); }
+    /**@brief Enable or disable the SubsetNN
+     * @param use : if true, enables the subsetNN which find the most compatible set of tracks without shared hits
+     *            if false, all tracks are reported regardless of shared hits
+    */
     void setSeedFindingUseSubsetNN( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder.SubsetNN:active", use ); }
+    /**@brief Enable or disable the SubsetNN
+     * @param n : minimum number of hits on a track seed. Seeds with fewer hits are discarded
+    */
     void setSeedFindingMinHitsOnTrack( int n = 3 ) { mFwdConfig.set<int>( "TrackFinder.SubsetNN:min-hits-on-track", n ); }
+    /**@brief Enable or disable the HitRemover
+     * @param use : if true, enables the hit remover which removes any hits from the hitmap that were used in a track
+     *            if false, hits are not removed after each iteration
+    */
     void setSeedFindingUseHitRemover( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder.HitRemover:active", use ); }
+    /**@brief Enable or disable the Truth Seed finding
+     * @param use : if true, use Mc info to group hits into track seeds
+     *            if false, seed finding uses options as in the case for data
+    */
     void setUseTruthSeedFinding( bool use = true ) { mFwdConfig.set<bool>( "TrackFinder:active", !use ); }
 
     // Track Fitting
+    /**@brief Turn off track fitting 
+     * Useful if you want to speed up the run but dont need fitting (testing seed finding)
+    */
     void setTrackFittingOff() { mFwdConfig.set( "TrackFitter:active", "false" ); }
+    /**@brief Enable / disable material effects
+     * Material effects in kalman filter
+    */
     void setFittingMaterialEffects( bool mat = true) { mFwdConfig.set<bool>( "TrackFitter:materialEffects", mat ); }
+    /**@brief Set the resolution for the Primary Vertex in XY
+     * @params sXY : sigma in XY (cm)
+    */
     void setPrimaryVertexSigmaXY( double sXY ) { mFwdConfig.set<double>( "TrackFitter.Vertex:sigmaXY", sXY ); }
+    /**@brief Set the resolution for the Primary Vertex in Z
+     * @params sZ : sigma in Z (cm)
+    */
     void setPrimaryVertexSigmaZ(  double sZ ) { mFwdConfig.set<double>( "TrackFitter.Vertex:sigmaZ", sZ ); }
+    // TODO: add options for beamline constraint
+
+    /**@brief Include or exclude the Primary Vertex in fit
+     * @param pvf : if true, use PRimary Vertex in fit
+    */
     void setIncludePrimaryVertexInFit( bool pvf = true ) { mFwdConfig.set<bool>( "TrackFitter.Vertex:includeInFit", pvf ); }
+    /**@brief Set B-field to zero (for zero field running)
+     * @param zeroB : if true, use Zero B field
+    */
     void setZeroB( bool zeroB = true ) { mFwdConfig.set<bool>( "TrackFitter:zeroB", zeroB ); }
+    /**@brief Set B-field to constant (even outside of TPC)
+     * @param constB : if true, use const 0.5T B field
+    */
     void setConstB( bool constB = true ) { mFwdConfig.set<bool>( "TrackFitter:constB", constB ); }
+    /**@brief Force the use of McSeed for fit
+     * @param mcSeed : if true, use mc momentum as the seed for the track fitter
+    */
     void setUseMcSeedForFit( bool mcSeed = true ) { mFwdConfig.set<bool>( "TrackFitter:mcSeed", mcSeed ); }
 
-    void setRefitWithFst() { mFwdConfig.set( "TrackFitter:refitSi", "true" ); mFwdConfig.set( "TrackFitter:refitFtt", "false" ); }
-    void setRefitWithFtt() { mFwdConfig.set( "TrackFitter:refitSi", "false" ); mFwdConfig.set( "TrackFitter:refitFtt", "true" ); }
 
+    /**@brief Sets the tracking to refit with Fst hits
+     * Note: This only makes sense if seed finding is done with FTT hits
+     * So calling this option sets SeedFinding with Ftt hits
+    */
+    void setRefitWithFst() { setSeedFindingWithFtt(); mFwdConfig.set( "TrackFitter:refitSi", "true" ); mFwdConfig.set( "TrackFitter:refitFtt", "false" ); }
+    /**@brief Sets the tracking to refit with Ftt hits
+     * Note: This only makes sense if seed finding is done with FST hits
+     * So calling this option sets SeedFinding with Fst hits
+    */
+    void setRefitWithFtt() { setSeedFindingWithFst(); mFwdConfig.set( "TrackFitter:refitSi", "false" ); mFwdConfig.set( "TrackFitter:refitFtt", "true" ); }
+
+    /**@brief Sets the maximum number of hits that can be considered failed before the entire track fit fails
+     * @param n : number of failed hits allowed, -1 = no limit
+    */
     void setMaxFailedHitsInFit( int n = -1 /*no lim*/ ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MaxFailedHits", n);}
+    /**@brief Sets Fitter debug level
+     * @param level : 0 = no output, higher numbers are more verbose
+    */
     void setFitDebugLvl( int level = 0 /*0=no output*/ ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:DebugLvl", level); }
+    /**@brief Sets Max fit iterations before failing
+     * @param n : num iterations
+    */
     void setFitMaxIterations( int n=4 ) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MaxIterations", n); }
+    /**@brief Sets Min fit iterations before converging
+     * @param n : num iterations
+    */
     void setFitMinIterations( int n = 1) {mFwdConfig.set<int>("TrackFitter.KalmanFitterRefTrack:MinIterations", n); }
 
-    // for MC
+    /**@brief Enables smearing of the MC Primary Vertex according to sigmaXY,Z
+     * @param pvs : if true, smear vertex 
+    */
     void setSmearMcPrimaryVertex( bool pvs = true ) { mFwdConfig.set<bool>( "TrackFitter.Vertex:smearMcVertex", pvs ); }
   
 };


### PR DESCRIPTION
This update makes the StFwdTrackMaker fully configurable from the ROOT macro without the need for any external XML config file.

Changes:
- FwdTrackerConfig: new functionality to allow loading a config from a string (instead of a file) and new functions for setting arbitrary values in the config
- StFwdTrackMaker: many new functions for setting configuration parameters
- New logic to use a default configuration if set for Data or Mc, else load from a config file

The default config file is embedded for consistency.
In the future BFC options can be used to toggle parameters if they need to change from one production to the next. 
