### PR TITLE
Disable logging outside of local domain, with no other changes

### DIFF
--- a/StRoot/RTS/include/rtsLog.h
+++ b/StRoot/RTS/include/rtsLog.h
@@ -93,41 +93,14 @@ void rtsLogAddJmlFile (char *fname);
 
 
 
-/*Tonko: not used Special (mis)handling for STAR Offline Code
-#ifdef __ROOT__	
-#define RTS_DISABLE_LOG
-#endif
-*/
 
-#ifdef RTS_DISABLE_LOG
+
+#ifndef RTS_ENABLE_LOG
 
 #define RTS_ASSERT(expr)	assert(expr)
-
-
-	#define LOG(SEV,STRING,ARGS...) \
-        do { \
-                const char *const yada = SEV ; \
-                if((*yada == 'E')) { \
-                        fprintf(stderr,"" ANSI_RED "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-                else if((*yada == 'C')) { \
-                        fprintf(stderr,"" ANSI_RED "" ANSI_REVERSE "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-                else if((*yada == 'I')) { \
-                        fprintf(stderr,"" ANSI_BLUE "" ANSI_BOLD "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-                else if((*yada == 'T')) { \
-                        fprintf(stderr,"" ANSI_GREEN "" ANSI_BOLD "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-                else if((*yada == 'W')) { \
-                        fprintf(stderr,"" ANSI_CYAN "" ANSI_BOLD "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-                else if((*yada == 'O')) { \
-                        fprintf(stderr,"" ANSI_BLUE "" ANSI_REVERSE "RTS_" SEV ": " __FILE__ " [line %d]: " STRING "" ANSI_RESET "\n" , __LINE__ , ##ARGS) ;\
-		} \
-	} while(0) \
-
-
+#define LOG(SEV,STRING,ARGS...)
+#define rtsLogUnix_v(str, ...)
+#define rtsLogAddCmd(x)
 
 
 // the following become noops...
@@ -136,7 +109,7 @@ void rtsLogAddJmlFile (char *fname);
 #define rtsLogLevelInt(x)
 #define rtsLogOutput(x)
 
-#else	/* RTS_DISABLE_LOG */
+#else	/* RTS_ENABLE_LOG */
 
 
 #ifdef __GNUC__
@@ -270,12 +243,12 @@ INLINE_HACK void rtsLogLevel(const char *level)
 
 
 
-#endif
+#endif  /* RTS_LOG_COLORED */
 
-#endif
+#endif  /* __vxworks */
 
 
-#endif	/* RTS_DISABLE_LOG */
+#endif	/* RTS_ENABLE_LOG */
 
 #ifdef __cplusplus
 }

--- a/StRoot/RTS/src/LOG/Makefile
+++ b/StRoot/RTS/src/LOG/Makefile
@@ -2,6 +2,7 @@
 include ../rtsmakefile.def
 include ../rtsplus.def
 
+
 # zap LDLIBS
 LDLIBS = 
 
@@ -28,7 +29,7 @@ rtsLog.o : rtsLog.C
 
 rtsLog: rtsLog.o rtsLogUnix.o
 	$(CXX) $(CXXFLAGS) rtsLogUnix.o rtsLog.o -o rtsLog
-	
+
 #operDisplay.sh:	
 
 

--- a/StRoot/RTS/src/LOG/rtsLog.C
+++ b/StRoot/RTS/src/LOG/rtsLog.C
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	use_stdin = 0 ;
 
 	rtsLogLevel(DBG) ;
-	rtsLogOutput(RTS_LOG_NET) ;
+	//rtsLogOutput(RTS_LOG_NET) ;
 
 	memset(logstr,0,sizeof(logstr)) ;
 

--- a/StRoot/RTS/src/LOG/rtsLogUnix.c
+++ b/StRoot/RTS/src/LOG/rtsLogUnix.c
@@ -29,6 +29,30 @@ extern "C" {
 volatile int tonkoLogLevel = 2 ;	
 
 
+
+
+
+
+#ifdef RTS_ENABLE_LOG
+#warning "DAQ logging is enabled"
+#ifdef RTS_LOG_DEFAULT_NET
+#warning "DAQ logging defaults to daqman"
+#else
+#warning "DAQ logging defaults to STDERR"
+#endif  /* RTS_LOG_DEFAULT_NET */
+#else
+#warning "DAQ logging is disabled"
+#endif  /* RTS_ENABLE_LOG */
+
+
+#ifdef RTS_ENABLE_LOG
+
+#ifdef RTS_LOG_DEFAULT_NET
+static int output_flag = RTS_LOG_NET ;
+#else
+static int output_flag = RTS_LOG_STDERR ;
+#endif
+
 static const char *getCmd(void) ;
 static int  odesc = -1 ;
 static int handchange ;
@@ -42,7 +66,7 @@ static char servER[80] = RTS_LOG_HOST ;
 #endif
 
 static int port = RTS_LOG_PORT ;
-static int output_flag = RTS_LOG_NET ;
+
 static char cmd[1024] ;
 
 /*
@@ -112,7 +136,6 @@ void rtsLogAddJmlFile (char *fname)
 	strcpy(_g_fname, fname);
 	jml_fname = _g_fname;
 }
-
 
 int rtsLogUnix_v(const char *str, ...) 
 {
@@ -328,8 +351,6 @@ int rtsLogUnix_v(const char *str, ...)
 	return 0 ;
 }
 
-
-
 static const char *getCmd(void)
 {
 
@@ -369,6 +390,11 @@ static const char *getCmd(void)
 	return ps.pr_fname ;
 #endif
 }
+
+
+#endif
+
+
 
 #ifdef __cplusplus
 }

--- a/StRoot/RTS/src/rtsmakefile.def
+++ b/StRoot/RTS/src/rtsmakefile.def
@@ -17,6 +17,8 @@ ifeq ($(HOST_NAME),daqman.starp.bnl.gov)
 endif
 
 
+HOSTDOMAIN = $(shell hostname -d)
+
 # jml...  TARGET_CPU_STRING to mean the full string...
 
 # go from "uname" to gcc -mcpu=TARGET_CPU variant
@@ -373,14 +375,38 @@ DEFINES = -D_REENTRANT ${RTS_DAQMAN_FLAGS} -DRTS_HOST_NAME=\"${HOST_NAME}\" -DTA
 
 
 # Set strict errors in LINUX
-BASEFLAGS = -O3 -Wall -Werror -Wno-error=strict-overflow -Wno-error=maybe-uninitialized -Wno-error=unused-label -Wno-error=unused-value -Wno-error=unused-variable -Wno-error=unused-function -Wno-unused-but-set-variable -pipe -fverbose-asm ${HOSTFLAGS}
+BASEFLAGS = -O3 -Wall -Wno-error=strict-overflow -Wno-error=maybe-uninitialized -Wno-error=unused-label -Wno-error=unused-value -Wno-error=unused-variable -Wno-error=unused-function -Wno-unused-but-set-variable -pipe -fverbose-asm ${HOSTFLAGS}
 
+
+#-O3
 ifneq (${TARGET_SYSTEM}, LINUX)
-     BASEFLAGS = -O3 -Wall  -pipe -fverbose-asm ${HOSTFLAGS} 
+     BASEFLAGS = -Wall  -pipe -fverbose-asm ${HOSTFLAGS} 
 endif
 
 ifeq (${HOST_NAME},xvme01.daq.bnl.local) 
-     BASEFLAGS = -O3 -Wall -Werror -Wno-error=strict-overflow -Wno-error=unused-label -Wno-error=unused-value -Wno-error=unused-variable -Wno-error=unused-function -Wno-unused-but-set-variable -pipe -fverbose-asm ${HOSTFLAGS}
+     BASEFLAGS = -O3 -Wall -Wno-error=strict-overflow -Wno-error=unused-label -Wno-error=unused-value -Wno-error=unused-variable -Wno-error=unused-function -Wno-unused-but-set-variable -pipe -fverbose-asm ${HOSTFLAGS}
+endif
+
+# if not compiling on one of the standard domains, then 
+# use the default log destination of std_err
+# if compiling on local domain, write to daqman
+#
+# if compiling somewhere else for writing to daqman these defines
+ifeq (${HOSTDOMAIN},starp.bnl.gov)
+	DEFINES += -DRTS_LOG_DEFAULT_NET
+	DEFINES += -DRTS_ENABLE_LOG
+else ifeq (${HOSTDOMAIN},daq.bnl.local) 
+	DEFINES += -DRTS_LOG_DEFAULT_NET
+	DEFINES += -DRTS_ENABLE_LOG
+else ifeq (${HOSTDOMAIN},daq2.bnl.local)
+	DEFINES += -DRTS_LOG_DEFAULT_NET
+	DEFINES += -DRTS_ENABLE_LOG
+else ifeq (${HOSTDOMAIN},trg.bnl.local)
+	DEFINES += -DRTS_LOG_DEFAULT_NET
+	DEFINES += -DRTS_ENABLE_LOG
+else ifeq (${HOSTDOMAIN},l4.bnl.local)
+	DEFINES += -DRTS_LOG_DEFAULT_NET
+	DEFINES += -DRTS_ENABLE_LOG
 endif
 
 CCFLAGS  = ${BASEFLAGS} ${USRCCFLAGS}  ${DEFINES} ${INCLUDES} 
@@ -395,6 +421,10 @@ ifeq ($(RTS_PROJECT),PP2PP)
 	export LDLIBS = -L${LIBDIR} -lrtsComLib -lsunRT -lrtslog  ${HOSTLIBS}
 endif
 endif
+
+
+
+
 
 # noticed problems on Linux where the default linker gcc doesn't work well for g++ compiled
 # files


### PR DESCRIPTION
Clean version of the pull request disabling DAQ logging when compiling outside of the local domain. 