### PR TITLE
Small fix for StFcsDb and StFcsWaveformFitMaker

### DIFF
--- a/StRoot/StFcsDbMaker/StFcsDb.cxx
+++ b/StRoot/StFcsDbMaker/StFcsDb.cxx
@@ -756,7 +756,6 @@ StThreeVectorD StFcsDb::projectTrack(int det, const g2t_track_st* g2ttrk, const 
   double linedir[3] = {g2ttrk->p[0],g2ttrk->p[1],g2ttrk->p[2]};
   if( g2tvert!=0 ){
     int vertind = g2ttrk->start_vertex_p - 1; //To correct for offset by one between fortran array and c array. 0 start index means it was generated at the starting vertex
-    std::cout << "+++++ DEBUG: vertind = " << vertind << " +++++" << std::endl;
     double linestart[3] = {g2tvert[vertind].ge_x[0],g2tvert[vertind].ge_x[1],g2tvert[vertind].ge_x[2]};
     if( vertind >= 0 ){//Since start index==0 means no start then vertind<0 will default to using origin
       return projectLine(det, linedir, linestart, showermaxz);

--- a/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.cxx
+++ b/StRoot/StFcsWaveformFitMaker/StFcsWaveformFitMaker.cxx
@@ -501,11 +501,11 @@ int StFcsWaveformFitMaker::Make() {
 	  if( mAnaWaveform ){
 	    integral = analyzeWaveform(mEnergySelect[ehp],hits[i],res,func,res[6]);
 	    hits[i]->setAdcSum(integral);
+	    hits[i]->setFitPeak(res[2]);
+	    hits[i]->setFitSigma(res[3]);
+	    hits[i]->setFitChi2(res[4]);
+	    hits[i]->setNPeak(res[5]);
 	  }
-	  hits[i]->setFitPeak(res[2]);	    
-	  hits[i]->setFitSigma(res[3]);	    
-	  hits[i]->setFitChi2(res[4]);	    
-	  hits[i]->setNPeak(res[5]);	    
 	  //apply gain and update energy
 	  float gain = mDb->getGain(hits[i]);
 	  float gaincorr = mDb->getGainCorrection(hits[i]);


### PR DESCRIPTION
Got rid of unneeded cout statement in StFcsDb.cxx. Fixed StFcsWaveformFitMaker  to not overwrite data in StFcsHit object when mAnaWaveform is false.