### PR TITLE
Proper dependencies for FCS Pi0 used in QA

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1639,6 +1639,7 @@ Bfc_st BFC[] = { // standard chains
    "StFcsClusterMaker","StFcsClusterMaker","Fill FCS clusters",                                     kFALSE},
   {"fcsPoint"   ,"","fcsChain", "StEvent,fcsDb",
    "StFcsPointMaker","StFcsPointMaker,libMinuit","Fill FCS points",                                 kFALSE},
+  {"fcsPi0Libs","", "", "MuDst", "", "StFcsPi0FinderForEcal", "Libs for FCS Pi0 Finder",            kFALSE},
   // FTT
   {"ftt","fttChain","","FttDat,FttHitCalib,FttClu,FttPoint", "StMaker","StChain","FST chain"        ,kFALSE}, 
   {"FttDat","","fttChain","StEvent","StFttRawHitMaker","StFttRawHitMaker,StEvent",
@@ -1922,7 +1923,8 @@ Bfc_st BFC[] = { // standard chains
   {"ppDAQfilter1","","",""                                               ,"","",STAR_CHAIN_OBSOLETE,kFALSE},
   {"ppLPeval1"   ,"","",""                                               ,"","",STAR_CHAIN_OBSOLETE,kFALSE},
   {"QA"          ,"","",""                                               ,"","",STAR_CHAIN_OBSOLETE,kFALSE},
-  {"EventQA","EventQA","","QUtils,Event","StEventQAMaker"   ,"St_QA_Maker","Filling Y2/Y3 Qa histo",kFALSE},
+  {"EventQA","EventQA","","QUtils,Event,fcsPi0Libs","StEventQAMaker"
+    ,"St_QA_Maker","Filling Y2/Y3 Qa histo",kFALSE},
   {"QAC"         ,"CosmicsQA","globT",""                    ,"StQACosmicMaker","StQACosmicMaker","",kFALSE},
   {"QAalltrigs"  ,"", "","",                                     "","","Analyze all triggers in QA",kFALSE},
   {"HitFilt"     ,"", "","",               "StHitFilterMaker","StHitFilterMaker","Hit filter Maker",kFALSE},

--- a/StRoot/St_QA_Maker/StEventQAMaker.cxx
+++ b/StRoot/St_QA_Maker/StEventQAMaker.cxx
@@ -46,9 +46,7 @@
 #include "StEpdCollection.h"
 
 //fcs
-#define SKIPDefImp
-#include "StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.cxx"
-#undef SKIPDefImp
+#include "StFcsPi0FinderForEcal/StFcsPi0FinderForEcal.h"
                                                                             
 #include "StEvent/StTpcRawData.h"
 


### PR DESCRIPTION
This resolves the issue brought in PR #437 :
St_QA_Maker should not directly depend on MuDst (a solution proposed in #437 ), but instead should depend on the StFcsPi0FinderForEcal, which itself has a dependency on MuDst.