### PR TITLE
Catch a memory leak in a TList

### DIFF
--- a/StRoot/StAnalysisUtilities/StHistUtil.cxx
+++ b/StRoot/StAnalysisUtilities/StHistUtil.cxx
@@ -476,6 +476,9 @@ StHistUtil::StHistUtil(){
   m_PaperHeight = 0;
 
   m_Detectors = "";
+
+  m_ItemsToClear = new TList();
+  m_ItemsToClear->SetOwner();
 }
 //_____________________________________________________________________________
 
@@ -500,6 +503,11 @@ StHistUtil::~StHistUtil(){
     for (int ijk=0; ijk<maxHistCopy; ijk++) delete newHist[ijk];
     delete [] newHist;
   }
+  delete m_ItemsToClear;
+}
+//_____________________________________________________________________________
+void StHistUtil::Clear() {
+  m_ItemsToClear->Clear();
 }
 //_____________________________________________________________________________
 void StHistUtil::SetOutFile(const Char_t *fileName, const Char_t* type) {
@@ -1789,6 +1797,7 @@ TList* StHistUtil::TrimListByPrefix(TList* dList, const Char_t* withPrefix) {
                   (obj->InheritsFrom("TH1") &&
                    m_ListOfPrint->FindObject(obj->GetName())))) dList2->AddLast(obj);
   }
+  m_ItemsToClear->Add(dList2);
   return dList2;
 }
 //_____________________________________________________________________________

--- a/StRoot/StAnalysisUtilities/StHistUtil.h
+++ b/StRoot/StAnalysisUtilities/StHistUtil.h
@@ -134,6 +134,7 @@ class StHistUtil {
   const Char_t** possibleSuffixes; //!
   TString m_Detectors;   // List of detectors
   UInt_t  m_PrintMode;   // Which output files to print
+  TList*  m_ItemsToClear; // List of items to clear at some intervals
 
   // For reference analyses:
   Bool_t m_analMode;
@@ -154,6 +155,7 @@ class StHistUtil {
  public: 
   StHistUtil();
   virtual        ~StHistUtil();
+  virtual void    Clear();
   virtual void    SetDebug(Bool_t dbg=kTRUE) { debug=dbg; }
   virtual Bool_t  Debug() { return debug; }
   virtual Int_t   DrawHists(const Char_t *dirName="EventQA");

--- a/StRoot/macros/analysis/bfcread_hist_files_add.C
+++ b/StRoot/macros/analysis/bfcread_hist_files_add.C
@@ -229,9 +229,6 @@ void bfcread_hist_files_add(
        cout << "bfcread_hist_files_add.C, # histograms copied = " << 
 	 hCCount << endl;
 
-       HM[bnum]->SetHArraySize(HU[bnum]->getNewHistSize());
-       HM[bnum]->SetHArray(HU[bnum]->getNewHist());
-       HM[bnum]->Make();
      }  // first time
 
      else {
@@ -243,13 +240,13 @@ void bfcread_hist_files_add(
        cout << "bfcread_hist_files_add.C, # histograms added = " << 
 	 hCCount << endl;
 
-       HM[bnum]->SetHArraySize(HU[bnum]->getNewHistSize());
-       HM[bnum]->SetHArray(HU[bnum]->getNewHist());
-       HM[bnum]->Make();
-
      }  //else (ifl not #1)
 
-     dirList->Delete();
+
+     HM[bnum]->SetHArraySize(HU[bnum]->getNewHistSize());
+     HM[bnum]->SetHArray(HU[bnum]->getNewHist());
+     HM[bnum]->Make();
+     HU[bnum]->Clear();
 
 // to see an example of histograms being added together:   
 //   TH1** kathyArray = HU[bnum]->getNewHist();

--- a/StRoot/macros/analysis/bfcread_hist_integrated_to_ps.C
+++ b/StRoot/macros/analysis/bfcread_hist_integrated_to_ps.C
@@ -204,7 +204,7 @@ void bfcread_hist_integrated_to_ps(
          cout << "bfcread_hist_integrated_to_ps.C, # histograms added with prefix " <<
            HU->GetPrefix(prefixNum) << " = " << hCCount << endl;
        } // first set or not
-       delete dirList; // Only when using PrintList or Prefixes
+       HU->Clear();
       } // found hists
 
      } // loop over prefixes

--- a/StRoot/macros/analysis/bfcread_hist_prefixes_add.C
+++ b/StRoot/macros/analysis/bfcread_hist_prefixes_add.C
@@ -163,6 +163,7 @@ void bfcread_hist_prefixes_add(
            HU[nbranch]->GetPrefix(prefixNum) << " = " << hCCount << endl;
        } // first set or not
       } // found hists
+      HU[nbranch]->Clear();
 
      } // loop over prefixes
 

--- a/StRoot/macros/analysis/bfcread_hist_prefixes_add_to_ps.C
+++ b/StRoot/macros/analysis/bfcread_hist_prefixes_add_to_ps.C
@@ -168,6 +168,7 @@ void bfcread_hist_prefixes_add_to_ps(
            HO->GetPrefix(prefixNum) << " = " << hCCount << endl;
        } // first set or not
       } // found hists
+      HO->Clear();
 
      } // loop over prefixes
 


### PR DESCRIPTION
This modification is to remove a memory leak that existed from creating a `TList` that was never cleared in `StHistUtil`. This is not used in production, but is used by some Offline QA macros, so those macros have been appropriately updated in this PR.