### PR TITLE
Provide manual timecut control for fast offline production and calibr…

### DIFF
--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -86,6 +86,7 @@ StFttClusterMaker::Finish()
 Int_t
 StFttClusterMaker::Make()
 { 
+    LOG_INFO << "StFttClusterMaker::Make" << endm;
     mEvent = (StEvent*)GetInputDS("StEvent");
     if(mEvent) {
     } else {
@@ -210,16 +211,26 @@ void StFttClusterMaker::InjectTestData(){
 
 
 bool StFttClusterMaker::PassTimeCut( StFttRawHit * hit ){
-    int time_cut0 = -999;
-    int time_cut1 =  999;
-    int time_cutm = 0;
-    //  in principle it could vary VMM to VMM;
-    mFttDb->getTimeCut(hit, time_cutm, time_cut0, time_cut1);
-    if ( time_cutm == 0 ) // default, cut on bunch crossing
-        return (hit->time() <= time_cut1 && hit->time() >= time_cut0); 
+    
+    if ( mTimeCutMode == -1 ){
+        int time_cut0 = -999;
+        int time_cut1 =  999;
+        int time_cutm = 0;
+        //  in principle it could vary VMM to VMM;
+        mFttDb->getTimeCut(hit, time_cutm, time_cut0, time_cut1);
+        if ( time_cutm == 0 ) // default, cut on bunch crossing
+            return (hit->time() <= time_cut1 && hit->time() >= time_cut0); 
 
-    // cut on timebin
-    return (hit->tb() <= time_cut1 && hit->tb() >= time_cut0);
+        // cut on timebin
+        return (hit->tb() <= time_cut1 && hit->tb() >= time_cut0);
+    } else { // manually set, use that
+        if ( mTimeCutMode == 0 ){
+            return (hit->time() <= mTimeCutMax && hit->time() >= mTimeCutMin); 
+        }
+        else if ( mTimeCutMode == 1 ){
+            return (hit->tb() <= mTimeCutMax && hit->tb() >= mTimeCutMin); 
+        }
+    }
 }
 
 

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -86,7 +86,6 @@ StFttClusterMaker::Finish()
 Int_t
 StFttClusterMaker::Make()
 { 
-    LOG_INFO << "StFttClusterMaker::Make" << endm;
     mEvent = (StEvent*)GetInputDS("StEvent");
     if(mEvent) {
     } else {

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -14,7 +14,7 @@
 #include <map>
 #include <array>
 #include <algorithm>    // std::is_sorted
-
+#include <climits>
 
 #include "StEvent.h"
 #include "StEnumerations.h"
@@ -209,28 +209,52 @@ void StFttClusterMaker::InjectTestData(){
 } // InjectTestData
 
 
+/**
+ * @brief Checks if a hit passes the time cut.
+ *
+ * This function checks if a given hit passes the time cut based on 
+ * the current time cut mode.
+ * - mTimeCutMode = kTimeCutModeAcceptAll: accept all hits
+ * - mTimeCutMode = kTimeCutModeDB: use the time cut from the database
+ * - mTimeCutMode = kTimeCutModeCalibratedTime: use the calibrated time cut 
+ *      set by the user
+ * - mTimeCutMode = kTimeCutModeTimebin: use the timebin cut set by the user
+ * 
+ * if unrecognized time cut mode is set, the function will return true accepting all hits
+ *
+ * @param hit Pointer to the StFttRawHit object to be checked.
+ * @return true if the hit passes the time cut, false otherwise.
+ */
 bool StFttClusterMaker::PassTimeCut( StFttRawHit * hit ){
-    
-    if ( mTimeCutMode == -1 ){
-        int time_cut0 = -999;
-        int time_cut1 =  999;
-        int time_cutm = 0;
-        //  in principle it could vary VMM to VMM;
-        mFttDb->getTimeCut(hit, time_cutm, time_cut0, time_cut1);
-        if ( time_cutm == 0 ) // default, cut on bunch crossing
-            return (hit->time() <= time_cut1 && hit->time() >= time_cut0); 
+    if (mTimeCutMode == kTimeCutModeAcceptAll) 
+        return true;
+    else if (mTimeCutMode == kTimeCutModeDB ) {
+        int timeCutMin = INT_MIN;
+        int timeCutMax = INT_MAX;
+        int hitTimeMode = (int)kHitCalibratedTime;
 
-        // cut on timebin
-        return (hit->tb() <= time_cut1 && hit->tb() >= time_cut0);
-    } else { // manually set, use that
-        if ( mTimeCutMode == 0 ){
-            return (hit->time() <= mTimeCutMax && hit->time() >= mTimeCutMin); 
+        mFttDb->getTimeCut(hit, hitTimeMode, timeCutMin, timeCutMax);
+        LOG_DEBUG << TString::Format( "StFttClusterMaker::PassTimeCut - DB gave hit time mode: %d, time cut min: %d, time cut max: %d", hitTimeMode, timeCutMin, timeCutMax ) << endm;
+        if (hitTimeMode == kHitCalibratedTime) {
+            return (hit->time() >= timeCutMin && hit->time() <= timeCutMax);
+        } else if ( hitTimeMode == kHitTimebin ) {
+            return (hit->tb() >= timeCutMin && hit->tb() <= timeCutMax);
+        } else {
+            LOG_WARN << "StFttClusterMaker::PassTimeCut - Unknown hit time mode from database: " << hitTimeMode << endm;
+            LOG_WARN << "Accepting all hits" << endm;
+            return true;
         }
-        else if ( mTimeCutMode == 1 ){
-            return (hit->tb() <= mTimeCutMax && hit->tb() >= mTimeCutMin); 
-        }
+    } else if (mTimeCutMode == kTimeCutModeCalibratedTime) {
+        return (hit->time() >= mTimeCutMin && hit->time() <= mTimeCutMax);
+    } else if (mTimeCutMode == kTimeCutModeTimebin) {
+        return (hit->tb() >= mTimeCutMin && hit->tb() <= mTimeCutMax);
+    } else {
+        LOG_WARN << "StFttClusterMaker::PassTimeCut - Unknown time cut mode: " << mTimeCutMode << endm;
+        LOG_WARN << "Accepting all hits" << endm;
+        return true; // Default return value if no conditions are met
     }
-}
+    return true;
+} // PassTimeCut
 
 
 StFttRawHit * StFttClusterMaker::FindMaxAdc( std::vector<StFttRawHit *> hits, size_t &pos ){

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.h
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.h
@@ -51,8 +51,6 @@ private:
     float GetThresholdFor( StFttRawHit * hit ) { return 0.0;}
     bool PassTimeCut( StFttRawHit * hit );
 
-
-
     StEvent*             mEvent;
     StFttCollection*     mFttCollection;
     int                  mRunYear;

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.h
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.h
@@ -59,12 +59,22 @@ private:
     bool                 mDebug;
     StFttDb*             mFttDb;
 
-    int mTimeCutMin  = -999;
-    int mTimeCutMax  =  999;
-    int mTimeCutMode = -1; //default - lookup from DB
+    enum HitTimeModes {
+        kHitCalibratedTime = 0,
+        kHitTimebin = 1
+    }
+    enum TimeCutModes {
+        kTimeCutModeDB = 0,
+        kTimeCutModeAcceptAll = 1,
+        kTimeCutModeCalibratedTime = 2,
+        kTimeCutModeTimebin = 3
+    };
+    int mTimeCutMin  = -40; // value from Run22 - Run24 online QA approximately 1 bx
+    int mTimeCutMax  =  100; // value from Run22 - Run24 online QA approximately 1 bx
+    int mTimeCutMode = kTime; //default - lookup from DB
 
 
-    ClassDef( StFttClusterMaker, 1 )
+    ClassDef( StFttClusterMaker, 0 )
 };
 
 #endif // STFTTCLUSTERMAKER_H

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.h
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.h
@@ -62,7 +62,7 @@ private:
     enum HitTimeModes {
         kHitCalibratedTime = 0,
         kHitTimebin = 1
-    }
+    };
     enum TimeCutModes {
         kTimeCutModeDB = 0,
         kTimeCutModeAcceptAll = 1,
@@ -71,7 +71,7 @@ private:
     };
     int mTimeCutMin  = -40; // value from Run22 - Run24 online QA approximately 1 bx
     int mTimeCutMax  =  100; // value from Run22 - Run24 online QA approximately 1 bx
-    int mTimeCutMode = kTime; //default - lookup from DB
+    int mTimeCutMode = 0; //default - kTimeCutModeDB, CINT cant use the enum directly
 
 
     ClassDef( StFttClusterMaker, 0 )

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.h
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.h
@@ -30,6 +30,12 @@ public:
     int  Finish();
     int  Make();
 
+    void SetTimeCut( int mode, int min, int max ) {
+        mTimeCutMode = mode;
+        mTimeCutMin = min;
+        mTimeCutMax = max;
+    }
+
 private:
     void ApplyHardwareMap();
     std::vector<StFttCluster*> FindClusters( std::vector<StFttRawHit * > );
@@ -45,11 +51,17 @@ private:
     float GetThresholdFor( StFttRawHit * hit ) { return 0.0;}
     bool PassTimeCut( StFttRawHit * hit );
 
+
+
     StEvent*             mEvent;
     StFttCollection*     mFttCollection;
     int                  mRunYear;
     bool                 mDebug;
     StFttDb*             mFttDb;
+
+    int mTimeCutMin  = -999;
+    int mTimeCutMax  =  999;
+    int mTimeCutMode = -1; //default - lookup from DB
 
 
     ClassDef( StFttClusterMaker, 1 )


### PR DESCRIPTION
…ation

This allows the StFttClusterMaker to be set to manually override DB timeline cuts for processing fast offline and for running calibrations