### PR TITLE
patched FTT table for Daniel

### DIFF
--- a/StDb/idl/fttDataWindowsB.idl
+++ b/StDb/idl/fttDataWindowsB.idl
@@ -1,0 +1,15 @@
+/* fttDataWindowsB.idl
+*
+* Table: fttDataWindowsB
+*
+* description: sTGC (ftt) data time windows
+*
+*/
+
+struct fttDataWindowsB {
+	short uuid[385]; /* fob(1-96) x vmm(1-4) = index 1 - 384 */
+	octet mode[385]; /* 0 = timebin, 1 = bcid */
+	short min[385]; /* time window min > -32768 */
+	short max[385]; /* time window max < 32768 */
+	short anchor[385]; /* calibrated time anchor for BCID */
+};


### PR DESCRIPTION
The patched version of the FTT table as requested by Daniel. Note that the table name is "fttDataWindowsB" now, please update FTT codes to use it instead of "fttDataWindows" one.