### PR TITLE
QAallevents: fill QA hists regardless of prim vtx

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1936,6 +1936,7 @@ Bfc_st BFC[] = { // standard chains
     ,"St_QA_Maker","Filling Y2/Y3 Qa histo",kFALSE},
   {"QAC"         ,"CosmicsQA","globT",""                    ,"StQACosmicMaker","StQACosmicMaker","",kFALSE},
   {"QAalltrigs"  ,"", "","",                                     "","","Analyze all triggers in QA",kFALSE},
+  {"QAallevents" ,"", "","",                                       "","","Analyze all events in QA",kFALSE},
   {"HitFilt"     ,"", "","",               "StHitFilterMaker","StHitFilterMaker","Hit filter Maker",kFALSE},
   {"SvtHitFilt"  ,"", "","HitFilt",                                    "","","SVT Hit filter Maker",kFALSE},
   {"TpcHitFilt"  ,"", "","HitFilt",                       "","","filter out TPC Hits not on tracks",kFALSE},

--- a/StRoot/StBFChain/StBFChain.cxx
+++ b/StRoot/StBFChain/StBFChain.cxx
@@ -730,8 +730,10 @@ Int_t StBFChain::Instantiate()
       if ( GetOption("EastOff"))      mk->SetAttr("EastOff",kTRUE);
       if ( GetOption("WestOff"))      mk->SetAttr("WestOff",kTRUE);
     }
-    if (maker == "StEventQAMaker" && GetOption("QAalltrigs"))
-      ProcessLine(Form("((StEventQAMaker *) %p)->AllTriggers();",mk));
+    if (maker == "StEventQAMaker") {
+      if ( GetOption("QAalltrigs"))   mk->SetAttr("allTrigs",kTRUE);
+      if ( GetOption("QAallevents"))  mk->SetAttr("allEvents",kTRUE);
+    }
     //Special options for V0s and Xis using estGlobal tracks
     if(maker=="StV0FinderMaker" && Key=="v0svt"){
       TString cmd(Form("StV0FinderMaker *V0mk=(StV0FinderMaker*) %p;",mk));

--- a/StRoot/St_QA_Maker/StQAMakerBase.cxx
+++ b/StRoot/St_QA_Maker/StQAMakerBase.cxx
@@ -202,6 +202,7 @@ StQAMakerBase::StQAMakerBase(const char *name, const char *title, const char* ty
   ITTF = kFALSE;
   EST = -1; // -1 = unknown
   allTrigs = kFALSE;
+  allEvents = kFALSE;
 
 //  - Set all the histogram booking constants
 
@@ -309,6 +310,8 @@ StQAMakerBase::~StQAMakerBase() {
 Int_t StQAMakerBase::Init() {
 // Histogram booking must wait until first event Make() to determine event type
   eventCount = 0;
+  if (IAttr("allTrigs")) allTrigs = kTRUE;
+  if (IAttr("allEvents")) allEvents = kTRUE;
   return StMaker::Init();
 }
 //_____________________________________________________________________________
@@ -337,7 +340,7 @@ Int_t StQAMakerBase::Make() {
 
     
 
-  if (!fillHists) return kStOk;
+  if (!(fillHists || allEvents)) return kStOk;
   // Call methods to fill histograms
 
   // Those divided by event class:

--- a/StRoot/St_QA_Maker/StQAMakerBase.h
+++ b/StRoot/St_QA_Maker/StQAMakerBase.h
@@ -271,6 +271,7 @@ class StQAMakerBase : public StMaker {
   Bool_t ITTF;
   Int_t EST;
   Bool_t allTrigs;
+  Bool_t allEvents;
 
   virtual void NewQABookHist();
   virtual TH2F* MH1F(const Text_t* name, const Text_t* title,


### PR DESCRIPTION
There is some interest in examining QA histograms for occasions when there is no primary vertex, including occasions when tracking is excluded from production (e.g. for calorimeter interests). This introduces a chain option `QAallevents` to enable bypassing the cut on primary vertex, and it is independent of the `QAalltrigs` option which is a bypass of the exclusion based on physics triggers.