### PR TITLE
Add idTruth and qaTruth to StEvent and MuDst FttPoint, FttCluster, and FttRawHit

### DIFF
--- a/StRoot/StEvent/StFttCluster.cxx
+++ b/StRoot/StEvent/StFttCluster.cxx
@@ -19,7 +19,10 @@ mSumAdc(0.0),
 mX(0.0),
 mSigma(0.0),
 mRawHits(0),
-mNeighbors(0)
+mNeighbors(0),
+mPoints(0),
+mIdTruth(0),
+mQaTruth(0)
 {
 
 }
@@ -58,6 +61,8 @@ operator<<( std::ostream &os, const StFttCluster& rh )
     os << "\tsumAdc      = " << rh.sumAdc()           << endl;
     os << "\tx           = " << rh.x()                << endl;
     os << "\tsigma       = " << rh.sigma()            << endl;
+    os << "\tidTruth     = " << rh.idTruth()          << endl;
+    os << "\tqaTruth     = " << rh.qaTruth()          << endl;
     os << ")"                << endl;
     return os;
 }

--- a/StRoot/StEvent/StFttCluster.h
+++ b/StRoot/StEvent/StFttCluster.h
@@ -28,6 +28,7 @@ public:
     float x() const;  // Mean x ("center of gravity") in local grid coordinate (1st moment).
     float sigma() const; // Maximum 2nd moment (along major axis).
     UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
+    UShort_t qaTruth() const { return mQaTruth; } // Get the truth quality
 
     void setId(int cluid);
     void setPlane(UChar_t plane);
@@ -39,6 +40,7 @@ public:
     void setX(float x0);
     void setSigma(float sigma);
     void setIdTruth(UShort_t id) { mIdTruth = id; }
+    void setQaTruth(UShort_t qa) { mQaTruth = qa; }
 
     StPtrVecFttRawHit& rawHits();
     const StPtrVecFttRawHit& rawHits() const;
@@ -65,8 +67,9 @@ private:
     StPtrVecFttCluster mNeighbors;    // Neighbor clusters
     StPtrVecFttPoint mPoints;        // Fitted points (photons) in the cluster
     UShort_t mIdTruth=0; // Truth ID
+    UShort_t mQaTruth=0; // Truth Quality
 
-    ClassDef(StFttCluster, 3)
+    ClassDef(StFttCluster, 4)
 };
 
 std::ostream& operator << ( std::ostream&, const StFttCluster& clu ); // Printing operator

--- a/StRoot/StEvent/StFttPoint.cxx
+++ b/StRoot/StEvent/StFttPoint.cxx
@@ -20,8 +20,8 @@ void StFttPoint::print(int opt) {
 }
 
 
-int StFttPoint::nClusters() const {
-    int n = 0;
+size_t StFttPoint::nClusters() const {
+    size_t n = 0;
     for ( size_t i = 0; i < 4; i++ ){
         if ( mClusters[i] != nullptr )
         n++;

--- a/StRoot/StEvent/StFttPoint.h
+++ b/StRoot/StEvent/StFttPoint.h
@@ -28,10 +28,11 @@ public:
     UChar_t quadrant()   const; // detector quadrant.
     float x() const;  // x position in cell unit at which point intersects the sub-detector in local coordinate
     float y() const;  // y position in cell unit at which point intersects the sub-detector in local coordinate
-    int nClusters() const; // Number of points in the parent cluster.
+    size_t nClusters() const; // Number of points in the parent cluster.
     StFttCluster* cluster( size_t i); //  Parent cluster of the photon.
     const StThreeVectorD& xyz() const; // XYZ position in global STAR coordinate
     UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
+    UShort_t qaTruth() const { return mQaTruth; } // Get the truth quality
 
     void setPlane(UChar_t plane);
     void setQuadrant(UChar_t quad);
@@ -40,6 +41,7 @@ public:
     void addCluster(StFttCluster* cluster, UChar_t dir);
     void setXYZ(const StThreeVectorD& p3);
     void setIdTruth(UShort_t id) { mIdTruth = id; }
+    void setQaTruth(UShort_t qa) { mQaTruth = qa; }
     
     void print(int option=0);
 
@@ -51,8 +53,9 @@ private:
     StFttCluster *mClusters[4];
     StThreeVectorD  mXYZ;    // Photon position in STAR coordinate
     UShort_t mIdTruth=0; // Truth ID
+    UShort_t mQaTruth=0; // Truth quality
 
-    ClassDef(StFttPoint, 2)
+    ClassDef(StFttPoint, 3)
 };
 
 inline UChar_t StFttPoint::plane() const { return mPlane; }

--- a/StRoot/StEvent/StFttRawHit.cxx
+++ b/StRoot/StEvent/StFttRawHit.cxx
@@ -27,7 +27,9 @@ mPlane(255),
 mQuadrant(kFttUnknownQuadrant),
 mRow(255),
 mStrip(255),
-mOrientation(kFttUnknownOrientation)
+mOrientation(kFttUnknownOrientation),
+mIdTruth(0),
+mQaTruth(0)
 { /*noop*/ }
 
 StFttRawHit::StFttRawHit(   UChar_t mSector, UChar_t mRDO, UChar_t mFEB, 
@@ -79,7 +81,10 @@ operator<<( ostream &os, const StFttRawHit& rh )
     os << "\tmQuadrant = "    << (int)rh.quadrant()    << endl;
     os << "\tmRow = "         << (int)rh.row()         << endl;
     os << "\tmStrip = "       << (int)rh.strip()       << endl;
-    os << "\tmOrientation = " << (int)rh.orientation() << " ) " << endl;
+    os << "\tmOrientation = " << (int)rh.orientation() << endl;
+    os << "\tidTruth = "      << (int)rh.idTruth()     << endl;
+    os << "\tqaTruth = "      << (int)rh.qaTruth()     << endl;
+    os << " ) " << endl;
 
 
     return os;

--- a/StRoot/StEvent/StFttRawHit.h
+++ b/StRoot/StEvent/StFttRawHit.h
@@ -36,8 +36,10 @@ public:
     void setMapping( UChar_t mPlane, UChar_t mQuadrant, UChar_t mRow, UChar_t mStrip, UChar_t mOrientation );
 
     void setTime( Short_t mTime ) { this->mTime = mTime; }
-    // consant getters
+    void setIdTruth( UShort_t id ) { mIdTruth = id; }
+    void setQaTruth( UShort_t qa ) { mQaTruth = qa; }
 
+    // consant getters
     UChar_t sector() const;
     UChar_t rdo() const;
     UChar_t feb() const;
@@ -54,6 +56,8 @@ public:
     UChar_t row() const;
     UChar_t strip() const;
     UChar_t orientation() const;
+    UShort_t idTruth() const { return mIdTruth; }
+    UShort_t qaTruth() const { return mQaTruth; }
 
 protected:
     UChar_t mSector;
@@ -74,10 +78,10 @@ protected:
     UChar_t mStrip;
     UChar_t mOrientation;
 
-    // StFttCluster *mCluster;
-    // StFttPoint   *mPoint;
+    UShort_t mIdTruth=0; // Truth ID
+    UShort_t mQaTruth=0; // Truth Quality
 
-    ClassDef( StFttRawHit, 3 );
+    ClassDef( StFttRawHit, 4 );
 };
 
 ostream& operator << ( ostream&, const StFttRawHit& digi ); // Printing operator

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.cxx
@@ -22,7 +22,10 @@ mSumAdc(0.0),
 mX(0.0),
 mSigma(0.0),
 mRawHits(0),
-mNeighbors(0)
+mNeighbors(0),
+mPoints(0),
+mIdTruth(0),
+mQaTruth(0)
 {
 
 }
@@ -54,4 +57,5 @@ void StMuFttCluster::set( StFttCluster * clu ){
     mX           = clu->x();
     mSigma       = clu->sigma();
     mIdTruth     = clu->idTruth();
+    mQaTruth     = clu->qaTruth();
 }

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.cxx
@@ -53,4 +53,5 @@ void StMuFttCluster::set( StFttCluster * clu ){
     mSumAdc      = clu->sumAdc();
     mX           = clu->x();
     mSigma       = clu->sigma();
+    mIdTruth     = clu->idTruth();
 }

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.h
@@ -25,6 +25,7 @@ public:
     float sumAdc() const;
     float x() const;  // Mean x ("center of gravity") in local grid coordinate (1st moment).
     float sigma() const; // Maximum 2nd moment (along major axis).
+    UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
 
     void setId(int cluid);
     void setPlane(UChar_t plane);
@@ -34,6 +35,7 @@ public:
     void setSumAdc(int theSumAdc);
     void setX(float x0);
     void setSigma(float sigma);
+    void setIdTruth(UShort_t id) { mIdTruth = id; }
 
     TRefArray* rawHits();
     const TRefArray* rawHits() const;
@@ -60,8 +62,9 @@ private:
     TRefArray mRawHits;            // Tower hits of the current cluster
     TRefArray mNeighbors;    // Neighbor clusters
     TRefArray mPoints;        // Fitted points (photons) in the cluster
+    UShort_t mIdTruth=0; // Truth ID
 
-    ClassDef(StMuFttCluster, 1)
+    ClassDef(StMuFttCluster, 2)
 };
 
 

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttCluster.h
@@ -26,6 +26,7 @@ public:
     float x() const;  // Mean x ("center of gravity") in local grid coordinate (1st moment).
     float sigma() const; // Maximum 2nd moment (along major axis).
     UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
+    UShort_t qaTruth() const { return 0; } // Get the truth quality
 
     void setId(int cluid);
     void setPlane(UChar_t plane);
@@ -36,6 +37,7 @@ public:
     void setX(float x0);
     void setSigma(float sigma);
     void setIdTruth(UShort_t id) { mIdTruth = id; }
+    void setQaTruth(UShort_t qa) { mQaTruth = qa; }
 
     TRefArray* rawHits();
     const TRefArray* rawHits() const;
@@ -63,8 +65,9 @@ private:
     TRefArray mNeighbors;    // Neighbor clusters
     TRefArray mPoints;        // Fitted points (photons) in the cluster
     UShort_t mIdTruth=0; // Truth ID
+    UShort_t mQaTruth=0; // Truth quality
 
-    ClassDef(StMuFttCluster, 2)
+    ClassDef(StMuFttCluster, 3)
 };
 
 

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.cxx
@@ -28,4 +28,5 @@ void StMuFttPoint::set( StFttPoint *point ){
     mY = point->y();
     mXYZ = TVector3( point->xyz().x(), point->xyz().y(), point->xyz().z() );
     mIdTruth = point->idTruth();
+    mQaTruth = point->qaTruth();
 } // set from StEvent

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.cxx
@@ -27,4 +27,5 @@ void StMuFttPoint::set( StFttPoint *point ){
     mX = point->x();
     mY = point->y();
     mXYZ = TVector3( point->xyz().x(), point->xyz().y(), point->xyz().z() );
+    mIdTruth = point->idTruth();
 } // set from StEvent

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.h
@@ -33,6 +33,7 @@ public:
     // StMuFttCluster* cluster( size_t i); //  Parent cluster of the photon.
     const TVector3& xyz()   const; // XYZ position in global STAR coordinate
     UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
+    UShort_t qaTruth() const { return mQaTruth; } // Get the truth quality
 
     void setPlane(UChar_t plane);
     void setQuadrant(UChar_t quad);
@@ -41,6 +42,7 @@ public:
     // void addCluster(StMuFttCluster* cluster);
     void setXYZ(const TVector3& p3);
     void setIdTruth(UShort_t id) { mIdTruth = id; }
+    void setQaTruth(UShort_t qa) { mQaTruth = qa; }
 
     
     void print(int option=0);
@@ -55,8 +57,9 @@ private:
     TRefArray mClusters=0; // parent clusters (could be up to 3?)
     TVector3  mXYZ;    // Photon position in STAR coordinate
     UShort_t mIdTruth=0; // Truth ID    
+    UShort_t mQaTruth=0; // Truth quality
 
-    ClassDef(StMuFttPoint, 2)
+    ClassDef(StMuFttPoint, 3)
 };
 
 inline UChar_t StMuFttPoint::plane() const { return mPlane; }

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttPoint.h
@@ -32,6 +32,7 @@ public:
     int nParentClusters()   const; // Number of points in the parent cluster.
     // StMuFttCluster* cluster( size_t i); //  Parent cluster of the photon.
     const TVector3& xyz()   const; // XYZ position in global STAR coordinate
+    UShort_t idTruth() const { return mIdTruth; } // Get the truth ID
 
     void setPlane(UChar_t plane);
     void setQuadrant(UChar_t quad);
@@ -39,6 +40,7 @@ public:
     void setY(float y);
     // void addCluster(StMuFttCluster* cluster);
     void setXYZ(const TVector3& p3);
+    void setIdTruth(UShort_t id) { mIdTruth = id; }
 
     
     void print(int option=0);
@@ -52,8 +54,9 @@ private:
     Float_t mY=0.0;         // y-position in local coordinate
     TRefArray mClusters=0; // parent clusters (could be up to 3?)
     TVector3  mXYZ;    // Photon position in STAR coordinate
+    UShort_t mIdTruth=0; // Truth ID    
 
-    ClassDef(StMuFttPoint, 1)
+    ClassDef(StMuFttPoint, 2)
 };
 
 inline UChar_t StMuFttPoint::plane() const { return mPlane; }

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttRawHit.cxx
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttRawHit.cxx
@@ -27,7 +27,9 @@ mPlane(255),
 mQuadrant(kFttUnknownQuadrant),
 mRow(255),
 mStrip(255),
-mOrientation(kFttUnknownOrientation)
+mOrientation(kFttUnknownOrientation),
+mIdTruth(0),
+mQaTruth(0)
 { /*noop*/ }
 
 StMuFttRawHit::StMuFttRawHit( StFttRawHit * stHit ){
@@ -66,6 +68,8 @@ void StMuFttRawHit::setMapping(   UChar_t mPlane, UChar_t mQuadrant,
 void StMuFttRawHit::set( StFttRawHit * stHit ){
     setRaw( stHit->sector(), stHit->rdo(), stHit->feb(), stHit->vmm(), stHit->channel(), stHit->adc(), stHit->bcid(), stHit->tb(), stHit->dbcid());
     setMapping( stHit->plane(), stHit->quadrant(), stHit->row(), stHit->strip(), stHit->orientation() );
+    setIdTruth( stHit->idTruth() );
+    setQaTruth( stHit->qaTruth() );
 } // set from StEvent object
 
 
@@ -88,6 +92,9 @@ operator<<( ostream &os, const StMuFttRawHit& rh )
     os << "\tmQuadrant = "    << (int)rh.quadrant()    << endl;
     os << "\tmRow = "         << (int)rh.row()         << endl;
     os << "\tmStrip = "       << (int)rh.strip()       << endl;
-    os << "\tmOrientation = " << (int)rh.orientation() << " ) " << endl;
+    os << "\tmOrientation = " << (int)rh.orientation() << endl;
+    os << "\tidTruth = "      << (int)rh.idTruth()     << endl;
+    os << "\tqaTruth = "      << (int)rh.qaTruth()     << endl;
+    os << " ) " << endl;
     return os;
 } // operator<< ostream

--- a/StRoot/StMuDSTMaker/COMMON/StMuFttRawHit.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuFttRawHit.h
@@ -37,9 +37,10 @@ public:
 
     void setMapping( UChar_t mPlane, UChar_t mQuadrant, UChar_t mRow, UChar_t mStrip, UChar_t mOrientation );
     void set( StFttRawHit * stHit );
+    void setIdTruth( UShort_t id ) { mIdTruth = id; }
+    void setQaTruth( UShort_t qa ) { mQaTruth = qa; }
 
     // consant getters
-
     UChar_t sector() const;
     UChar_t rdo() const;
     UChar_t feb() const;
@@ -55,6 +56,8 @@ public:
     UChar_t row() const;
     UChar_t strip() const;
     UChar_t orientation() const;
+    UShort_t idTruth() const { return mIdTruth; }
+    UShort_t qaTruth() const { return mQaTruth; }
 
 protected:
     UChar_t mSector;
@@ -74,10 +77,10 @@ protected:
     UChar_t mStrip;
     UChar_t mOrientation;
 
-    // StFttCluster *mCluster;
-    // StFttPoint   *mPoint;
+    UShort_t mIdTruth;
+    UShort_t mQaTruth;
 
-    ClassDef( StMuFttRawHit, 2 );
+    ClassDef( StMuFttRawHit, 3 );
 };
 
 std::ostream& operator << ( std::ostream&, const StMuFttRawHit& hit ); // Printing operator


### PR DESCRIPTION
Adds idTruth member to StMuFttPoint (used by StFttFastSimMaker) and StMuFttCluster (to be used by "slow" simulator)
mirrors updates to StEvent in #698 