### PR TITLE
Update StFstFastSimMaker to write hits into the StFstHitCollection

### DIFF
--- a/StRoot/StEvent/StFstHit.h
+++ b/StRoot/StEvent/StFstHit.h
@@ -42,6 +42,7 @@ public:
    unsigned char getNRawHitsPhi() const;
    float         localPosition(unsigned int ) const;
 
+   void setDiskWedgeSensor(unsigned char disk, unsigned char wedge, unsigned char sensor);
    void setDisk(unsigned char disk);
    void setWedge(unsigned char wedge);
    void setSensor(unsigned char sensor);
@@ -90,6 +91,8 @@ inline unsigned char StFstHit::getNRawHits() const        { return mNRawHits;   
 inline unsigned char StFstHit::getNRawHitsR() const       { return mNRawHitsR;          };
 inline unsigned char StFstHit::getNRawHitsPhi() const     { return mNRawHitsPhi;        };
 
+inline void StFstHit::setDiskWedgeSensor(unsigned char disk, unsigned char wedge, unsigned char sensor) { setHardwarePosition( 
+  (1+disk)*kFstNumWedgePerDisk * kFstNumSensorsPerWedge*0 + (1 + (wedge - 1)*kFstNumSensorsPerWedge + sensor) ); }
 inline void StFstHit::setApv(unsigned char apv)                   { mApv = apv;                   };
 inline void StFstHit::setMaxTimeBin(unsigned char tb)             { mMaxTimeBin = tb;             };
 inline void StFstHit::setMeanPhiStrip(float meanPhiStrip)         { mMeanPhiStrip = meanPhiStrip; };

--- a/StRoot/StFstSimMaker/StFstFastSimMaker.h
+++ b/StRoot/StFstSimMaker/StFstFastSimMaker.h
@@ -21,10 +21,6 @@ class StFstFastSimMaker : public StMaker {
 		int Make();
 		int Init();
 		int Finish();
-		virtual const char *GetCVS() const;
-		
-		/// Set offset for each disk ( x=R*cos(idisk*60 degrees), y=R*sin(...) )
-		void SetRaster(float R = 1.0) { mRaster = R; }
 
 		/// Set min/max active radii for each disk
 		void SetDisk(const int i, const float rmn, const float rmx);
@@ -40,7 +36,6 @@ class StFstFastSimMaker : public StMaker {
 		int mNumR;
 		int mNumPHI;
 		int mNumSEC;
-		float mRaster;
 		float mInEff;
 		bool mHist;
 		bool mGEANTPassthrough;
@@ -67,10 +62,5 @@ class StFstFastSimMaker : public StMaker {
 
 		ClassDef(StFstFastSimMaker, 0)
 };
-
-inline const char *StFstFastSimMaker::GetCVS() const {
-	static const char cvs[] = "Tag $Name:  $ $Id: StFstFastSimMaker.h,v 1.1 2021/03/26 13:58:21 jdb Exp $ built " __DATE__ " " __TIME__;
-	return cvs;
-}
 
 #endif

--- a/StRoot/StFstSimMaker/StFstFastSimMaker.h
+++ b/StRoot/StFstSimMaker/StFstFastSimMaker.h
@@ -31,7 +31,7 @@ class StFstFastSimMaker : public StMaker {
 		void SetInEfficiency(float ineff = 0.1) { mInEff = ineff; }
 		void SetQAFileName(TString filename = 0.1) { mQAFileName = filename; }
 		void SetFillHist(const bool hist = false) { mHist = hist; }
-		
+		void setGEANTPassthrough(bool passthrough = false) { mGEANTPassthrough = passthrough; }
 
 	private:
 		void FillSilicon(StEvent *event);
@@ -43,6 +43,7 @@ class StFstFastSimMaker : public StMaker {
 		float mRaster;
 		float mInEff;
 		bool mHist;
+		bool mGEANTPassthrough;
 		TString mQAFileName;
 
 		TH3F *hTrutHitYXDisk;


### PR DESCRIPTION
as is done for the real data reco chain. I continue to write hits into the StRnDCollection, but this is no longer used by downstream code. 

Also add a function to StFstHit to allow setting the disk, wedge, and sensor for sim hits. Does not change the StFstHit data structure. 