### PR TITLE
Prevent ROOT6/CLING from loading all TROOT exposed classes twice... 

### DIFF
--- a/StRoot/StBFChain/BFC.C
+++ b/StRoot/StBFChain/BFC.C
@@ -1,4 +1,4 @@
-#if !defined(__CINT__)
+#if !defined(__CINT__) && !defined(__CLING__)
 #include "TROOT.h"
 #endif
 #include "Bfc.h"


### PR DESCRIPTION
… (which couldn't possibly cause any side effects, but lets be safe about it shall we?)