### PR TITLE
Add EPDX to RICH scalers

### DIFF
--- a/StRoot/StDAQMaker/StSCReader.cxx
+++ b/StRoot/StDAQMaker/StSCReader.cxx
@@ -36,8 +36,9 @@ void StSCReader::FillTime(  unsigned int utime)
   //but new DAQ reader only gets used for 2009+ anyhow
   time_t UTime = utime; //er->getEventInfo().UnixTime;
   struct tm *time=gmtime(&UTime);
-  flipBBCBkg = (time->tm_year > 95 && time->tm_year < 109 ? 1 : 0) ;
-  useNoKillers = (time->tm_year > 110 ? 1 : 0);;
+  flipBBCBkg = (time->tm_year > 95 && time->tm_year < 109 ? 1 : 0);
+  useNoKillers = (time->tm_year > 110 ? 1 : 0);
+  useEPD = (time->tm_year > 118 || (time->tm_year = 118 && time->tm_mon > 2) ? 1 : 0);
 }
 
 double StSCReader::getCTBWest() {
@@ -78,6 +79,10 @@ double StSCReader::getZDCEastNoKiller() {
 
 double StSCReader::getZDCXNoKiller() {
   return sc.rich_scalers[14];
+}
+
+double StSCReader::getEPDX() {
+  return sc.rich_scalers[13];
 }
 
 double StSCReader::getMult() {
@@ -170,7 +175,11 @@ TDataSet* StSCReader::getSCTable(unsigned long runno) {
     tb->ctbEast      = getCTBEast();
     tb->ctbTOFp      = getCTBOrTOFp();
   }
-  tb->tofp         = getTOFp();
+  if (useEPD) { // use otherwise empty space
+    tb->tofp         = getEPDX();
+  } else {
+    tb->tofp         = getTOFp();
+  }
   tb->zdcWest      = getZDCWest();
   tb->zdcEast      = getZDCEast();
   tb->zdcX         = getZDCX();

--- a/StRoot/StDAQMaker/StSCReader.cxx
+++ b/StRoot/StDAQMaker/StSCReader.cxx
@@ -38,7 +38,7 @@ void StSCReader::FillTime(  unsigned int utime)
   struct tm *time=gmtime(&UTime);
   flipBBCBkg = (time->tm_year > 95 && time->tm_year < 109 ? 1 : 0);
   useNoKillers = (time->tm_year > 110);
-  useEPD = (time->tm_year > 118 || (time->tm_year = 118 && time->tm_mon > 2));
+  useEPD = (time->tm_year > 118 || (time->tm_year == 118 && time->tm_mon > 2));
 }
 
 double StSCReader::getCTBWest() {

--- a/StRoot/StDAQMaker/StSCReader.cxx
+++ b/StRoot/StDAQMaker/StSCReader.cxx
@@ -37,8 +37,8 @@ void StSCReader::FillTime(  unsigned int utime)
   time_t UTime = utime; //er->getEventInfo().UnixTime;
   struct tm *time=gmtime(&UTime);
   flipBBCBkg = (time->tm_year > 95 && time->tm_year < 109 ? 1 : 0);
-  useNoKillers = (time->tm_year > 110 ? 1 : 0);
-  useEPD = (time->tm_year > 118 || (time->tm_year = 118 && time->tm_mon > 2) ? 1 : 0);
+  useNoKillers = (time->tm_year > 110);
+  useEPD = (time->tm_year > 118 || (time->tm_year = 118 && time->tm_mon > 2));
 }
 
 double StSCReader::getCTBWest() {

--- a/StRoot/StDAQMaker/StSCReader.h
+++ b/StRoot/StDAQMaker/StSCReader.h
@@ -36,6 +36,7 @@ class StSCReader
     double getZDCWestNoKiller();
     double getZDCEastNoKiller();
     double getZDCXNoKiller();
+    double getEPDX();
     double getMult();
     double getL0();
     double getBBCX();
@@ -57,6 +58,7 @@ class StSCReader
     sc_t *fSC;
     short flipBBCBkg;
     short useNoKillers;
+    short useEPD;
 };
 
 #endif

--- a/StRoot/StDAQMaker/StSCReader.h
+++ b/StRoot/StDAQMaker/StSCReader.h
@@ -57,8 +57,8 @@ class StSCReader
 
     sc_t *fSC;
     short flipBBCBkg;
-    short useNoKillers;
-    short useEPD;
+    bool useNoKillers;
+    bool useEPD;
 };
 
 #endif

--- a/StRoot/StDaqLib/SC/SC_Reader.cxx
+++ b/StRoot/StDaqLib/SC/SC_Reader.cxx
@@ -57,6 +57,10 @@ int SC_Reader::ZDCXNoKiller() {
   return sc.rich_scalers[14];
 } 
 
+int SC_Reader::EPDX() {
+  return sc.rich_scalers[13];
+} 
+
 int SC_Reader::PVPDEast() {
   return sc.rich_scalers[8];
 } 

--- a/StRoot/StDaqLib/SC/SC_Reader.hh
+++ b/StRoot/StDaqLib/SC/SC_Reader.hh
@@ -16,6 +16,7 @@ public:
   int ZDCWestNoKiller();
   int ZDCEastNoKiller();
   int ZDCXNoKiller();
+  int EPDX();
   int Mult();
   int L0();
   int BBCX();

--- a/StRoot/StDetectorDbMaker/St_spaceChargeCorC.cxx
+++ b/StRoot/StDetectorDbMaker/St_spaceChargeCorC.cxx
@@ -35,6 +35,7 @@ Double_t St_spaceChargeCorC::getSpaceChargeCoulombs(Double_t scaleFactor)
         case (13) : mult = scalers->getCTBOrTOFp(); break; // zdcx-no-killer as of 2011
         case (14) : mult = scalers->getCTBEast(); break; // zdce-no-killer as of 2011
         case (15) : mult = scalers->getCTBWest(); break; // zdcw-no-killer as of 2011
+        case (16) : mult = scalers->getEPDX(); break; // EPD after March 2018
 
         default  : mult = 0.;
       }

--- a/StRoot/StDetectorDbMaker/St_trigDetSumsC.h
+++ b/StRoot/StDetectorDbMaker/St_trigDetSumsC.h
@@ -21,6 +21,7 @@ class St_trigDetSumsC : public TChair {
   Double_t 	ctbEast(Int_t i = 0) 	        {return validity(Struct(i)->ctbEast);}
   Double_t 	ctbTOFp(Int_t i = 0) 	        {return validity(Struct(i)->ctbTOFp);}
   Double_t 	tofp(Int_t i = 0) 	        {return validity(Struct(i)->tofp);}
+  Double_t 	epdx(Int_t i = 0) 	        {return validity(Struct(i)->tofp);} // re-use for EPD
   Double_t 	zdcWest(Int_t i = 0) 	        {return validity(Struct(i)->zdcWest);}
   Double_t 	zdcEast(Int_t i = 0) 	        {return validity(Struct(i)->zdcEast);}
   Double_t 	zdcX(Int_t i = 0) 	        {return validity(Struct(i)->zdcX);}
@@ -42,6 +43,7 @@ class St_trigDetSumsC : public TChair {
   Double_t getCTBEast() {return ctbEast();}
   Double_t getCTBOrTOFp() {return ctbTOFp();}
   Double_t getTOFp() {return tofp();}
+  Double_t getEPDX() {return epdx();}
   Double_t getZDCWest() {return zdcWest();}
   Double_t getZDCEast() {return zdcEast();}
   Double_t getZDCX() {return zdcX();}

--- a/StRoot/StPass0CalibMaker/StSpaceChargeEbyEMaker.cxx
+++ b/StRoot/StPass0CalibMaker/StSpaceChargeEbyEMaker.cxx
@@ -684,7 +684,7 @@ Int_t StSpaceChargeEbyEMaker::Make() {
 
   if (doGaps) DetermineGaps();
   if (doNtuple) {
-      static float X[123];
+      static float X[124];
       static float ntent = 0.0;
       static float nttrk = 0.0;
 
@@ -770,6 +770,12 @@ Int_t StSpaceChargeEbyEMaker::Make() {
       X[43] = s0*X[43] + s1*St_trigDetSumsC::instance()->getCTBOrTOFp(); // ZDCXNoKiller
       X[44] = s0*X[44] + s1*St_trigDetSumsC::instance()->getCTBWest();   // ZDCWestNoKiller
       X[45] = s0*X[45] + s1*St_trigDetSumsC::instance()->getCTBEast();   // ZDCEastNoKiller
+
+      // EPD:
+      // Stored in rich scaler rs14 for 2018+ data, and available
+      //   for the DAQ stream via otherwise empty TOFp member of
+      //   trigDetSums starting with SL24b
+      X[123] = s0*X[123] + s1*St_trigDetSumsC::instance()->getEPDX();
 
       // StMagUtilities distortion correction parameters
       X[46] = s0*X[46] + s1*m_ExB->GetConst_0();
@@ -1036,7 +1042,7 @@ void StSpaceChargeEbyEMaker::InitQAHists() {
   }
 
   if (doNtuple) ntup = new TNtuple("SC","Space Charge",
-    "sc:dca:zdcx:zdcw:zdce:bbcx:bbcw:bbce:bbcbb:bbcyb:intb:inty:fill:mag:run:event:dcan:dcap:dcae:dcaw:gapf:gapi:gapd:gapfn:gapin:gapdn:gapfp:gapip:gapdp:gapfe:gapie:gapde:gapfw:gapiw:gapdw:usc:uscmode:ugl:zdcc:bbcc:vpdx:vpdw:vpde:zdcxnk:zdcwnk:zdcenk:const0:const1:sce:scw:usce:sc1:gapf1:gapi1:sc2:gapf2:gapi2:sc3:gapf3:gapi3:sc4:gapf4:gapi4:sc5:gapf5:gapi5:sc6:gapf6:gapi6:sc7:gapf7:gapi7:sc8:gapf8:gapi8:sc9:gapf9:gapi9:sc10:gapf10:gapi10:sc11:gapf11:gapi11:sc12:gapf12:gapi12:sc13:gapf13:gapi13:sc14:gapf14:gapi14:sc15:gapf15:gapi15:sc16:gapf16:gapi16:sc17:gapf17:gapi17:sc18:gapf18:gapi18:sc19:gapf19:gapi19:sc20:gapf20:gapi20:sc21:gapf21:gapi21:sc22:gapf22:gapi22:sc23:gapf23:gapi23:sc24:gapf24:gapi24");
+    "sc:dca:zdcx:zdcw:zdce:bbcx:bbcw:bbce:bbcbb:bbcyb:intb:inty:fill:mag:run:event:dcan:dcap:dcae:dcaw:gapf:gapi:gapd:gapfn:gapin:gapdn:gapfp:gapip:gapdp:gapfe:gapie:gapde:gapfw:gapiw:gapdw:usc:uscmode:ugl:zdcc:bbcc:vpdx:vpdw:vpde:zdcxnk:zdcwnk:zdcenk:const0:const1:sce:scw:usce:sc1:gapf1:gapi1:sc2:gapf2:gapi2:sc3:gapf3:gapi3:sc4:gapf4:gapi4:sc5:gapf5:gapi5:sc6:gapf6:gapi6:sc7:gapf7:gapi7:sc8:gapf8:gapi8:sc9:gapf9:gapi9:sc10:gapf10:gapi10:sc11:gapf11:gapi11:sc12:gapf12:gapi12:sc13:gapf13:gapi13:sc14:gapf14:gapi14:sc15:gapf15:gapi15:sc16:gapf16:gapi16:sc17:gapf17:gapi17:sc18:gapf18:gapi18:sc19:gapf19:gapi19:sc20:gapf20:gapi20:sc21:gapf21:gapi21:sc22:gapf22:gapi22:sc23:gapf23:gapi23:sc24:gapf24:gapi24:epdx");
 
   if (doGaps) {
     gapZhist = new TH2F("Gaps","Gaps",GZN,GZL,GZH,GN,GL,GH);


### PR DESCRIPTION
The EPD coincidence rate began filling element `rs14` of the RICH scaler struct in the DAQ stream and online databases at the end of March 2018. This needs to be propagated into the `trigDetSums` table in the offline database ([now done](https://www.star.bnl.gov/cgi-bin/protected/viewvc.cgi/cvsroot/online/DataBase/dbcron/macros/FillTD.C?r1=1.2&r2=1.3)), and when reading the DAQ structures (this PR). As was previously done for the no-killer ZDCs, this makes use of a no-longer needed scaler in the trigDetSums struct (TOFp in this case), while retaining backward compatibility with older data in which that now-defunct scaler was actually used.