### PR TITLE
Look for local StEvent enumerations first

### DIFF
--- a/StRoot/StEvent/StEnumerations.cxx
+++ b/StRoot/StEvent/StEnumerations.cxx
@@ -19,11 +19,15 @@ void detectorId(int *ids=0, char** cds=0)
  memset(ids,0,sizeof(ids[0])*100);
  memset(cds,0,sizeof(cds[0])*100);
 
- TString myPath("$STAR/StRoot/StEvent/StEnumerations.h");
- gSystem->ExpandPathName(myPath);
-
+ // Look for local enumerations (when developing) before global
+ TString myPath("./StRoot/StEvent/StEnumerations.h");
  int notExi = gSystem->AccessPathName(myPath.Data(),kFileExists);
- if (notExi)    { ids[0]=-1; return;}
+ if (notExi) {
+   myPath = "$STAR/StRoot/StEvent/StEnumerations.h";
+   gSystem->ExpandPathName(myPath);
+   notExi = gSystem->AccessPathName(myPath.Data(),kFileExists);
+   if (notExi)    { ids[0]=-1; return;}
+ }
  FILE *fp = fopen(myPath.Data(),"r");
  if (!fp)       { ids[0]=-1; return;}
  char buf[400];


### PR DESCRIPTION
Even though STAR is winding down, there is still some development work ongoing involving FWD detectors. I believe the parsing of StEnumerations.h within StEnumerations.cxx may be making it a little difficult for them because it does not currently allow for a local (developmental) version of enumerations. This PR modified that with a local search first, and hopefully that helps them out.

Note that the parsing is done at run-time, so even with this patch, test jobs need to have not just the compiled code where the job runs, they need also have a local StRoot/StEvent/StEnumerations.h present where the job runs.

p.s. I meant to include @dkapukchyan as a reviewer, but it seems he doesn't show up as someone I can add.