### PR TITLE
Update Stgm geometry z-plane locations according to survey data

### DIFF
--- a/StRoot/StFttSimMaker/StFttFastSimMaker.cxx
+++ b/StRoot/StFttSimMaker/StFttFastSimMaker.cxx
@@ -65,7 +65,7 @@ Int_t StFttFastSimMaker::Make() {
         
         StFttPoint *point = new StFttPoint();
         point->setPlane(plane_id);
-        point->setQuadrant(0); // TODO this could be improved, but it is not used in the current implementation
+        point->setQuadrant(0);
         StThreeVectorD xyz;
         xyz.set(x, y, z);
         point->setXYZ( xyz );

--- a/StRoot/StFttSimMaker/StFttFastSimMaker.cxx
+++ b/StRoot/StFttSimMaker/StFttFastSimMaker.cxx
@@ -65,7 +65,7 @@ Int_t StFttFastSimMaker::Make() {
         
         StFttPoint *point = new StFttPoint();
         point->setPlane(plane_id);
-        point->setQuadrant(0);
+        point->setQuadrant(0); // TODO this could be improved, but it is not used in the current implementation
         StThreeVectorD xyz;
         xyz.set(x, y, z);
         point->setXYZ( xyz );

--- a/StarVMC/Geometry/StgmGeo/StgmGeo1.xml
+++ b/StarVMC/Geometry/StgmGeo/StgmGeo1.xml
@@ -215,20 +215,20 @@
       <!-- Create and place the STGC Mother volume in the CAVE -->
 
         <Create    block="STGM" />
-        <Placement block="STGM" in="CAVE" konly="ONLY" x="0" y="5.9" z="307.65" >
+        <Placement block="STGM" in="CAVE" konly="ONLY" x="0" y="5.9" z="338.8385" >
             <Misalign table="Geometry/stgc/stgcOnTpc" row="0"/>
         </Placement>
 
         <Volume name="STGM" comment="STGC Mother volume" assembly="true" >
             <Material name="Air" />
             <!-- STGM placement and params taken from old geometry -->
-            <Shape type="tube" rmin="0" rmax="95.0" dz="52.0" />
+            <Shape type="tube" rmin="0" rmax="95.0" dz="30.0" />
 
 
             <Create block="STFM"  />
             <!-- First z-plane station -->
             <!-- z relative to Mother zcenter -->
-            zplane = -26.75; 
+            zplane = -26.4965; 
             <Placement in="STGM" y="0" x="0" z="zplane" block="STFM" konly="MANY"  >
                 <Misalign table="Geometry/stgc/pentOnStation"  row="0" />
                 <Misalign table="Geometry/stgc/stationOnStgc"  row="0" />
@@ -255,7 +255,7 @@
             <Info format="Positioning sTGC {2I}">station</Info>
 
 
-            zplane = -3.95; 
+            zplane = -8.8855; 
             <Placement in="STGM" y="0" x="0" z="zplane" block="STFM" konly="MANY"  >
                 <Misalign table="Geometry/stgc/pentOnStation"  row="4" />
                 <Misalign table="Geometry/stgc/stationOnStgc"  row="1" />
@@ -281,7 +281,7 @@
             station = 2;
             <Info format="Positioning sTGC {2I}">station</Info>
 
-            zplane = +18.95; 
+            zplane = +8.7985; 
             <Placement in="STGM" y="0" x="0" z="zplane" block="STFM" konly="MANY"  >
                 <Misalign table="Geometry/stgc/pentOnStation"  row="8" />
                 <Misalign table="Geometry/stgc/stationOnStgc"  row="2" />
@@ -307,7 +307,7 @@
             station = 3;
             <Info format="Positioning sTGC {2I}">station</Info>
 
-            zplane = +41.75; 
+            zplane = +26.5835; 
             <Placement in="STGM" y="0" x="0" z="zplane" block="STFM" konly="MANY"  >
                 <Misalign table="Geometry/stgc/pentOnStation"  row="12" />
                 <Misalign table="Geometry/stgc/stationOnStgc"  row="3" />


### PR DESCRIPTION
Move sTGC planes to match the z-locations measured as part of the precision position survey. Use the z coord for quadrant A on each plane as the z-location for the entire plane