### PR TITLE
Setup AA chain for Run 24

### DIFF
--- a/StRoot/StBFChain/BigFullChain.h
+++ b/StRoot/StBFChain/BigFullChain.h
@@ -1055,6 +1055,10 @@ Bfc_st BFC[] = { // standard chains
    "B2024a,ITTF,BAna,ppOpt,ImpBToFt0Mode,VFPPVnoCTB,beamline3D,l3onl,epdhit,btof,mtd,emcDY2,ftt,fcs,trgd,ZDCvtx,analysis",
    "","","Production chain for year 2024 pp data - CorrY (+ l3, epd, mtd, btof, fcs, ftt, e/b-emc)",kFALSE},
 
+  {"P2024a","" ,"",
+   "B2024a,ITTF,BAna,iTpcIT,VFMinuit,etofa,btof,mtd,l3onl,emcDY2,epdHit,trgd,ZDCvtx,analysis",
+           "","",        "Base chain for year 2024 AA data - CorrY (+ l3, epd, mtd, b/etof, b-emc)",kFALSE},
+
 
   // Other chains/Calibration
   {"LaserCal0","" ,"","db,detDb,tpc_daq,tpcDb,tcl,globT,laser,LaserTest","",""


### PR DESCRIPTION
Introduce `P2024a`, a copy of `P2023a` modified for the 2024 geometry, for the AuAu data taken at the end of Run 24. This is needed promptly for FastOffline.