### PR TITLE
Add support in StVertex for "Fwd" vertex

### DIFF
--- a/StRoot/StEvent/StEnumerations.h
+++ b/StRoot/StEvent/StEnumerations.h
@@ -400,7 +400,9 @@ enum StVertexId {kUndefinedVtxId   = kUndefinedVertexIdentifier,
                  kFtpcEastCalVtxId = kFtpcEastCalibrationVertexIdentifier,
                  kFtpcWestCalVtxId = kFtpcWestCalibrationVertexIdentifier,
 		         kBEAMConstrVtxId,
-                 kRejectedVtxId};
+                 kRejectedVtxId,
+                 kFwdVtxId
+                 };
 
 /*!
  * \enum StRichPidFlag

--- a/StRoot/StEvent/StVertex.h
+++ b/StRoot/StEvent/StVertex.h
@@ -128,6 +128,7 @@ public:
     virtual void setKinkVertex()      {SETBIT(mFlag,kKinkVtxId);}    
     virtual void setBeamConstrained() {SETBIT(mFlag,kBEAMConstrVtxId);}
     virtual void setRejected()        {SETBIT(mFlag,kRejectedVtxId);}
+    virtual void setFwdVertex()       {SETBIT(mFlag,kFwdVtxId);}
 
     bool        isPrimaryVtx()      const {return TESTBIT(mFlag,kPrimaryVtxId);}
     bool        isV0Vtx()           const {return TESTBIT(mFlag,kV0VtxId);}
@@ -135,6 +136,7 @@ public:
     bool        isKinkVertex()      const {return TESTBIT(mFlag,kKinkVtxId);}
     bool        isBeamConstrained() const {return TESTBIT(mFlag,kBEAMConstrVtxId);}
     bool        isRejected()        const {return TESTBIT(mFlag,kRejectedVtxId);}
+    bool        isFwdVtx()          const {return TESTBIT(mFlag,kFwdVtxId);}
     void Print(Option_t *option="") const {cout << option << *this << endl; }
     static void   SetNoFitPointCutForGoodTrack(UInt_t val) {fgNoFitPointCutForGoodTrack = val;}
     static UInt_t NoFitPointCutForGoodTrack() {return fgNoFitPointCutForGoodTrack;}


### PR DESCRIPTION
Minimal updates to enum StVertexId and StVertex class to allow primary vertices to be assigned as FWD - so that we can use the primary vertex index to seamlessly refer to standard primary vertices and those found from forward tracks.