### PR TITLE
Revert incorrect changes to fst consts merged in fst-tracking pr.

### DIFF
--- a/StRoot/StEvent/StFstConsts.h
+++ b/StRoot/StEvent/StFstConsts.h
@@ -52,8 +52,8 @@ const float kFstrStart[kFstNumRStripsPerWedge]= {5.000, 7.875, 10.750, 13.625, 1
 const float kFstrStop[kFstNumRStripsPerWedge] = {7.875, 10.750, 136.25, 16.500, 19.375, 22.250, 25.125, 28.000}; // in cm
 
 //general APV chip constants
-const unsigned char kFstNumTimeBins = 3;    // 9 time bins for ADC sampling (maximum time bin number, 3 or 9)
-const unsigned char kFstDefaultTimeBin = 1; // the default time bin number (2nd time bin) for FST raw hits
+const unsigned char kFstNumTimeBins = 9;    // 9 time bins for ADC sampling (maximum time bin number, 3 or 9)
+const unsigned char kFstDefaultTimeBin = 2; // the default time bin number (2nd time bin) for FST raw hits
 const int kFstMaxAdc                = 4096; // ADC value should be less than 4096 (12 bits ADC)
 
 #endif


### PR DESCRIPTION
recent merge of fast-tracking mode incorrectly modified the values in StFstConst.h
This reverts those changes, since they are no longer needed with the more general fix to FST (PR #685 )