### PR TITLE
Backport cons changes for 64-bit SL16j_embed release

### DIFF
--- a/StRoot/StiMaker/StiDefaultToolkit.h
+++ b/StRoot/StiMaker/StiDefaultToolkit.h
@@ -17,6 +17,8 @@
 #define StiDefaultToolkit_H 1
 #include "Sti/StiToolkit.h"
 
+class StiTrackMerger;
+
 /** 
  * @class StiDefaultToolkit
  * @brief Definition of toolkit

--- a/asps/rexe/Conscript
+++ b/asps/rexe/Conscript
@@ -79,9 +79,7 @@ if ($FC =~ /^pgf/) {
 }
 $LIBS .= " -lgeant321 -lgcalor"; 
 $LIBS  .= " " . $env->{CERNLIBS};
-$LIBS  .= $env->{LDALL};
 $LIBS  .= " " . $env->{Packages}->{MYSQL}->{LIBS};
-$LIBS  .= $env->{LDNONE};
 $LIBS  .= " " . $FLIBS . " " . $env->{CLIBS};#   " " . $env->{SYSLIBS} ;
 if ($STAR_SYS =~ /^sun4x_5.$/) {
     if ($LIBPATH) { $LIBPATH .= $main::PATH_SEPARATOR; }

--- a/mgr/ConsDefs.pm
+++ b/mgr/ConsDefs.pm
@@ -142,12 +142,10 @@
 	}
 
 	$G77FLAGS .= " -std=legacy -fno-second-underscore -w -fno-automatic -Wall -W -Wsurprising -fPIC";
-	$FFLAGS    = $G77FLAGS;
-	$FLIBS     = "-lgfortran";
-#	$FLIBS      = `$FC $FFLAGS -print-file-name=libgfortran.$SOEXT`; chomp($FLIBS);
-#	if ($FLIBS eq "libgfortran.$SOEXT") {
-#	  $FLIBS    = `$FC $FFLAGS -print-file-name=libgfortran.a`; chomp($FLIBS);
-#	}
+	
+	$FFLAGS    = $G77FLAGS;     # will be overwritten below, ignore
+	$FLIBS     = "-lgfortran -lquadmath";
+
     } else {
 	$G77       = "g77";
 	$G77FLAGS  = "$XMACHOPT -fno-second-underscore -w -fno-automatic -Wall -W -Wsurprising -fPIC";
@@ -200,7 +198,7 @@
     $STIC          = "stic";
     $STICFLAGS     = "";
     $AGETOF        = "agetof";
-    $AGETOFLAGS    = "-V 1";
+    $AGETOFLAGS    = "-V 1 -d $STAR_BIN/agetof.def";
     $LIBSTDC       = `$CC $CFLAGS -print-file-name=libstdc++.a | awk '{ if (\$1 != "libstdc++.a") print \$1}'`;
     chomp($LIBSTDC);
 
@@ -917,107 +915,31 @@
     #
     # *** Standard package first, then XOPTSTAR ***
     #	
-    my ($MYSQLINCDIR,$mysqlheader);
-    if ( defined($ENV{USE_LOCAL_MYSQL}) ){
-	($MYSQLINCDIR,$mysqlheader) =
-	    script::find_lib( $XOPTSTAR . "/include " .  $XOPTSTAR . "/include/mysql ".
-			      $MYSQL . " " .
-			      "/sw/include/mysql ".
-			      "/include /usr/include ".
-			      "/usr/include/mysql  ".
-			      "/usr/mysql/include  ".
-			      "/usr/mysql  ",
-			      "mysql.h");
-    } else { 
-	($MYSQLINCDIR,$mysqlheader) =
-	    script::find_lib( $MYSQL . " " .
-			      "/sw/include/mysql ".
-			      "/include /usr/include ".
-			      "/usr/include/mysql  ".
-			      "/usr/mysql/include  ".
-			      "/usr/mysql  ".
-			      $XOPTSTAR . "/include " .  $XOPTSTAR . "/include/mysql " ,
-			      "mysql.h");
-    }
 
-    if (! $MYSQLINCDIR) {
-	die "Can't find mysql.h in standard path and $XOPTSTAR/include  $XOPTSTAR/include/mysql\n";
-    }
 
     # search for the config    
-    my ($MYSQLCONFIG,$mysqlconf);
-    # if ( defined($ENV{USE_LOCAL_MYSQL}) ){
-	($MYSQLCONFIG,$mysqlconf) =
-	    script::find_lib($XOPTSTAR . "/bin " .  $XOPTSTAR . "/bin/mysql ".
-			     $MYSQL . " ".
-			     "/usr/$LLIB/mysql /usr/bin/mysql /usr/bin ",
-			     "mysql_config");
-    # } else {
-    #	($MYSQLCONFIG,$mysqlconf) =
-    #	    script::find_lib($MYSQL . " ".
-    #			     "/usr/$LLIB/mysql /usr/bin/mysql /usr/bin ".
-    #			     $XOPTSTAR . "/bin " .  $XOPTSTAR . "/bin/mysql ",
-    #			     "mysql_config");
-    # } 
+    chomp(my $mysqlconf = `which mysql_config`);
 
-
-    # Associate the proper lib with where the inc was found
-    my ($mysqllibdir)=$MYSQLINCDIR;
-    $mysqllibdir =~ s/include/$LLIB/;
-
-    # print "DEBUG :: $mysqllibdir\n";
-    # Note - there is a trick here - the first element uses mysqllibdir
-    #        which is dreived from where the INC is found hence subject to 
-    #        USE_LOCAL_MYSQL switch. This may not have been obvious.
-    # my ($MYSQLLIBDIR,$MYSQLLIB) =
-    #	script::find_lib($mysqllibdir . " /usr/$LLIB/mysql ".
-    #			 $XOPTSTAR . "/lib " .  $XOPTSTAR . "/lib/mysql ",
-    #			 "libmysqlclient");
-    #			 # "libmysqlclient_r libmysqlclient");
-    # # die "*** $MYSQLLIBDIR,$MYSQLLIB\n";
-
-    # if ($STAR_HOST_SYS =~ /^rh/ or $STAR_HOST_SYS =~ /^sl/) {
-    if ( $mysqlconf ){
-	$mysqlconf = "$MYSQLCONFIG/$mysqlconf";
-	# if ( 1==1 ){
-	# Do not guess, just take it - this leads to a cons error though TBC
-	chomp($MYSQLLIB = `$mysqlconf  --libs`);
-	# but remove -L which are treated separately by cons
-	my(@libs) = split(" ", $MYSQLLIB);
-	my($test) = shift(@libs);
-	if ( $test =~ /-L/){
-	    $MYSQLLIBDIR = $test; $MYSQLLIBDIR =~ s/-L//;
-	    $MYSQLLIB = "";
-	    foreach my $el (@libs){
-		$MYSQLLIB  .= " ".$el if ($el !~ m/-L/);
-	    }
-	}
-	
-	# here is a check for libmysqlclient
-	
-	
-	# die "DEBUG got $MYSQLLIBDIR $MYSQLLIB\n";
-	
-	# mysqlconf returns (on SL5, 64 bits)
-	#  -L/usr/lib64/mysql -lmysqlclient -lz -lcrypt -lnsl -lm -L/usr/lib64 -lssl -lcrypto
-	# } else {
-	#    $MYSQLLIB .= " -L/usr/$LLIB";
-	#    if (-r "/usr/$LLIB/libmystrings.a") {$MYSQLLIB .= " -lmystrings";}
-	#    if (-r "/usr/$LLIB/libssl.a"      ) {$MYSQLLIB .= " -lssl";}
-	#    if (-r "/usr/$LLIB/libcrypto.a"   ) {$MYSQLLIB .= " -lcrypto";}
-	#    if ( $MYSQLLIB =~ m/client_r/     ) {$MYSQLLIB .= " -lpthread";}
-	#    # if (-r "/usr/$LLIB/libk5crypto.a" ) {$MYSQLLIB .= " -lcrypto";}
-	#    $MYSQLLIB .= " -lz";
-	#    # $MYSQLLIB .= " -lz -lcrypt -lnsl";
-	# }
-    } else {
-	die "No mysql_config found\n";
+    if ($?) {
+        die "No mysql_config found\n";
     }
-    print "Using $mysqlconf\n\tMYSQLINCDIR = $MYSQLINCDIR MYSQLLIBDIR = $MYSQLLIBDIR  \tMYSQLLIB = $MYSQLLIB\n"
-          if ! $param::quiet;
 
-    # die "\n";
+    chomp(my $MYSQLINCDIR = `mysql_config --variable=pkgincludedir`);
+    chomp(my $MYSQLLIBDIR = `mysql_config --variable=pkglibdir`);
 
+    chomp(my $MYSQLLIB = `$mysqlconf --libs`);
+    # Remove -L which are treated separately by cons
+    my(@libs) = split(" ", $MYSQLLIB);
+    my($test) = shift(@libs);
+    if ( $test =~ /-L/) {
+        $MYSQLLIBDIR = $test; $MYSQLLIBDIR =~ s/-L//;
+        $MYSQLLIB = "";
+        foreach my $el (@libs) {
+            $MYSQLLIB  .= " ".$el if ($el !~ m/-L/);
+        }
+    }
+
+    print "Using $mysqlconf\n\tMYSQLINCDIR = $MYSQLINCDIR\n\tMYSQLLIBDIR = $MYSQLLIBDIR\n\tMYSQLLIB = $MYSQLLIB\n" if !$param::quiet;
 
 
     # QT
@@ -1115,65 +1037,62 @@
     }
 
     # Logger
-    $LoggerDir = $XOPTSTAR . "/include/log4cxx";
+    chomp($LoggerDir = `pkg-config --variable=prefix liblog4cxx`);
+    $LoggerDir = $MYSTAR unless $LoggerDir;
 
-    if (-d $LoggerDir) {
-	$LoggerINCDIR = $XOPTSTAR . "/include";
-	$LoggerLIBDIR = $XOPTSTAR . "/lib";
-	$LoggerLIBS   = "-llog4cxx";
-	print
-	    "Use Logger  ",
-	    "LIBDIR = $LoggerLIBDIR \tLoggerINCDIR = $LoggerINCDIR \tLoggerLIBS = $LoggerLIBS\n"
-	    if $LoggerLIBDIR && ! $param::quiet;
+    if (not -d $LoggerDir."/include/log4cxx") {
+        die "No log4cxx found\n";
     }
+
+    $LoggerINCDIR = $LoggerDir . "/include";
+    $LoggerLIBDIR = $LoggerDir . "/lib";
+    $LoggerLIBS   = "-llog4cxx";
+
+    print "Using $LoggerDir\n\tLoggerLIBDIR = $LoggerLIBDIR\n\tLoggerINCDIR = $LoggerINCDIR\n\tLoggerLIBS = $LoggerLIBS\n" unless $param::quiet;
+
     # xml2
-    my  ($XMLINCDIR,$XMLLIBDIR,$XMLLIBS) = ("","","");
-    my ($xml) =  script::find_lib($XOPTSTAR . "/bin /usr/bin",
-				  "xml2-config");
-    if ($xml) {
-	$xml .= "/xml2-config";
-	$XMLINCDIR = `$xml --cflags`;
-	chomp($XMLINCDIR);
-	$XMLINCDIR =~ s/-I//;
-	my $XML  = `$xml --libs`; # die "$XML\n";
-	my(@libs)= split(" ", $XML);
+    chomp(my $xml = `which xml2-config`);
 
-	$XMLLIBDIR = shift(@libs);
-	if ($XMLLIBDIR =~ /-L/){
-	    $XMLLIBDIR =~ s/-L//;
-	    $XMLLIBS   = join(" ",@libs);
-	} else {
-	    # no -L, assume all were LIBS
-	    $XMLLIBS   = $XMLLIBDIR ." ".join(" ",@libs);
-	    # and fix -L / should work for both 32 and 64
-	    $XMLLIBDIR = "/usr/$LLIB";
-	}
-
-
-	# ($XMLLIBDIR,$XMLLIBS) = split(' ', $XML);
-	# if ($XMLLIBDIR =~ /-L/){
-	#    $XMLLIBDIR =~ s/-L//;
-	# } else {
-	#    # may not have any -L
-	#    if ($XMLLIBS
-	# }
-
-	my $XMLVersion = `$xml --version`;            # print "XMLVersion = $XMLVersion\n";
-	my ($major,$minor) = split '\.', $XMLVersion; # print "major = $major,minor = $minor\n";
-	$XMLCPPFlag = "";#-DXmlTreeReader";
-	if ($major < 2 or $major == 2 and $minor < 5) {
-	    $XMLCPPFlag = "-DNoXmlTreeReader";
-	}
-	if ( ! $param::quiet ){
-	    if ( $XMLLIBDIR ){
-		print "Use xml $xml XMLLIBDIR = $XMLLIBDIR \tXMLINCDIR = $XMLINCDIR \tXMLLIBS = $XMLLIBS XMLCPPFlag =$XMLCPPFlag\n";
-	    } else {
-		print "Use xml -> WARNING ** Could not define XMLLIBDIR, XMLINCDIR, XMLLIBS\n";
-	    }
-	}
-    } else {
-	print "Could not find xml libs\n" if (! $param::quiet);
+    if ($?) {
+        die "No xml2-config found\n";
     }
+
+    my  ($XMLINCDIR,$XMLLIBDIR,$XMLLIBS) = ("","","");
+
+    $XMLINCDIR = `$xml --cflags`;
+    chomp($XMLINCDIR);
+    $XMLINCDIR =~ s/-I//;
+    my $XML  = `$xml --libs`; # die "$XML\n";
+    my(@libs)= split(" ", $XML);
+
+    $XMLLIBDIR = shift(@libs);
+    if ($XMLLIBDIR =~ /-L/){
+        $XMLLIBDIR =~ s/-L//;
+        $XMLLIBS   = join(" ",@libs);
+    } else {
+        # no -L, assume all were LIBS
+        $XMLLIBS   = $XMLLIBDIR ." ".join(" ",@libs);
+        # and fix -L / should work for both 32 and 64
+        $XMLLIBDIR = "/usr/$LLIB";
+    }
+
+    my $XMLVersion = `$xml --version`;            # print "XMLVersion = $XMLVersion\n";
+    my ($major,$minor) = split '\.', $XMLVersion; # print "major = $major,minor = $minor\n";
+    $XMLCPPFlag = "";#-DXmlTreeReader";
+    if ($major < 2 or $major == 2 and $minor < 5) {
+        $XMLCPPFlag = "-DNoXmlTreeReader";
+    }
+    if ( ! $param::quiet ){
+        if ( $XMLLIBDIR ){
+            print "Using $xml\n\tXMLLIBDIR = $XMLLIBDIR\n\tXMLINCDIR = $XMLINCDIR\n\tXMLLIBS = $XMLLIBS\n\tXMLCPPFlag = $XMLCPPFlag\n" if !$param::quiet;
+        } else {
+            print "Use xml -> WARNING ** Could not define XMLLIBDIR, XMLINCDIR, XMLLIBS\n";
+        }
+    }
+
+    chomp($FASTJET_PREFIX = `fastjet-config --prefix`);
+    chomp($GSL_PREFIX = `gsl-config --prefix`);
+
  #Vc check SSE support
  my $cmd = "touch temp_gccflags.c; $CXX -E -dM -o - temp_gccflags.c | grep -q SSE";
  my $VcCPPFLAGS = " -DVC_IMPL=SSE";
@@ -1287,7 +1206,9 @@
 		      },
 		  'SUFOBJ' => "." . $O,
 		  'ENV'    => {
+		      'CPATH'           => $CPATH,
 		      'PATH'            => $PATH,
+		      'PYTHONPATH'      => $PYTHONPATH,
 		      'LM_LICENSE_FILE' => $LM_LICENSE_FILE,
 		      'INCLUDE'         => $INCLUDE_PATH,
 		      'ROOT'            => $ROOT,
@@ -1331,6 +1252,12 @@
 			    'CPPFLAGS' => $CERNLIB_CPPFLAGS,
 			    'CERNLIBS' => $CERNLIBS
 			    },
+                       'FASTJET' => {
+                           'INCDIR'=> "$FASTJET_PREFIX/include"
+                           },
+                       'GSL' => {
+                           'INCDIR'=> "$GSL_PREFIX/include"
+                           },
 		       'MYSQL' => {
 			   'LIBDIR'=> $MYSQLLIBDIR,
 			   'INCDIR'=> $MYSQLINCDIR,

--- a/mgr/Construct
+++ b/mgr/Construct
@@ -364,17 +364,15 @@ my @sysdirlist = qw(asps/Simulation/agetof
 if ($STAR_SYS !~ /x86_darwin/) {
   push @sysdirlist, "asps/DAQBrowser";
 }
-if (!($USE_64BITS and $USE_64BITS != "0") && $STAR_SYS !~ /x86_darwin/){
-  push @sysdirlist, "asps/Simulation/geant321";
-  push @sysdirlist, "asps/Simulation/gcalor";
-  push @sysdirlist, "asps/rexe";
-  push @sysdirlist, "asps/Simulation/starsim";
-  if ($STAR_HOST_SYS !~ /sl61_gcc445/) {# broken Qt
-    push @sysdirlist, "OnlTools/OnlinePlots";
-    push @sysdirlist, "OnlTools/PDFUtil";
-    push @sysdirlist, "OnlTools/StOnlineDisplay";
-    push @sysdirlist, "OnlTools/Jevp";
-  }
+push @sysdirlist, "asps/Simulation/geant321";
+push @sysdirlist, "asps/Simulation/gcalor";
+push @sysdirlist, "asps/rexe";
+push @sysdirlist, "asps/Simulation/starsim";
+if ($STAR_HOST_SYS !~ /sl61_gcc445/) {# broken Qt
+  push @sysdirlist, "OnlTools/OnlinePlots";
+  push @sysdirlist, "OnlTools/PDFUtil";
+  push @sysdirlist, "OnlTools/StOnlineDisplay";
+  push @sysdirlist, "OnlTools/Jevp";
 }
 
 #print "sysdirlist = @sysdirlist \n subdirs = @subdirs\n";

--- a/pams/gen/idl/eg_event.idl
+++ b/pams/gen/idl/eg_event.idl
@@ -1,0 +1,30 @@
+/* eg_event.idl - Event Generator event table */
+
+struct eg_event {	   /*VENUS     Description                           */
+   long   n_event;         /*nrevt     eg event number                       */
+   float  b_impact;        /*bimevt    actual impact parameter               */
+   float  phi_impact;      /*phievt    reaction plane                        */
+/* long   event_type;                  trigger, minbias bkgd, cosmic, etc.   */
+/* long   polarization_evt[10];        to be defined                         */
+/* long   n_part_prot_east;            number of participant protons         */
+/* long   n_part_neut_east;            number of participant neutrons        */
+/* long   n_part_prot_west;            number of participant protons         */
+/* long   n_part_neut_west;            number of participant neutrons        */
+   long   n_track;         /*nptls     # tracks                              */
+   long   n_vertex;        /*ivtxs     # vertices                            */
+/* long   n_fs_track;                  # final state tracks                  */
+/* long   n_not_fs_track;              # non-final state tracks              */
+/* long   n_primary_vertex;            # primary vertices                    */
+/* long   n_fs_vertex;                 # non-final state vertices            */
+/* struct eg_vertex_t   *p_first_primary_vertex; ptr to ll of primary verts  */
+/* struct eg_vertex_t   *p_first_fs_vertex;      ptr to ll of fin. state vert*/
+};
+
+/* Latest revision - $Date: 1997/01/08 21:15:08 $ */
+/*
+
+05dec96 - cetull
+	This table is derived from VENUS and GSTAR internal structures and
+	variables.
+
+*/

--- a/pams/gen/idl/eg_gener.idl
+++ b/pams/gen/idl/eg_gener.idl
@@ -1,0 +1,27 @@
+/* eg_gener.idl - Event Generator generator table */
+
+struct eg_gener {        /*VENUS       Description                           */
+/* long     generator;                 event generator identification        */
+   char     eg_name[32]; /*            event generator name                  */
+   float    eg_version;  /*            version of event generator            */
+/* long     eg_run;                    generator run number                  */
+/* long     eg_rndm[2];                generator random numbers              */
+   float    sqrts;       /*engy        center of mass energy                 */
+/* long     is_minbias;                minimum bias flag                     */
+/* float    b_min;                     minimum impact parameter              */
+   float    b_max;       /*bmaxim      maximum impact parameter              */
+   long     east_a;      /*maproj      projectile 1 mass number              */
+   long     east_z;      /*laproj      projectile 1 charge                   */
+   long     west_a;      /*matarg      projectile 2 mass number              */
+   long     west_z;      /*latarg      projectile 2 charge                   */
+/* long     polarization_run[10];      to be defined                         */
+};
+
+/* Latest revision - $Date: 1997/01/08 21:15:11 $ */
+/*
+
+05dec96 - cetull
+	This table is derived from VENUS and GSTAR internal structures and
+	variables.
+
+*/

--- a/pams/gen/idl/eg_track.idl
+++ b/pams/gen/idl/eg_track.idl
@@ -1,0 +1,27 @@
+/* eg_track.idl - Event Generator track table */
+
+struct eg_track {               /*VENUS         Description                  */
+/* long   label;                                event generator label        */
+/* long   eg_pid;                               event generator id           */
+   long   ge_pid;               /*idtype        GEANT id                     */
+   float  p[3];                 /*pptl[3]       momentum                     */
+   long   itrack;	        /*it            Track Number  (not in gstar) */
+   long   ivertex;		/*iv            Vertex Number (not in gstar) */
+   long   iz;                   /*iz                          (not in gstar) */
+/* struct eg_vertex_t *p_start_vertex;          ptr to start vertex          */
+/* struct eg_vertex_t *p_stop_vertex;           ptr to stop vertex           */
+/* struct eg_track_t  *p_parent_track;          ptr to parent track          */
+/* struct eg_track_t  *p_next_fs_track;         ptr to next final state trk  */
+/* struct eg_track_t  *p_prev_fs_track;         ptr to prev final state trk  */
+/* struct eg_track_t  *p_next_not_fs_track;     ptr to next non-fs track     */
+/* struct eg_track_t  *p_prev_not_fs_track;     ptr to prev non-fs track     */
+};
+
+/* Latest revision - $Date: 1997/01/08 21:15:14 $ */
+/*
+
+05dec96 - cetull
+	This table is derived from VENUS and GSTAR internal structures and
+	variables.
+
+*/

--- a/pams/gen/idl/eg_vertex.idl
+++ b/pams/gen/idl/eg_vertex.idl
@@ -1,0 +1,29 @@
+/* eg_vertex.idl - Event Generator vertex table */
+
+struct eg_vertex {      /*VENUS      Description                             */
+/* long   label;                     event generator label                   */
+/* long   i_eg_process;              event generator production process      */
+   float  x[3];         /*xstrx,y,z  space point                             */
+   float  t;            /*xstrt      time coordinate                         */
+   long   ivstor;       /*ivstor     ?                        (not in gstar) */
+   long   iz;           /*iz         ?                        (not in gstar) */
+   long   npstor;       /*npstor     ?                        (not in gstar) */
+/* long   n_fs_track;                # final state daughter tracks           */
+/* long   n_not_fs_track;            # non-final state daughter tracks       */
+/* struct eg_track_t  *p_parent_track;        ptr to parent track            */
+/* struct eg_track_t  *p_first_fs_track;      ptr to ll of final state trks  */
+/* struct eg_track_t  *p_first_not_fs_track;  ptr to ll of non-fs tracks     */
+/* struct eg_vertex_t *p_next_primary_vertex; ptr to next primary vertex     */
+/* struct eg_vertex_t *p_prev_primary_vertex; ptr to prev primary vertex     */
+/* struct eg_vertex_t *p_next_fs_vertex;      ptr to next final state vertex */
+/* struct eg_vertex_t *p_prev_fs_vertex;      ptr to prev final state vertex */
+};
+
+/* Latest revision - $Date: 1997/01/08 21:15:17 $ */
+/*
+
+05dec96 - cetull
+	This table is derived from VENUS and GSTAR internal structures and
+	variables.
+
+*/

--- a/pams/gen/idl/particle.idl
+++ b/pams/gen/idl/particle.idl
@@ -1,0 +1,93 @@
+/* Generated particle table
+*
+* $Id: particle.idl,v 1.3 1999/02/18 20:51:07 longacre Exp $
+*
+* $Log: particle.idl,v $
+* Revision 1.3  1999/02/18 20:51:07  longacre
+* add two new starlight
+*
+* Revision 1.2  1999/02/18 15:52:20  longacre
+*  added listing headpss.inc
+*
+* Revision 1.1  1998/04/16 17:26:34  longacre
+* first row of particle table in most generators
+*
+* PSSHEP(1) = B impact parameter
+* PSSHEP(2) = PHI angle of impact
+* PSSHEP(3) = GENERATOR NUMBER
+*  1 FRITIOF : MINBIAS
+*  2 FRITIOF : CENTRAL
+* 10 HBT     : MINBIAS
+* 11 HBT     : CENTRAL
+* 20 HIJET   : RHICEVT : MINBIAS 
+* 21 HIJET   : RHICEVT : CENTRAL
+* 22 HIJET   : PLASMA
+* 23 HIJET   : LANDAU
+* 24 HIJET   : SMOKE
+* 25 HIJET   : VOLCANO
+* 26 HIJET   : CHIRAL
+* 27 HIJET   : PTSIM
+* 28 HIJET   : STRANGSIM
+* 29 HIJET   : HIFLOW
+* 30 HIJING  : REGULAR : MINBIAS 
+* 31 HIJING  : REGULAR : CENTRAL 
+* 32 HIJING  : JET     : MINBIAS  
+* 33 HIJING  : JET     : CENTRAL 
+* 40 PYTHIA  : MINBIAS
+* 41 PYTHIA  : JET
+* 42 PYTHIA  : PHOTON
+* 43 PYTHIA  : W
+* 50 STARLIGHT
+* 51 STARLIGHT gamma gamma
+* 52 STARLIGHT photnuc : coherent
+* 60 VENUS   : MINBIAS 
+* 61 VENUS   : CENTRAL  
+* 62 VENUS   : CENTRAL : MEV
+* 70 VNI     : NOAFTER : MINBIAS 
+* 71 VNI     : AFTER   : MINBIAS 
+* 72 VNI     : NOAFTER : CENTRAL 
+* 73 VNI     : AFTER   : CENTRAL 
+* 74 VNI     : NOAFTER : JET
+* 75 VNI     : AFTER   : JET
+* 76 VNI     : NOAFTER : PHOTON
+* 77 VNI     : AFTER   : PHOTON
+* 78 VNI     : NOAFTER : CHIRAL
+* 79 VNI     : AFTER   : CHIRAL
+* 80 VNI     : CENTRAL : MEV
+* 90 RQMD    : MINBIAS
+* 91 RQMD    : CENTRAL
+* 100 BEAMGAS: VENUS   : MINBIAS
+* PSSHEP(4) = ENERGY OF N N CMS
+* PSSHEP(5) = Awest.Aeast  p p  =  1.1 or Au Au = 197.197
+* VSSHEP(1) = run number
+* VSSHEP(2) = event number
+* VSSHEP(3) = DATE
+* VSSHEP(4) = TIME
+*
+* headpss.inc
+* Here is the headpss common block that are in each generator
+*
+*      COMMON/HEADPSS/IFIRST,PSSHEP(5),VSSHEP(4)
+*      INTEGER IFIRST
+*      DOUBLE PRECISION PSSHEP,VSSHEP
+*      SAVE /HEADPSS/
+   $Id: particle.idl,v 1.3 1999/02/18 20:51:07 longacre Exp $ 
+   $Log: particle.idl,v $
+   Revision 1.3  1999/02/18 20:51:07  longacre
+   add two new starlight
+
+   Revision 1.2  1999/02/18 15:52:20  longacre
+    added listing headpss.inc
+
+   Revision 1.1  1998/02/10 15:12:41  fisyak
+   Particle table
+ 
+*/
+struct particle {
+  long  isthep;      /* status code of the entry */
+  long  idhep;       /* particle identity, accordingly to the PDG standard */
+  long  jmohep[2];   /* pointer(s) to position where the mother(s) stored */
+  long  jdahep[2];   /* pointers to position of the first/last daughter */
+  float phep[5];     /* p4 and mass (GeV) */
+  float vhep[4];     /* production vertex (mm) and time (mm/c) */ 
+};


### PR DESCRIPTION
With these changes, one should be able to build the `SL16j_embed` (pre-git) release using the Spack-based environment available on the SDCC interactive nodes.

Resolves #749 