### PR TITLE
Include TString header to fix incomplete type error in StGmtGeom

### DIFF
--- a/StRoot/StGmtUtil/geometry/StGmtGeom.h
+++ b/StRoot/StGmtUtil/geometry/StGmtGeom.h
@@ -10,6 +10,7 @@
 #define _ST_GMT_GEOM_H_
 
 #include <TVector3.h>
+#include <TString.h>
 #include <string>
 #include <sstream>
 #include <cstdlib>


### PR DESCRIPTION
Fixed build error caused by missing #include <TString.h> in StGmtGeom.h

```
In file included from .sl73_x8664_gcc485/OBJ/StRoot/StGmtUtil/geometry/StGmtGeom.cxx:12:0:
.sl73_x8664_gcc485/OBJ/StRoot/StGmtUtil/geometry/StGmtGeom.h:195:14: error: field 'signal' has incomplete type
      TString signal;   // label string
              ^
.sl73_x8664_gcc485/OBJ/StRoot/StGmtUtil/geometry/StGmtGeom.cxx:657:1: error: too many initializers for 'StGmtGeom::StGmtGeomData'
 };
 ^
```