### PR TITLE
StBTofCalibMaker bug fix: missing setVertexIndex for MuDst when selecting FXT vertices

### DIFF
--- a/StRoot/StBTofCalibMaker/StBTofCalibMaker.cxx
+++ b/StRoot/StBTofCalibMaker/StBTofCalibMaker.cxx
@@ -1401,7 +1401,11 @@ void StBTofCalibMaker::processMuDst()
           int nPrimaryVertices = mMuDst->numberOfPrimaryVertices();
           for(int iVtx=0; iVtx<nPrimaryVertices; iVtx++){
             pVtx = mMuDst->primaryVertex(iVtx);
-            if(pVtx->position().z() > 198. && pVtx->position().z() < 202.) break;
+            if(pVtx->position().z() > 198. && pVtx->position().z() < 202.){
+              mMuDst->setVertexIndex(iVtx);
+              LOG_INFO << " Vertex " << iVtx << " has been selected as the primary vertex for this event!" << endm;
+              break;
+            }
             else if(iVtx == nPrimaryVertices - 1){
 	      LOG_WARN << " No FXT primary vertex within target ... bye-bye" <<endm;
 	      return;


### PR DESCRIPTION
In processMuDst() function, MuDst::setVertexIndex is missing when picking a different primary vertex in FXT events. This leads to dcaGlobal values (gDcaMag) to be all default (-999..). The cut on the variable gDcaMag seems to be only used in mPPPAMode. Not sure how much it may affect the afterburner production in this mode.

The issue seems to be NOT relevant for processStEvent() (normal daq production) as the calculations are using different accessing methods.

