### PR TITLE
Set debugging and timeout settings for XRootD in rootlogon.C

### DIFF
--- a/StRoot/macros/rootlogon.C
+++ b/StRoot/macros/rootlogon.C
@@ -1,4 +1,9 @@
 {
+  // This will help tracing failure on XrdOpen() if any
+  gEnv->SetValue("XNet.DebugTimestamp","1");
+  gEnv->SetValue("XNet.ReconnectTimeout","15");
+  gEnv->SetValue("XNet.RequestTimeout","90");
+
   gSystem->Load("libStarClassLibrary");
   gSystem->Load("libGeom");
   gSystem->Load("libTable");

--- a/StRoot/macros/rootlogon.C
+++ b/StRoot/macros/rootlogon.C
@@ -1,4 +1,9 @@
 {
+  // ROOT and XROOTD
+  // some rootd default dummy stuff
+  TAuthenticate::SetGlobalUser("starlib");
+  TAuthenticate::SetGlobalPasswd("ROOT4STAR");
+
   // This will help tracing failure on XrdOpen() if any
   gEnv->SetValue("XNet.DebugTimestamp","1");
   gEnv->SetValue("XNet.ReconnectTimeout","15");


### PR DESCRIPTION
These lines come directly form /afs/rhic.bnl.gov/star/ROOT/5.34.38/root/etc/rootlogon.C