### PR TITLE
Allow loading a local rootlogon.C from the current directory

### DIFF
--- a/StRoot/macros/rootlogon.C
+++ b/StRoot/macros/rootlogon.C
@@ -51,4 +51,11 @@
   gInterpreter->AddIncludePath("$STAR/.$STAR_HOST_SYS/include");
   gInterpreter->AddIncludePath("$STAR/StRoot");
   gInterpreter->AddIncludePath("/usr/include/mysql");
+
+  // Requested by users, allow loading a "complementary" local
+  // rootlogon if exists
+  if ( !gSystem->AccessPathName("./rootlogon.C", kFileExists ) ){
+    cout << "Found and loading local rootlogon.C" << endl;
+    gROOT->Macro("./rootlogon.C");
+  }
 }


### PR DESCRIPTION
Adds logic to check for and load a local ./rootlogon.C if it exists, as requested by users. This enables complementary user-defined ROOT configuration alongside the default setup.

These lines are taken directly from /afs/rhic.bnl.gov/star/ROOT/5.34.38/root/etc/rootlogon.C. I haven’t tested them myself, but @jlauret has confirmed that they work.