### PR TITLE
Make use of already designated topology bits

### DIFF
--- a/StRoot/StEvent/StTrackTopologyMap.cxx
+++ b/StRoot/StEvent/StTrackTopologyMap.cxx
@@ -82,7 +82,7 @@
  *  50   18   TPC row=43
  *  51   19   TPC row=44
  *  52   20   TPC row=45
- *  53   21   Mwpc
+ *  53   21   Mwpc / TPC prompt hit
  *  54   22   CTB
  *  55   23   ToF
  *  56   24   RICH
@@ -315,6 +315,66 @@ StTrackTopologyMap::hasHitInSsdLayer(unsigned int layer) const
         return bit(layer+5);
       else
         return bit(layer+6);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInMwpc() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(53);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInCtb() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(54);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInToF() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(55);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInRich() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(56);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInBemc() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(57);
+    }
+}
+
+bool
+StTrackTopologyMap::hasHitInEemc() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(58);
     }
 }
 

--- a/StRoot/StEvent/StTrackTopologyMap.cxx
+++ b/StRoot/StEvent/StTrackTopologyMap.cxx
@@ -339,7 +339,7 @@ StTrackTopologyMap::hasHitInCtb() const
 }
 
 bool
-StTrackTopologyMap::hasHitInToF() const
+StTrackTopologyMap::hasHitInTof() const
 {
     if(ftpcFormat())
         return false;
@@ -449,28 +449,28 @@ StTrackTopologyMap::numberOfHits(StDetectorId id) const
             break;
         case kMwpcWestId:
         case kMwpcEastId:
-            if (bit(53)) n++;
+            if (hasHitInMwpc()) n++;
             break;
         case kCtbId:
-            if (bit(54)) n++;
+            if (hasHitInCtb()) n++;
             break;
         case kTofId:
-            if (bit(55)) n++;
+            if (hasHitInTof()) n++;
             break;
         case kRichId:
-            if (bit(56)) n++;
+            if (hasHitInRich()) n++;
             break;
         case kBarrelEmcTowerId:
         case kBarrelEmcPreShowerId:
         case kBarrelSmdEtaStripId:
         case kBarrelSmdPhiStripId:
-            if (bit(57)) n++;
+            if (hasHitInBemc()) n++;
             break;
         case kEndcapEmcTowerId:
         case kEndcapEmcPreShowerId:
         case kEndcapSmdUStripId:
         case kEndcapSmdVStripId:
-            if (bit(58)) n++;
+            if (hasHitInEemc()) n++;
             break;
         default:
             n = 0;

--- a/StRoot/StEvent/StTrackTopologyMap.h
+++ b/StRoot/StEvent/StTrackTopologyMap.h
@@ -89,11 +89,11 @@ public:
     bool           hasHitInSstLayer(unsigned int) const;   
     bool           hasHitInMwpc() const;
     bool           hasHitInTpcPrompt() const { return histHitInMwpc(); }
-    bool           hasHitInCtb(unsigned int) const;
-    bool           hasHitInToF(unsigned int) const;
-    bool           hasHitInRich(unsigned int) const;
-    bool           hasHitInBemc(unsigned int) const;
-    bool           hasHitInEemc(unsigned int) const;
+    bool           hasHitInCtb() const;
+    bool           hasHitInTof() const;
+    bool           hasHitInRich() const;
+    bool           hasHitInBemc() const;
+    bool           hasHitInEemc() const;
     
     bool           trackTpcOnly() const; 
     bool           trackSvtOnly() const;  

--- a/StRoot/StEvent/StTrackTopologyMap.h
+++ b/StRoot/StEvent/StTrackTopologyMap.h
@@ -87,6 +87,13 @@ public:
     bool           hasHitInIstLayer(unsigned int) const;          // first layer = 1   
     bool           hasHitInSsdLayer(unsigned int) const;          // first layer = 1   
     bool           hasHitInSstLayer(unsigned int) const;   
+    bool           hasHitInMwpc() const;
+    bool           hasHitInTpcPrompt() const { return histHitInMwpc(); }
+    bool           hasHitInCtb(unsigned int) const;
+    bool           hasHitInToF(unsigned int) const;
+    bool           hasHitInRich(unsigned int) const;
+    bool           hasHitInBemc(unsigned int) const;
+    bool           hasHitInEemc(unsigned int) const;
     
     bool           trackTpcOnly() const; 
     bool           trackSvtOnly() const;  

--- a/StRoot/StEvent/StTrackTopologyMap.h
+++ b/StRoot/StEvent/StTrackTopologyMap.h
@@ -88,7 +88,7 @@ public:
     bool           hasHitInSsdLayer(unsigned int) const;          // first layer = 1   
     bool           hasHitInSstLayer(unsigned int) const;   
     bool           hasHitInMwpc() const;
-    bool           hasHitInTpcPrompt() const { return histHitInMwpc(); }
+    bool           hasHitInTpcPrompt() const;
     bool           hasHitInCtb() const;
     bool           hasHitInTof() const;
     bool           hasHitInRich() const;
@@ -126,6 +126,11 @@ ostream& operator<< (ostream&, const StTrackTopologyMap&);
 inline bool StTrackTopologyMap::hasHitInSstLayer(unsigned int val) const  
 {
     return hasHitInSsdLayer(val);
+}
+
+inline bool StTrackTopologyMap::hasHitInTpcPrompt() const
+{
+    return hasHitInMwpc();
 }
 
 #endif

--- a/StRoot/StEventUtilities/StuFixTopoMap.cxx
+++ b/StRoot/StEventUtilities/StuFixTopoMap.cxx
@@ -35,7 +35,7 @@
  *    map[1]   Bit number  Quantity                                  
  *    ------   ----------  --------                                  
  *                0-20     TPC, remaining 21 padrows                 
- *                21       Track extrapolates to MWC (no=0, yes=1)   
+ *                21       Track extrapolates to MWC (no=0, yes=1) (or has prompt hits)
  *                22       Track extrapolates to CTB (no=0, yes=1)   
  *                23       Track extrapolates to TOF (no=0, yes=1)   
  *                24       Track extrapolates to RCH (no=0, yes=1)   
@@ -141,6 +141,14 @@ bool StuFixTopoMap(StTrack* track)
         }
     }
     else {
+
+        // Tracks with hits on other detectors
+        if (track->isPromptTrack()) word2 |= 1U<<21; // Prompt hit is an MWPC hit
+        if (track->isCtbMatched()) word2 |= 1U<<22;
+        if (track->isToFMatched() ||
+            track->isBToFMatched()) word2 |= 1U<<23;
+        if (track->isBemcMatched()) word2 |= 1U<<25;
+        if (track->isEemcMatched()) word2 |= 1U<<26;
 
         // ???
         if (info->numberOfReferencedPoints(kPxlId) ||

--- a/StRoot/StiMaker/StiStEventFiller.cxx
+++ b/StRoot/StiMaker/StiStEventFiller.cxx
@@ -1343,8 +1343,8 @@ void StiStEventFiller::fillTrack(StTrack* gTrack, StiKalmanTrack* track,StTrackD
   fillGeometry(gTrack, track, true ); // outer geometry
   fillFitTraits(gTrack, track);
   gTrack->setDetectorInfo(detInfo);
-  StuFixTopoMap(gTrack);
   fillFlags(gTrack);
+  StuFixTopoMap(gTrack);
   if (!track->isPrimary()) fillDca(gTrack,track);
   return;
 }


### PR DESCRIPTION
Several already-designated bits in StTrackTopologyMap have remained unused (zeros). However, there are StTrack flags set in StiStEventFiller for exactly these that can be used to set the bits in the topology map. This does require swapping the order of setting the flags to precede filling the topology maps in StiStEventFiller. This PR does nothing to alter the intent of bits in the topology map, i.e. no change to anything in StEvent itself.

The advantage of filling the track topology map over the track flags is that it is propagated all the way to the PicoDst, while the track flags are not, thereby giving PicoDst users a handle on this information about the tracks without changing anything about the PicoDst structure.

I plan to follow this PR with another that makes use of currently undesignated bits in the track topology map to include additional track flags that may be useful to PicoDst users as well.