### PR TITLE
Additional flagging of possible pile-up

### DIFF
--- a/StRoot/StEvent/StTrackTopologyMap.cxx
+++ b/StRoot/StEvent/StTrackTopologyMap.cxx
@@ -88,8 +88,8 @@
  *  56   24   RICH
  *  57   25   Barrel EMC/SMD
  *  58   26   Endcap EMC/SMD
- *  59   27
- *  60   28
+ *  59   27   Post-crossing track
+ *  60   28   Central-membrane crossing track
  *  61   29   HFT Format (case 3) - TPC tracks
  *  62   30   turn around flag  (flags that track spirals back)
  *  63   31   FTPC Format (flags TOC or FTPC)
@@ -375,6 +375,26 @@ StTrackTopologyMap::hasHitInEemc() const
         return false;
     else {
         return bit(58);
+    }
+}
+
+bool
+StTrackTopologyMap::postXTrack() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(59);
+    }
+}
+
+bool
+StTrackTopologyMap::membraneCrossingTrack() const
+{
+    if(ftpcFormat())
+        return false;
+    else {
+        return bit(60);
     }
 }
 

--- a/StRoot/StEvent/StTrackTopologyMap.h
+++ b/StRoot/StEvent/StTrackTopologyMap.h
@@ -94,6 +94,8 @@ public:
     bool           hasHitInRich() const;
     bool           hasHitInBemc() const;
     bool           hasHitInEemc() const;
+    bool           postXTrack() const;
+    bool           membraneCrossingTrack() const;
     
     bool           trackTpcOnly() const; 
     bool           trackSvtOnly() const;  

--- a/StRoot/StEventUtilities/StuFixTopoMap.cxx
+++ b/StRoot/StEventUtilities/StuFixTopoMap.cxx
@@ -41,7 +41,9 @@
  *                24       Track extrapolates to RCH (no=0, yes=1)   
  *                25       Track extrapolates to EMCB (no=0, yes=1)  
  *                26       Track extrapolates to EMCEC (no=0, yes=1) 
- *               27-29     reserved for future use                   
+ *                27       Track post-crossing (no=0, yes=1)
+ *                28       Track crosses TPC central membrane (no=0, yes=1)
+ *                29       reserved for future use                   
  *                30       Turn around flag, some elements used >1   
  *                31       Format interpreter; (SVT/SSD/TPC=0,FTPC=1)
  *
@@ -68,7 +70,8 @@
  *                24       Track extrapolates to RCH (no=0, yes=1)
  *                25       Track extrapolates to EMCB (no=0, yes=1)
  *                26       Track extrapolates to EMCEC (no=0, yes=1)
- *               27-28     reserved for future use
+ *                27       Track post-crossing (no=0, yes=1)
+ *                28       Track crosses TPC central membrane (no=0, yes=1)
  *                29       HFT flag  (HFT=1, SVT/SSD=0)
  *                30       Turn around flag, some elements used >1
  *                31       Format interpreter; (SVT/SSD/TPC=0,FTPC=1)
@@ -149,6 +152,10 @@ bool StuFixTopoMap(StTrack* track)
             track->isBToFMatched()) word2 |= 1U<<23;
         if (track->isBemcMatched()) word2 |= 1U<<25;
         if (track->isEemcMatched()) word2 |= 1U<<26;
+
+        // Tracks with helpful pile-up rejection flags
+        if (track->isPostXTrack()) word2 |= 1U<<27;
+        if (track->isMembraneCrossingTrack()) word2 |= 1U<<28;
 
         // ???
         if (info->numberOfReferencedPoints(kPxlId) ||


### PR DESCRIPTION
Following quickly on the heels of PR #773 , I have more modifications to StTrackTopologyMap to propose...

A few bits were labeled as "reserved for future use"....well, there isn't much future left to add new detectors to STAR here in the last couple months of running. So I propose to target these for some of the more useful binary track flags instead of leaving them as useless zeros for eternity:

1. post-crossing tracks (definitely contain pile-up hits on the tracks)
2. tracks crossing the TPC central membrane (unlikely to be pile-up)

Both of these are rather TPC-centric, but I think this is worthwhile utilization of the topology map without requiring any structural changes to the PicoDsts in particular.