### PR TITLE
epd finder fix

### DIFF
--- a/StRoot/StEpdUtil/StEpdEpFinder.cxx
+++ b/StRoot/StEpdUtil/StEpdEpFinder.cxx
@@ -327,6 +327,7 @@ StEpdEpInfo StEpdEpFinder::Results(TClonesArray* EpdHits, TVector3 primVertex, i
   for (int order=1; order<_EpOrderMax+1; order++){
     for (int ewFull=0; ewFull<3; ewFull++){  // 0,1,2 means East,West,Full
       result.PsiPhiWeightedAndShifted[ewFull][order-1] = result.PsiPhiWeighted[ewFull][order-1];
+      if (result.PsiPhiWeighted[ewFull][order-1] < -900.0) continue; // invalid angle, so skip shifting
       if (mEpdShiftInput_sin[ewFull][order-1] != 0){
 	for (int i=1; i<=_EpTermsMax; i++){
 	  double tmp = (double)(order*i);

--- a/StRoot/StEpdUtil/StEpdEpInfo.cxx
+++ b/StRoot/StEpdUtil/StEpdEpInfo.cxx
@@ -170,6 +170,7 @@ double StEpdEpInfo::WestRingPhiWeightedPsi(int order, int ring){return RingPhiWe
 //----- Simple method to put angles in a convenient range: (0,2pi/n) ----
 double StEpdEpInfo::Range(double psi,int order){
   if (ArgumentOutOfBounds(order)) return -999;
+  if (psi < -900.0) return -999.0; // invalid angle
   double wrap = 2.0*TMath::Pi()/(double)order;
   if (psi<0.0) psi += (1.0+(int)(fabs(psi)/wrap))*wrap;
   else{ if (psi>wrap) psi -= ((int)(psi/wrap))*wrap;}


### PR DESCRIPTION
Fixes #788 

### Summary
This PR addresses the bug where empty events (resulting in a `-999` invalid angle ) were being processed as valid angles, creating spikes in the Event Plane distribution from the StEpdFinder and StEpdInfo software. 

**Changes made:**
* **`StEpdUtil/StEpdEpFinder.cxx`**: Added a `continue` condition to skip the shift correction loop if the angle is invalid (`< -900.0`). This prevents calculating `sin`/`cos` shifts on garbage values.
* **`StEpdUtil/StEpdEpInfo.cxx`**: Added an early return in the `Range()` function. If the input angle is invalid (`< -900.0`), it explicitly returns `-999.0` rather than allowing the math below it to incorrectly wrap the error code into a valid $[0, 2\pi/n]$ range.