### PR TITLE
Coerce to string

### DIFF
--- a/mgr/ageParser.py
+++ b/mgr/ageParser.py
@@ -802,7 +802,7 @@ def OnInlinedComment( tokens ):
     post = tokens.get('post','')
     #comment = '! '+tokens.get('comment')
     #line1=comment
-    line2=pre+post
+    line2=str(pre)+str(post)
     #tryRules( line1.rstrip(';') )
     tryRules( line2.rstrip(';') )
     


### PR DESCRIPTION
Rumors are that a new version of the support cone geometry, implemented in the deprecated agstar style, that will be incoming.  The ageParser should streamline this.  Requires (at least) this small fix.