### PR TITLE
Fix d hyperon

### DIFF
--- a/StRoot/StarClassLibrary/StDLambda.hh
+++ b/StRoot/StarClassLibrary/StDLambda.hh
@@ -15,7 +15,7 @@
  *
  * Pseudoparticle representing a loosely bound deuteron + Lambda state.
  * Decays via d_Lambda --> deuteron(45) + Lambda(98, constrained to p+pi-).
- * GEANT3 ID: 60100.  STAR PDG encoding: kDLambda.
+ * GEANT3 ID: 60104.  STAR PDG encoding: kDLambda.
  *
  **************************************************************************/
 #ifndef StDLambda_hh

--- a/StRoot/StarClassLibrary/StarPDGEncoding.hh
+++ b/StRoot/StarClassLibrary/StarPDGEncoding.hh
@@ -15,7 +15,7 @@ enum {
 
   /// STAR-specific PDG codes for d-hyperon pseudoparticles (loosely bound
   /// deuteron-hyperon states). No official PDG numbers exist for these.
-  kDLambda         = 1000000010, ///< d + Lambda  (GID 60100)
+  kDLambda         = 1000000010, ///< d + Lambda  (GID 60104)
   kDSigma0         = 1000000011, ///< d + Sigma0  (GID 60101)
   kDXiMinus        = 1000000012, ///< d + Xi-     (GID 60102)
   kDXiZero         = 1000000013  ///< d + Xi0     (GID 60103)

--- a/pams/sim/gstar/gstar_part.g
+++ b/pams/sim/gstar/gstar_part.g
@@ -787,17 +787,17 @@ Particle H_dibaryon               code      = 60001,
 **
 *   Decay chains (Lambda always constrained to p+pi- via ID=98):
 *
-*   d_Lambda  (60100): d + Lambda              [sum of daughters = 1.876+1.115683 = 2.9917 GeV]
 *   d_Sigma0  (60101): d + Sigma0->Lambda+gamma [sum = 1.876+1.193 = 3.069 GeV]
 *   d_Xi_minus(60102): d + Xi-->Lambda+pi-      [sum = 1.876+1.32171 = 3.198 GeV]
 *   d_Xi_zero (60103): d + Xi0->Lambda+pi0      [sum = 1.876+1.31486 = 3.191 GeV]
+*   d_Lambda  (60104): d + Lambda              [sum of daughters = 1.876+1.115683 = 2.9917 GeV]
 **
 ***************************************************************************
 
 * d + Lambda --> d(45) + _lam_to_p_piminus_(98)
 * sum of daughters = 1.876 + 1.115683 = 2.9917 GeV
-  Particle d_Lambda                   code      = 60100       ,
-                                      mass      = 2.998        ,
+  Particle d_Lambda                   code      = 60104       ,
+                                      mass      = 2.992        ,
                                       charge    = 1            ,
                                       tlife     = 1.0E-19      ,
                                       pdg       = UNDEFINED    ,

--- a/pams/sim/gstar/gstar_part.g
+++ b/pams/sim/gstar/gstar_part.g
@@ -782,22 +782,24 @@ Particle H_dibaryon               code      = 60001,
 ***************************************************************************
 **
 ** d-Hyperon pseudoparticles: loosely bound deuteron-hyperon states
-** IDs start at 60100.  Parent mass is set above the sum of daughter masses
-** so that decay products carry momentum in the final state.
+** IDs start at 60100.  Parent mass is kept a few MeV above the sum of
+** daughter masses so that the decays remain kinematically allowed and
+** the final-state particles carry non-zero momentum.
 **
 *   Decay chains (Lambda always constrained to p+pi- via ID=98):
 *
 *   d_Sigma0  (60101): d + Sigma0->Lambda+gamma [sum = 1.876+1.193 = 3.069 GeV]
 *   d_Xi_minus(60102): d + Xi-->Lambda+pi-      [sum = 1.876+1.32171 = 3.198 GeV]
 *   d_Xi_zero (60103): d + Xi0->Lambda+pi0      [sum = 1.876+1.31486 = 3.191 GeV]
-*   d_Lambda  (60104): d + Lambda              [sum of daughters = 1.876+1.115683 = 2.9917 GeV]
+*   d_Lambda  (60104): d + Lambda               [sum of daughters = 1.876+1.115683 = 2.9917 GeV]
 **
 ***************************************************************************
 
 * d + Lambda --> d(45) + _lam_to_p_piminus_(98)
-* sum of daughters = 1.876 + 1.115683 = 2.9917 GeV
+* sum of daughters = 1.876 + 1.115683 = 2.9917 GeV; parent mass kept
+* a few MeV above threshold for stable decay kinematics
   Particle d_Lambda                   code      = 60104       ,
-                                      mass      = 2.992        ,
+                                      mass      = 2.996        ,
                                       charge    = 1            ,
                                       tlife     = 1.0E-19      ,
                                       pdg       = UNDEFINED    ,


### PR DESCRIPTION
Simple update.  Better mass estimate, and change G3 ID.  The G3 ID change seems to resolve the segmentation violation observed when running this decay chain. 