### PR TITLE
Allow for different FXT vertex z location

### DIFF
--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -2740,6 +2740,10 @@ bool StPicoDstMaker::selectVertex() {
   }
   else if ( mVtxMode == PicoVtxMode::FXT ) {
     
+    // Target z at west-side location until the final OO200 dataset
+    float z_tgt = (mMuDst->event()->runNumber() < 27032000 ? 200.0 : -180.0);
+    float z_tgtTolerance = 2.0;
+
     // Loop over primary vertices
     for (unsigned int iVtx = 0; iVtx < mMuDst->numberOfPrimaryVertices(); ++iVtx) {
       
@@ -2748,7 +2752,7 @@ bool StPicoDstMaker::selectVertex() {
       if (!vtx) continue;
       
       // Check TpcVz and VpdVz difference
-      if (vtx->position().z() > 198. && vtx->position().z() < 202.) {
+      if (TMath::Abs(vtx->position().z() - z_tgt) < z_tgtTolerance) {
 	// Reset vertex index
 	mMuDst->setVertexIndex( iVtx );
 	// Reset pointer to the primary vertex

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.h
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.h
@@ -19,7 +19,7 @@
  *      over all primary vertices. The first one that has at least
  *      2 MTD-matched primary tracks is selected.
  *   e) FXT - set the first primary vertex that was reconstructed in z between
- *      +198 and +202 cm along z axis (or -182 and -178 cm for runs > 27032000).
+ *      +198 and +202 cm along z axis (or -182 and -178 cm for runs >= 27032000).
  * Default is NotSet. In this case the program execution will be terminated.
  * Has to be explicitly set.
  *

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.h
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.h
@@ -18,8 +18,8 @@
  *   d) Mtd - sets the first primary vertex as a default and then loops
  *      over all primary vertices. The first one that has at least
  *      2 MTD-matched primary tracks is selected.
- *   e) FXT - set the first vertex that was reconstructed in z 
- *      from 198 to 202 cm along z axis.
+ *   e) FXT - set the first primary vertex that was reconstructed in z between
+ *      +198 and +202 cm along z axis (or −182 and −178 cm for runs > 27032000).
  * Default is NotSet. In this case the program execution will be terminated.
  * Has to be explicitly set.
  *

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.h
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.h
@@ -19,7 +19,7 @@
  *      over all primary vertices. The first one that has at least
  *      2 MTD-matched primary tracks is selected.
  *   e) FXT - set the first primary vertex that was reconstructed in z between
- *      +198 and +202 cm along z axis (or −182 and −178 cm for runs > 27032000).
+ *      +198 and +202 cm along z axis (or -182 and -178 cm for runs > 27032000).
  * Default is NotSet. In this case the program execution will be terminated.
  * Has to be explicitly set.
  *


### PR DESCRIPTION
I welcome other suggestions for accommodating the alternate location of the target(s) in 2026. While perhaps a database table might be more appropriate (particularly if the location needs fine tuning), it seems a bit overkill to create a new table for the two positions that ever existed here...though I would certainly consider that an open future possibility if we decide to do some fine tuning, or decide that there are multiple codes that can utilize this location. For now, this seems a straightforward first step to allow us to move forward with calibration work.

I also welcome any other code considerations anyone can think of regarding this location of the fixed target, e.g. tracking.