### PR TITLE
Transfering setDbAccess to StFcsDb just in case user forget to set

### DIFF
--- a/StRoot/StFcsDbMaker/StFcsDbMaker.cxx
+++ b/StRoot/StFcsDbMaker/StFcsDbMaker.cxx
@@ -117,7 +117,6 @@
  **************************************************************************/
 
 #include "StFcsDbMaker.h"
-#include "StFcsDb.h"
 #include "StFcsDbPulse.h"
 #include "St_db_Maker/St_db_Maker.h"
 #include "StMessMgr.h"

--- a/StRoot/StFcsDbMaker/StFcsDbMaker.h
+++ b/StRoot/StFcsDbMaker/StFcsDbMaker.h
@@ -90,6 +90,7 @@
 
 #ifndef StMaker_H
 #include "StMaker.h"
+#include "StFcsDb.h"
 #endif
 
 class StFcsDb;
@@ -103,7 +104,7 @@ public:
   int  InitRun(int runNumber);
   void  Clear(Option_t *option);
   int  Make();
-  void setDbAccess(int v){mDbAccess=v;}
+  void setDbAccess(int v){mDbAccess=v; if(mFcsDb) mFcsDb->setDbAccess(v);}
  
 private:
   StFcsDb *mFcsDb;


### PR DESCRIPTION
This is a minor change for StFcsDbMaker::setDbAccess to also set StFcsDb::setDbAccess for users (like me) forgetting to set the same for StFcsDb as well while debugging. This should not affect anything while using this with DB access on (default). 